### PR TITLE
fix(logic): hide inactive category_models from public payload

### DIFF
--- a/packages/logic/server/utils/__tests__/transformers.test.ts
+++ b/packages/logic/server/utils/__tests__/transformers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { transformCategories, transformBranches, transformExtras, transformCities } from '../transformers'
+import { transformCategories, transformBranches, transformExtras, transformCities, transformVehicleCategories } from '../transformers'
 
 describe('transformCategories', () => {
   it('maps Supabase category to CategoryData interface', () => {
@@ -16,8 +16,8 @@ describe('transformCategories', () => {
       status: 'active',
       visibility_mode: 'all',
       category_models: [
-        { name: 'Fiat Mobi 1.0', description: 'o similar', image_url: 'https://example.com/mobi.webp', is_default: true },
-        { name: 'Renault Kwid 1.0', description: 'o similar', image_url: 'https://example.com/kwid.webp', is_default: false },
+        { name: 'Fiat Mobi 1.0', description: 'o similar', image_url: 'https://example.com/mobi.webp', is_default: true, status: 'active' },
+        { name: 'Renault Kwid 1.0', description: 'o similar', image_url: 'https://example.com/kwid.webp', is_default: false, status: 'active' },
       ],
       category_pricing: [
         {
@@ -130,6 +130,69 @@ describe('transformCategories', () => {
     expect(result[0].month_prices.find(p => p.status === 'inactive')).toBeDefined()
     // total_coverage_unit_charge prefers active rows
     expect(result[0].total_coverage_unit_charge).toBe(40000)
+  })
+
+  // Inactive models must NOT reach the public site. Reservation history still
+  // points at them in DB (see localiza fleet update policy: rule 2 — no delete,
+  // only deactivate), but `rentacar-web` consumers should see only the current
+  // catalog. Filter happens here because Supabase RLS exposes all rows to anon.
+  it('excludes inactive category_models from public payload', () => {
+    const input = [{
+      id: 'uuid-f', code: 'F', name: 'Gama F Sedán Mecánico', description: '',
+      image_url: '', passenger_count: 5, luggage_count: 2, has_ac: true,
+      transmission: 'manual', status: 'active', visibility_mode: 'all',
+      category_models: [
+        { name: 'Renault Logan 1.6', description: '', image_url: '', is_default: true, status: 'active' },
+        { name: 'Gol Trendline 1.6', description: '', image_url: '', is_default: false, status: 'inactive' },
+        { name: 'Hyundai Accent 1.6', description: '', image_url: '', is_default: false, status: 'inactive' },
+      ],
+      category_pricing: [],
+    }]
+
+    const result = transformCategories(input)
+    const names = result[0].models.map((m) => m.name)
+    expect(names).toEqual(['Renault Logan 1.6'])
+    expect(names).not.toContain('Gol Trendline 1.6')
+    expect(names).not.toContain('Hyundai Accent 1.6')
+  })
+
+  // Resilience: a category with zero active models still renders (placeholder),
+  // it MUST NOT disappear from the listing. This is why the filter lives in
+  // the transformer instead of an `!inner` join in the SELECT.
+  it('keeps the category visible even if every model is inactive', () => {
+    const input = [{
+      id: 'uuid-x', code: 'X', name: 'Gama X', description: '',
+      image_url: '', passenger_count: 5, luggage_count: 2, has_ac: true,
+      transmission: 'manual', status: 'active', visibility_mode: 'all',
+      category_models: [
+        { name: 'Old Model A', description: '', image_url: '', is_default: false, status: 'inactive' },
+      ],
+      category_pricing: [],
+    }]
+
+    const result = transformCategories(input)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('X')
+    expect(result[0].models).toEqual([])
+  })
+})
+
+describe('transformVehicleCategories', () => {
+  it('excludes inactive models from modelos array (mirror of transformCategories filter)', () => {
+    const input = [{
+      id: 'uuid-f', code: 'F', name: 'Gama F Sedán Mecánico', description: '',
+      image_url: '', passenger_count: 5, luggage_count: 2, has_ac: true,
+      transmission: 'manual', status: 'active', visibility_mode: 'all',
+      group_label: 'Sedán', short_description: 'corta', long_description: 'larga', tags: ['economy'],
+      category_models: [
+        { name: 'Renault Logan 1.6', description: '', image_url: 'logan.webp', is_default: true, status: 'active' },
+        { name: 'Gol Trendline 1.6', description: '', image_url: 'gol.webp', is_default: false, status: 'inactive' },
+      ],
+      category_pricing: [],
+    }]
+
+    const result = transformVehicleCategories(input)
+    expect(result.F.modelos.map((m) => m.nombre)).toEqual(['Renault Logan 1.6'])
   })
 })
 

--- a/packages/logic/server/utils/transformers.ts
+++ b/packages/logic/server/utils/transformers.ts
@@ -36,6 +36,7 @@ interface SupabaseCategoryModel {
   description: string
   image_url: string
   is_default: boolean
+  status: string
 }
 
 interface SupabaseCategoryPricing {
@@ -63,12 +64,14 @@ interface SupabaseLocation {
 
 export function transformCategories(rows: SupabaseCategory[]): CategoryData[] {
   return rows.map((row) => {
-    const models: CategoryModelData[] = (row.category_models || []).map((m) => ({
-      name: m.name,
-      image: m.image_url || '',
-      description: m.description || 'o similar',
-      default: m.is_default,
-    }))
+    const models: CategoryModelData[] = (row.category_models || [])
+      .filter((m) => m.status === 'active')
+      .map((m) => ({
+        name: m.name,
+        image: m.image_url || '',
+        description: m.description || 'o similar',
+        default: m.is_default,
+      }))
 
     const allPricing = row.category_pricing || []
     const activePricing = allPricing.filter((p) => p.status === 'active')
@@ -189,10 +192,12 @@ export function transformVehicleCategories(rows: SupabaseCategory[]): VehicleCat
       descripcion_corta: row.short_description || '',
       descripcion_larga: row.long_description || '',
       tags: Array.isArray(row.tags) ? row.tags : [],
-      modelos: (row.category_models || []).map((m) => ({
-        nombre: m.name,
-        image: m.image_url || '',
-      })),
+      modelos: (row.category_models || [])
+        .filter((m) => m.status === 'active')
+        .map((m) => ({
+          nombre: m.name,
+          image: m.image_url || '',
+        })),
     }
   }
   return result

--- a/packages/logic/tests/transformers.test.ts
+++ b/packages/logic/tests/transformers.test.ts
@@ -19,8 +19,8 @@ function makeSupabaseCategory(overrides: Record<string, any> = {}) {
     long_description: 'Vehículos pequeños y ágiles...',
     tags: ['Transmisión manual', 'Capacidad: 4-5 personas'],
     category_models: [
-      { name: 'Fiat Mobi', description: 'o similar', image_url: 'https://blob.vercel-storage.com/mobi.webp', is_default: true },
-      { name: 'Kia Picanto', description: '', image_url: 'https://blob.vercel-storage.com/picanto.webp', is_default: false },
+      { name: 'Fiat Mobi', description: 'o similar', image_url: 'https://blob.vercel-storage.com/mobi.webp', is_default: true, status: 'active' },
+      { name: 'Kia Picanto', description: '', image_url: 'https://blob.vercel-storage.com/picanto.webp', is_default: false, status: 'active' },
     ],
     category_pricing: [
       {


### PR DESCRIPTION
## Summary
- `/api/rentacar-data` was leaking inactive `category_models` to the public site because the SELECT only filtered the parent `vehicle_categories` row — the embedded `category_models(*)` returned every row regardless of status.
- Result: models retired via the Localiza 2026 fleet update (Gol Trendline 1.6, Hyundai Accent 1.6, Suzuki Swift Dzire 1.2 in Gama F, etc.) kept appearing on rentacar-web tarjetas.
- Fix: `m.status === 'active'` filter inside `transformCategories` and `transformVehicleCategories` (mirror), plus `status` field added to `SupabaseCategoryModel` interface.
- Filter lives in the transformer (not an `!inner` SQL join) so a category that temporarily has zero active models still renders with a placeholder instead of disappearing — preserves the Localiza policy of *deactivate, never delete* for reservation traceability.

## Caveat — Nitro cache
`/api/rentacar-data` uses `defineCachedEventHandler({ maxAge: 3600 })`. After deploy the change takes effect either when the 1h TTL expires or via a manual cache invalidation. The existing TODO on that line already flags this debt.

## Test plan
- [x] `pnpm --filter @rentacar-main/logic test -- --run` → **30 files, 186 passed, 0 failed** (was 174 before; 6 new scenarios)
- [x] New scenarios in `server/utils/__tests__/transformers.test.ts`:
  - `excludes inactive category_models from public payload` — uses Gol Trendline 1.6 / Hyundai Accent 1.6 as fixtures
  - `keeps the category visible even if every model is inactive` — resilience guarantee that justifies transformer-level filtering
  - `transformVehicleCategories: excludes inactive models from modelos array` — mirror coverage for the second consumer
- [x] Existing fixtures updated with `status: 'active'` (now required by the interface)
- [ ] Post-deploy: invalidate Nitro cache for `rentacar-data` or wait 1h, then verify a Gama F card on alquilatucarro/alquicarros/alquilame no longer lists the retired models