### PR TITLE
fix(reservations): autoclose date popovers on calendar selection

### DIFF
--- a/docs/specs/2026-05-06-searcher-calendar-autoclose-design.md
+++ b/docs/specs/2026-05-06-searcher-calendar-autoclose-design.md
@@ -1,7 +1,7 @@
 # Searcher: Cierre automático del calendario al seleccionar fecha
 
 **Date:** 2026-05-06
-**Status:** Approved (brainstorming)
+**Status:** Approved
 **Scope:** UI fix — desktop only (móvil usa input nativo)
 
 ## Problem
@@ -10,7 +10,10 @@ En el formulario de búsqueda de disponibilidad (`Searcher.vue`), los popovers d
 
 ## Root cause
 
-`packages/ui-{brand}/app/components/Searcher.vue` (idéntico en las 3 marcas), líneas 132-160 y 196-225:
+`packages/ui-{brand}/app/components/Searcher.vue` (idéntico en las 3 marcas):
+
+- Desktop pickup popover: líneas 132-160 (popover) dentro del bloque desktop 119-164.
+- Desktop return popover: líneas 196-225 (popover) dentro del bloque desktop 182-229.
 
 ```vue
 <u-popover v-model:open="pickupDateCalendarOpen">
@@ -23,7 +26,7 @@ En el formulario de búsqueda de disponibilidad (`Searcher.vue`), los popovers d
 
 `<u-popover>` se abre con `@click="pickupDateCalendarOpen = true"` en el `<u-input-date>`, pero ningún handler escucha el evento de selección de `<u-calendar>` para revertir `pickupDateCalendarOpen` a `false`. Misma estructura con `returnDateCalendarOpen`.
 
-Móvil (`<input type="date">` en líneas 168-177 y 230-…) cierra automáticamente vía SO — fuera de alcance.
+Móvil (`<input type="date">` nativo en líneas 103-117 para recogida y 165-180 para devolución) cierra automáticamente vía SO — fuera de alcance.
 
 ## Decision
 
@@ -83,8 +86,8 @@ Consumidores del componente: páginas `[city]/...` que embeben `<Searcher />`. N
 
 **SCEN-004 — Móvil intacto**
 - **Given** viewport <640px (input `<input type="date">` nativo visible).
-- **When** el usuario selecciona una fecha en el picker nativo del SO.
-- **Then** el comportamiento existente se preserva; sin regresión en `fechaRecogida`/`fechaDevolucion` ni en el watcher de +7 días.
+- **When** el usuario abre la página de búsqueda.
+- **Then** los inputs móviles (`#pickup-date-mobile`, `#return-date-mobile`) son visibles, tienen `type="date"`, y los inputs desktop (`#pickup-date`, `#return-date`) están ocultos vía clase `hidden sm:block`. Cambio del modelo en estos inputs preserva `fechaRecogida`/`fechaDevolucion` y dispara el watcher de +7 días igual que hoy.
 
 **SCEN-005 — Watcher de fecha por defecto preservado**
 - **Given** viewport ≥640px, sin fecha de recogida seleccionada (estado inicial).
@@ -93,42 +96,49 @@ Consumidores del componente: páginas `[city]/...` que embeben `<Searcher />`. N
 
 ## Satisfaction strategy
 
-- **E2E (Playwright, multi-marca via `BRAND` env):** nuevo `e2e/searcher-calendar-autoclose.spec.ts` cubriendo SCEN-001..003 y SCEN-005. Selectores estables: `#pickup-date`, `#return-date` (id existentes); agregar `data-testid` al popover si los selectores actuales no permiten asertar visibilidad.
-- **SCEN-004** verificado por inspección de no-cambio (diff vacío en bloque móvil del `Searcher.vue`); no requiere test nuevo.
+- **E2E (Playwright, multi-marca via `BRAND` env):** nuevo `e2e/searcher-calendar-autoclose.spec.ts` cubriendo SCEN-001..005. Selectores y aserciones de visibilidad del popover:
+  - **Apertura:** click en `#pickup-date` (resp. `#return-date`) y esperar `[role="dialog"]` visible. `<u-popover>` de Nuxt UI usa Reka UI internamente, que renderiza el `content` con `role="dialog"` cuando está abierto.
+  - **Cierre:** asertar que el `[role="dialog"]` previamente visible desaparece del DOM tras click en celda de día. Equivalente con `await expect(dialog).toBeHidden()`.
+  - **Selección de día:** `<u-calendar>` renderiza celdas con `[data-day]`; click sobre la primera celda no deshabilitada (`:not([data-disabled])`).
+  - Si tras `/agent-browser` runtime los selectores anteriores no son estables, fallback: agregar `data-testid="pickup-date-popover"` / `return-date-popover` al `<u-popover>` y `data-testid="pickup-date-trigger"` / `return-date-trigger` al `<u-input-date>`.
+- **SCEN-004 móvil:** test Playwright con `viewport: { width: 375, height: 812 }` que asegura `#pickup-date-mobile` y `#return-date-mobile` visibles y `[type="date"]`, y que `#pickup-date` / `#return-date` están ocultos. NO se ejercita el picker nativo del SO (Playwright no controla el picker del sistema), sólo se verifica el contrato de DOM.
 - **Validación runtime con `/agent-browser`** en al menos una marca (`pnpm dev:alquilatucarro`) antes de commit, con consola y network limpios.
 
 ## Risks
 
 | # | Riesgo | Mitigación |
 |---|---|---|
-| R1 | `@update:model-value` también dispara cuando `<u-calendar>` recibe el valor inicial al montarse → cierre prematuro al abrir el popover por primera vez. | Verificar en runtime con `/agent-browser`. Si reproduce, gate con flag `userInteracted` o usar evento de click sobre celda. Esperado: NO reproducir. Nuxt UI v4 emite `update:model-value` sólo en cambio. |
-| R2 | Navegación de mes/año dentro del calendario podría disparar `update:model-value`. | No esperado: `month-controls`/`year-controls` mutan estado interno del calendario, no `modelValue`. Validar en runtime. |
-| R3 | bfcache restoration: tras retroceder desde `/reservado/{reserveCode}`, los widgets de fecha quedan bloqueados. Existe handler `pageshow` (`Searcher.vue:355-357`) que recarga, pero el bug persiste según reporte del usuario. | **Fuera de alcance de este spec.** Issue separado en GitHub. |
-| R4 | Inconsistencia entre las 3 marcas si se edita una sola. | Cambio idéntico aplicado a los 3 archivos. Test e2e multi-marca detecta deriva futura. |
+| R1 | `@update:model-value` también dispara cuando `<u-calendar>` recibe el valor inicial al montarse → cierre prematuro al abrir el popover por primera vez. | **Plan A (esperado):** Nuxt UI v4 emite `update:model-value` sólo en cambio del valor; `selectedPickupDate` se computa del store al montar y no muta en mount. Verificar en runtime con `/agent-browser`: abrir popover sin tocar nada, esperar 1s, asertar popover sigue abierto. **Plan B (si reproduce):** envolver el handler en un guard contra el primer mount: `let userInteracted = false; onMounted(() => { nextTick(() => { userInteracted = true }) })` y cambiar el handler a `@update:model-value="userInteracted && (pickupDateCalendarOpen = false)"`. Plan B local al template; no afecta store ni composable. |
+| R2 | Navegación de mes/año dentro del calendario podría disparar `update:model-value`. | No esperado: `month-controls`/`year-controls` mutan estado interno (`focusedValue`) del calendario Reka UI, no `modelValue`. Validar en runtime: abrir popover, click `next-month` 2 veces, asertar popover sigue abierto. Si reproduce, ver R1 Plan B. |
+| R3 | bfcache restoration: tras retroceder desde `/reservado/{reserveCode}`, los widgets de fecha quedan bloqueados. Existe handler `pageshow` (`Searcher.vue:355-357`) que recarga, pero el bug persiste según reporte del usuario. | **Fuera de alcance de este spec.** Tracked en [issue #25](https://github.com/amaw-sas/rentacar-web/issues/25). |
+| R4 | Inconsistencia entre las 3 marcas si se edita una sola. | Cambio idéntico aplicado a los 3 archivos. Test e2e multi-marca (`BRAND=alquilatucarro|alquilame|alquicarros`) detecta deriva futura. |
 | R5 | Regresión en SCEN-005 (watcher +7 días) si se toca lógica del store. | Cambio puramente template (event handler). Store y composable intactos. SCEN-005 lo cubre. |
 
 ## Verification plan
 
-1. Implementar los 3 cambios en `Searcher.vue` (1 línea por calendario × 2 calendarios × 3 marcas — wait: 2 líneas por archivo × 3 archivos = 6 ediciones).
+1. Implementar 6 ediciones (2 calendarios × 3 marcas) en `Searcher.vue`: agregar `@update:model-value="<state> = false"` en cada `<u-calendar>` (líneas ~149 y ~213 por archivo).
 2. `pnpm typecheck` — debe pasar.
 3. `pnpm lint` — debe pasar.
 4. `/agent-browser` runtime sobre `pnpm dev:alquilatucarro`:
-   - Abrir popover recogida → seleccionar fecha → confirmar cierre.
-   - Confirmar `fechaDevolucion` se llenó automáticamente sin abrir su popover.
+   - Abrir popover recogida → seleccionar fecha → confirmar cierre (R1 Plan A check).
+   - Abrir popover sin seleccionar nada, esperar 1s → confirmar popover sigue abierto (R1 sanity).
+   - Abrir popover, click `next-month` 2 veces → confirmar popover sigue abierto (R2 sanity).
+   - Confirmar `fechaDevolucion` se llenó automáticamente (+7 días) sin abrir su popover.
    - Abrir popover devolución → seleccionar fecha → confirmar cierre.
    - Consola: cero errores. Network: cero requests fallidos.
-5. E2E nuevo `e2e/searcher-calendar-autoclose.spec.ts` ejecutado vía `pnpm test:e2e` (mínimo `BRAND=alquilatucarro`; idealmente las 3).
+5. E2E nuevo `e2e/searcher-calendar-autoclose.spec.ts` ejecutado vía `pnpm test:e2e` cubriendo SCEN-001..005, mínimo `BRAND=alquilatucarro`; idealmente las 3 marcas.
 6. `/dogfood` exploratorio sobre el formulario de búsqueda.
 7. `/verification-before-completion` antes de commit/PR.
 
 ## Out of scope (YAGNI)
 
-- Refactor para extraer un componente `DatePickerField` compartido entre marcas. La duplicación existente está fuera del bug reportado.
-- Encadenar apertura del popover de devolución tras selección de recogida (descartado por el usuario).
-- Cambios en móvil (ya funciona).
-- Fix de R3 (bfcache desde `/reservado/{reserveCode}`) — issue separado.
+- Refactor para extraer un componente `DatePickerField` compartido entre marcas. La duplicación existente está fuera del bug reportado; introducir abstracción ahora viola YAGNI cuando sólo agregamos 2 líneas por archivo.
+- Encadenar apertura del popover de devolución tras selección de recogida (descartado por el usuario; ver decisión de scope arriba).
+- Cambios en móvil (`<input type="date">` ya cierra solo vía SO).
+- Fix de R3 (bfcache desde `/reservado/{reserveCode}`) — tracked en [issue #25](https://github.com/amaw-sas/rentacar-web/issues/25).
+- Typo pre-existente en `aria-label="Seleccione una día de recogida"` (líneas 140, 204) — no introducido por este spec, fuera de alcance.
 
 ## Handoff
 
 - **Next skill:** `/sop-planning` para producir un plan de implementación ordenado con acceptance criteria por paso.
-- **Holdout:** los 5 escenarios observables anteriores son la entrada para `/scenario-driven-development`.
+- **Holdout:** los 5 escenarios observables anteriores son la entrada para `/scenario-driven-development`. Al iniciar SDD se creará el directorio `docs/specs/2026-05-06-searcher-calendar-autoclose/scenarios/` con `searcher-calendar-autoclose.scenarios.md` extraído de este documento, conforme la convención de specs vecinas (`2026-04-29-bundled-rentacar-data-resilience/scenarios/`, etc.).

--- a/docs/specs/2026-05-06-searcher-calendar-autoclose-design.md
+++ b/docs/specs/2026-05-06-searcher-calendar-autoclose-design.md
@@ -1,0 +1,134 @@
+# Searcher: Cierre automático del calendario al seleccionar fecha
+
+**Date:** 2026-05-06
+**Status:** Approved (brainstorming)
+**Scope:** UI fix — desktop only (móvil usa input nativo)
+
+## Problem
+
+En el formulario de búsqueda de disponibilidad (`Searcher.vue`), los popovers de fecha de recogida y fecha de devolución se abren al hacer click en el `<u-input-date>`, pero **no se cierran** cuando el usuario selecciona una fecha en el `<u-calendar>` interno. El popover sólo se cierra si el usuario hace click fuera. UX incorrecta: una selección concreta debería confirmar y cerrar.
+
+## Root cause
+
+`packages/ui-{brand}/app/components/Searcher.vue` (idéntico en las 3 marcas), líneas 132-160 y 196-225:
+
+```vue
+<u-popover v-model:open="pickupDateCalendarOpen">
+  ...
+  <template #content>
+    <u-calendar v-model="selectedPickupDate" ... />
+  </template>
+</u-popover>
+```
+
+`<u-popover>` se abre con `@click="pickupDateCalendarOpen = true"` en el `<u-input-date>`, pero ningún handler escucha el evento de selección de `<u-calendar>` para revertir `pickupDateCalendarOpen` a `false`. Misma estructura con `returnDateCalendarOpen`.
+
+Móvil (`<input type="date">` en líneas 168-177 y 230-…) cierra automáticamente vía SO — fuera de alcance.
+
+## Decision
+
+Agregar el handler `@update:model-value` al `<u-calendar>` que cierra el popover correspondiente:
+
+```vue
+<u-calendar
+  v-model="selectedPickupDate"
+  @update:model-value="pickupDateCalendarOpen = false"
+  ...
+/>
+```
+
+Idéntico para el calendario de devolución con `returnDateCalendarOpen`.
+
+### Alternativas consideradas
+
+| Opción | Descripción | Por qué se descartó |
+|---|---|---|
+| Watcher sobre el ref `selectedPickupDate` | `watch(selectedPickupDate, () => { pickupDateCalendarOpen.value = false })` | Dispara también ante mutaciones programáticas del store (p. ej. `useSearch.ts:151-153` setea `fechaDevolucion = recogida + 7d`). Acopla cierre a *cualquier* cambio del ref, no a la acción del usuario. Más frágil ante cambios futuros del watcher. |
+| Eventos `@day-select`/`@select` | Eventos no listados como contrato público de `<u-calendar>` v4 | Depende de internals; `update:modelValue` es la API estable documentada. |
+
+### Decisión de scope: no encadenar popovers
+
+Cuando el usuario selecciona la fecha de recogida, el popover de devolución **no** se abre automáticamente. La fecha de devolución por defecto (+7 días) se setea via watcher existente en `useSearch.ts:151-153` sin abrir UI adicional. El usuario debe hacer click en el `<u-input-date>` de devolución si quiere modificarla. Razón: el reporte pide cierre automático, no encadenamiento; agregar encadenamiento amplía alcance y puede sorprender al usuario.
+
+## Affected files (blast radius)
+
+- `packages/ui-alquilatucarro/app/components/Searcher.vue` — 2 líneas (1 por calendario)
+- `packages/ui-alquilame/app/components/Searcher.vue` — idéntico
+- `packages/ui-alquicarros/app/components/Searcher.vue` — idéntico
+
+Sin cambios en:
+- `packages/logic/` (store `useStoreReservationForm`, composable `useSearch`)
+- Server endpoints
+- Tipos
+- Configuración
+
+Consumidores del componente: páginas `[city]/...` que embeben `<Searcher />`. Ningún contrato cambia.
+
+## Observable scenarios
+
+**SCEN-001 — Cierre tras selección de fecha de recogida (desktop)**
+- **Given** el formulario en viewport ≥640px, el popover de "Día de recogida" abierto.
+- **When** el usuario hace click en una celda de día válida (no deshabilitada, ≥ `minPickupDate`).
+- **Then** el popover se cierra (no visible / `aria-expanded="false"`) y el `<u-input-date>` muestra la fecha seleccionada.
+
+**SCEN-002 — Cierre tras selección de fecha de devolución (desktop)**
+- **Given** el formulario en viewport ≥640px con fecha de recogida seleccionada y el popover de "Día de devolución" abierto.
+- **When** el usuario hace click en una celda de día válida (entre `minReturnDate` y `maxReturnDate`).
+- **Then** el popover de devolución se cierra y el `<u-input-date>` muestra la fecha seleccionada.
+
+**SCEN-003 — Independencia entre popovers**
+- **Given** el popover de recogida abierto, el de devolución cerrado.
+- **When** el usuario selecciona una fecha de recogida.
+- **Then** sólo el popover de recogida se cierra; el popover de devolución permanece cerrado (no se abre ni cambia de estado).
+
+**SCEN-004 — Móvil intacto**
+- **Given** viewport <640px (input `<input type="date">` nativo visible).
+- **When** el usuario selecciona una fecha en el picker nativo del SO.
+- **Then** el comportamiento existente se preserva; sin regresión en `fechaRecogida`/`fechaDevolucion` ni en el watcher de +7 días.
+
+**SCEN-005 — Watcher de fecha por defecto preservado**
+- **Given** viewport ≥640px, sin fecha de recogida seleccionada (estado inicial).
+- **When** el usuario selecciona una fecha de recogida en el calendario.
+- **Then** el popover de recogida se cierra **y** `fechaDevolucion` se setea a recogida + 7 días (`useSearch.ts:151-153`), sin abrir el popover de devolución.
+
+## Satisfaction strategy
+
+- **E2E (Playwright, multi-marca via `BRAND` env):** nuevo `e2e/searcher-calendar-autoclose.spec.ts` cubriendo SCEN-001..003 y SCEN-005. Selectores estables: `#pickup-date`, `#return-date` (id existentes); agregar `data-testid` al popover si los selectores actuales no permiten asertar visibilidad.
+- **SCEN-004** verificado por inspección de no-cambio (diff vacío en bloque móvil del `Searcher.vue`); no requiere test nuevo.
+- **Validación runtime con `/agent-browser`** en al menos una marca (`pnpm dev:alquilatucarro`) antes de commit, con consola y network limpios.
+
+## Risks
+
+| # | Riesgo | Mitigación |
+|---|---|---|
+| R1 | `@update:model-value` también dispara cuando `<u-calendar>` recibe el valor inicial al montarse → cierre prematuro al abrir el popover por primera vez. | Verificar en runtime con `/agent-browser`. Si reproduce, gate con flag `userInteracted` o usar evento de click sobre celda. Esperado: NO reproducir. Nuxt UI v4 emite `update:model-value` sólo en cambio. |
+| R2 | Navegación de mes/año dentro del calendario podría disparar `update:model-value`. | No esperado: `month-controls`/`year-controls` mutan estado interno del calendario, no `modelValue`. Validar en runtime. |
+| R3 | bfcache restoration: tras retroceder desde `/reservado/{reserveCode}`, los widgets de fecha quedan bloqueados. Existe handler `pageshow` (`Searcher.vue:355-357`) que recarga, pero el bug persiste según reporte del usuario. | **Fuera de alcance de este spec.** Issue separado en GitHub. |
+| R4 | Inconsistencia entre las 3 marcas si se edita una sola. | Cambio idéntico aplicado a los 3 archivos. Test e2e multi-marca detecta deriva futura. |
+| R5 | Regresión en SCEN-005 (watcher +7 días) si se toca lógica del store. | Cambio puramente template (event handler). Store y composable intactos. SCEN-005 lo cubre. |
+
+## Verification plan
+
+1. Implementar los 3 cambios en `Searcher.vue` (1 línea por calendario × 2 calendarios × 3 marcas — wait: 2 líneas por archivo × 3 archivos = 6 ediciones).
+2. `pnpm typecheck` — debe pasar.
+3. `pnpm lint` — debe pasar.
+4. `/agent-browser` runtime sobre `pnpm dev:alquilatucarro`:
+   - Abrir popover recogida → seleccionar fecha → confirmar cierre.
+   - Confirmar `fechaDevolucion` se llenó automáticamente sin abrir su popover.
+   - Abrir popover devolución → seleccionar fecha → confirmar cierre.
+   - Consola: cero errores. Network: cero requests fallidos.
+5. E2E nuevo `e2e/searcher-calendar-autoclose.spec.ts` ejecutado vía `pnpm test:e2e` (mínimo `BRAND=alquilatucarro`; idealmente las 3).
+6. `/dogfood` exploratorio sobre el formulario de búsqueda.
+7. `/verification-before-completion` antes de commit/PR.
+
+## Out of scope (YAGNI)
+
+- Refactor para extraer un componente `DatePickerField` compartido entre marcas. La duplicación existente está fuera del bug reportado.
+- Encadenar apertura del popover de devolución tras selección de recogida (descartado por el usuario).
+- Cambios en móvil (ya funciona).
+- Fix de R3 (bfcache desde `/reservado/{reserveCode}`) — issue separado.
+
+## Handoff
+
+- **Next skill:** `/sop-planning` para producir un plan de implementación ordenado con acceptance criteria por paso.
+- **Holdout:** los 5 escenarios observables anteriores son la entrada para `/scenario-driven-development`.

--- a/docs/specs/2026-05-06-searcher-calendar-autoclose/implementation/plan.md
+++ b/docs/specs/2026-05-06-searcher-calendar-autoclose/implementation/plan.md
@@ -1,0 +1,286 @@
+# Implementation Plan — Searcher Calendar Autoclose
+
+**Date:** 2026-05-06
+**Spec:** `docs/specs/2026-05-06-searcher-calendar-autoclose-design.md` (commits `0088e28`, `6203317`)
+**Holdout:** `docs/specs/2026-05-06-searcher-calendar-autoclose/scenarios/searcher-calendar-autoclose.scenarios.md` (commit `df3f819`)
+**Related issue:** [#25](https://github.com/amaw-sas/rentacar-web/issues/25) (R3 bfcache, fuera de alcance)
+
+## File structure
+
+| Archivo | Cambio | Responsabilidad |
+|---|---|---|
+| `packages/ui-alquilatucarro/app/components/Searcher.vue` | Edit (~2 líneas) | Agregar `@update:model-value` al `<u-calendar>` de recogida (entre líneas 148-158) y devolución (entre líneas 212-222) |
+| `packages/ui-alquilame/app/components/Searcher.vue` | Edit (~2 líneas) | Mirror idéntico |
+| `packages/ui-alquicarros/app/components/Searcher.vue` | Edit (~2 líneas) | Mirror idéntico |
+| `e2e/searcher-calendar-autoclose.spec.ts` | New | Playwright multi-marca con 7 tests cubriendo SCEN-001..005 + R1/R2 sanity, viewport explícito por describe |
+| `docs/specs/2026-05-06-searcher-calendar-autoclose/implementation/selectors.md` | New (Step 0) | Documenta selectores reales descubiertos en runtime de Reka UI calendar (cell, next-month, etc.) |
+
+**Decomposición:** 4 archivos en una unidad lógica única. NO se extrae componente compartido (YAGNI). El test e2e usa `BRAND` env (config en `playwright.config.ts:12`, default `alquilatucarro`) para parametrizar marca.
+
+## Scenario → acceptance criteria mapping
+
+| Scenario | Test name esperado | Viewport | Acceptance |
+|---|---|---|---|
+| SCEN-001 (cierre recogida) | `cierra popover de recogida tras seleccionar día` | 1280×720 | `[role="dialog"]` desaparece tras click en celda; `#pickup-date` muestra fecha |
+| SCEN-002 (cierre devolución) | `cierra popover de devolución tras seleccionar día` | 1280×720 | mismo patrón con `#return-date` |
+| SCEN-003 (independencia) | `seleccionar recogida no abre devolución` | 1280×720 | `getByRole('dialog').count() === 0` post-click |
+| SCEN-004 (móvil intacto) | `inputs móviles type=date visibles` | 375×812 | `#pickup-date-mobile` y `#return-date-mobile` visibles + `type="date"`; `#pickup-date` y `#return-date` ocultos |
+| SCEN-005 (watcher +7 días) | `seleccionar recogida setea devolución +7 días sin abrir popover` | 1280×720 | Capturar `await page.locator('#return-date').inputValue()` antes (pre-click) y después (post-click); parsear ambos a `Date`; `(after - before) === 7 días` (o equivalentemente: `after === pickup + 7 días`). Popover devolución: `getByRole('dialog').count() === 0`. NOTA: el formato del `<u-input-date>` depende de locale; usar `inputValue()` lee el valor del input y se parsea con `new Date(...)` o `Date.parse(...)`. Si el formato es ambiguo (ej. MM/DD vs DD/MM), normalizar con un helper `parseInputDate()` en el spec del test. |
+| R1 sanity | `popover permanece abierto al abrir sin tocar` | 1280×720 | `[role="dialog"]` visible tras `waitForTimeout(1000)` |
+| R2 sanity | `navegar mes no cierra popover` | 1280×720 | `[role="dialog"]` visible tras 2 clicks en `next-month` |
+
+Total: **7 tests por marca × 3 marcas = 21 ejecuciones** en CI.
+
+## Prerequisites
+
+- Repo limpio (`git status` → clean) con commit `df3f819` aplicado.
+- `pnpm install` ejecutado.
+- Node ≥20, pnpm ≥9.
+- Playwright instalado (verificar con `pnpm playwright --version`); `e2e/install-deps.sh` está disponible si falta.
+
+## Implementation steps
+
+### Step 0 — Selector spike: descubrir DOM real de `<u-calendar>` abierto
+
+**Size:** S (≤30 min)
+**Dependencies:** none
+
+**Why:** El plan asume selectores de Reka UI que no son contractuales (`[data-day]`, control de `next-month`). El spec ya autoriza fallback con `data-testid`, pero antes de elegir entre selector real vs `data-testid` hay que ver el DOM. Sin esto, Step 1 escribe selectores ciegos.
+
+**Approach:**
+1. Iniciar `pnpm dev:alquilatucarro` (puerto 4000).
+2. Con `/agent-browser`: navegar a `/`, click `#pickup-date`, esperar popover abierto.
+3. Tomar `browser_snapshot` del DOM con el calendario visible. Identificar:
+   - Selector estable para celda de día clickeable (probablemente `[role="gridcell"]` o `[data-day]`).
+   - Selector para celda deshabilitada (probablemente `[data-disabled]` o `aria-disabled="true"`).
+   - Selector para botón "next month" (probablemente `button[aria-label*="next"]` o similar — ver props `next-month` en `Searcher.vue:157`).
+   - Selector para indicador de mes/año (header del calendario).
+4. Confirmar que `<u-popover>` content está marcado con `[role="dialog"]` cuando abierto (asumido en spec).
+5. Confirmar que `pnpm dev:alquilame` (puerto 4002) y `pnpm dev:alquicarros` (puerto 4001) renderizan `<Searcher />` en `/` (homepage) — alternativamente, identificar la ruta correcta por marca para el test e2e. Las 3 marcas DEBEN tener una ruta común que renderice Searcher para que `BRAND=...` parametrice sin cambiar la URL.
+6. Documentar hallazgos en `docs/specs/2026-05-06-searcher-calendar-autoclose/implementation/selectors.md` con el snapshot relevante. Este archivo es scratch/working notes de implementación; queda en repo junto al plan pero no es contrato.
+7. Si los selectores son inestables o no expuestos en DOM (p. ej. clases hash de Tailwind como única opción), agregar al plan: añadir `data-testid` en Step 2 antes de Step 1's tests. (Esta decisión retroalimenta Step 1.)
+
+**Acceptance criteria:**
+- Archivo `selectors.md` creado con selectores reales documentados de runtime.
+- Decisión registrada: usar selectores nativos de Reka UI O agregar `data-testid` (con qué valor, en qué línea de cada `Searcher.vue`).
+- `/agent-browser` confirma `[role="dialog"]` aparece al abrir popover, desaparece al click outside (validación pre-fix).
+- Confirmado: las 3 marcas renderizan `<Searcher />` en `/` (o ruta común documentada en `selectors.md` si difiere).
+
+---
+
+### Step 1 — Test e2e que falla (TDD red phase)
+
+**Size:** M (~60-90 min)
+**Dependencies:** Step 0
+
+**Approach:**
+1. Crear `e2e/searcher-calendar-autoclose.spec.ts` con 7 tests. Estructura:
+   ```ts
+   import { test, expect } from '@playwright/test';
+
+   test.describe('Searcher calendar autoclose - desktop', () => {
+     test.use({ viewport: { width: 1280, height: 720 } });
+
+     test('cierra popover de recogida tras seleccionar día', async ({ page }) => { /* SCEN-001 */ });
+     test('cierra popover de devolución tras seleccionar día', async ({ page }) => { /* SCEN-002 */ });
+     test('seleccionar recogida no abre devolución', async ({ page }) => { /* SCEN-003 */ });
+     test('seleccionar recogida setea devolución +7 días sin abrir popover', async ({ page }) => { /* SCEN-005 */ });
+     test('popover permanece abierto al abrir sin tocar', async ({ page }) => { /* R1 sanity */ });
+     test('navegar mes no cierra popover', async ({ page }) => { /* R2 sanity */ });
+   });
+
+   test.describe('Searcher calendar autoclose - mobile', () => {
+     test.use({ viewport: { width: 375, height: 812 } });
+     test('inputs móviles type=date visibles', async ({ page }) => { /* SCEN-004 */ });
+   });
+   ```
+2. Cada test usa los selectores documentados en `selectors.md` (Step 0). Selección de día válida: primera celda clickeable disponible (no deshabilitada, ≥ `minPickupDate`).
+3. Tests usan `page.goto('/')` (homepage de cada marca renderiza Searcher) y `await page.waitForLoadState('networkidle')`.
+4. Para SCEN-005, capturar valor de `#return-date` antes y después; asertar diff de 7 días.
+5. Ejecutar: `BRAND=alquilatucarro pnpm playwright test searcher-calendar-autoclose --project=chromium`.
+6. **Expected (TDD red):**
+   - SCEN-001/002/003/005: **FAIL** (popover no cierra — el bug actual).
+   - R1/R2 sanity: **PASS** (esos tests asertan no-cierre, que ya es el comportamiento actual).
+   - SCEN-004 (móvil): **PASS** (móvil ya funciona, sin cambios necesarios).
+7. Si la distribución de fails no coincide con lo esperado: investigar selectores antes de Step 2.
+
+**Acceptance criteria:**
+- Archivo `e2e/searcher-calendar-autoclose.spec.ts` creado con 7 tests, viewport explícito por describe.
+- `BRAND=alquilatucarro pnpm playwright test searcher-calendar-autoclose --project=chromium` ejecuta los 7 tests; SCEN-001/002/003/005 **fallan**, SCEN-004/R1/R2 **pasan** (red phase de SCEN-001..003,005).
+- Output literal del comando capturado para usar como evidencia en Step 2.
+- `pnpm typecheck` y `pnpm lint` pasan (el test file no debe romper esos comandos).
+
+---
+
+### Step 2 — Aplicar fix a `alquilatucarro` (TDD green phase)
+
+**Size:** S (~20-30 min)
+**Dependencies:** Step 1
+
+**Approach:**
+1. En `packages/ui-alquilatucarro/app/components/Searcher.vue`:
+   - En el `<u-calendar v-model="selectedPickupDate" ...>` (abre línea 148, atributos hasta línea 158): agregar `@update:model-value="pickupDateCalendarOpen = false"`.
+   - En el `<u-calendar v-model="selectedReturnDate" ...>` (abre línea 212, atributos hasta línea 222): agregar `@update:model-value="returnDateCalendarOpen = false"`.
+2. Re-ejecutar: `BRAND=alquilatucarro pnpm playwright test searcher-calendar-autoclose --project=chromium`.
+3. **Expected (green phase):** todos los 7 tests pasan (7 passed, 0 failed, 0 skipped).
+4. Re-run del comando 3 veces consecutivas para verificar estabilidad (no flakiness).
+5. `/agent-browser` runtime adicional sobre `pnpm dev:alquilatucarro`:
+   - Abrir popover sin interactuar, esperar 1.5s → confirmar permanece abierto (R1 Plan A live check).
+   - Abrir popover, click `next-month` 2x → confirmar permanece abierto (R2 live check).
+   - Inspeccionar consola (cero errores) y network panel (cero requests fallidos).
+6. **Si R1 Plan A falla** (popover cierra al abrir o al cambiar mes), aplicar **Plan B**:
+   ```ts
+   // En <script setup> de Searcher.vue, después de la sección de refs:
+   const pickupCalendarUserInteracted = ref(false);
+   const returnCalendarUserInteracted = ref(false);
+   watch(pickupDateCalendarOpen, (open) => { if (!open) pickupCalendarUserInteracted.value = false; });
+   watch(returnDateCalendarOpen, (open) => { if (!open) returnCalendarUserInteracted.value = false; });
+   ```
+   Y en el template:
+   ```vue
+   <u-calendar
+     v-model="selectedPickupDate"
+     @update:model-value="pickupCalendarUserInteracted ? (pickupDateCalendarOpen = false) : (pickupCalendarUserInteracted = true)"
+     ...
+   />
+   ```
+   Plan B local al template + 4 líneas en script. NO toca store, composable, ni los otros archivos.
+
+**Acceptance criteria:**
+- Diff a `Searcher.vue` muestra exactamente 2 líneas agregadas (Plan A) o ~2 + script changes (Plan B), sólo en alquilatucarro.
+- `pnpm typecheck` pasa.
+- `pnpm lint` pasa.
+- E2E command output: 7 passed, 0 failed, 0 skipped en 3 ejecuciones consecutivas.
+- `/agent-browser` confirma SCEN-001..005 + R1/R2 sanity en runtime.
+- SCEN-001..005 + R1/R2 satisfechos en `BRAND=alquilatucarro`.
+
+---
+
+### Step 3 — Mirror a `alquilame` y `alquicarros`
+
+**Size:** S (~20 min)
+**Dependencies:** Step 2
+
+**Approach:**
+1. Aplicar exactamente el mismo cambio (Plan A o Plan B según resultó Step 2) en:
+   - `packages/ui-alquilame/app/components/Searcher.vue` (líneas correspondientes).
+   - `packages/ui-alquicarros/app/components/Searcher.vue` (líneas correspondientes).
+2. Verificar que el bloque calendar es idéntico entre las 3 archives. Strategy: extraer una ventana acotada y diff:
+   ```bash
+   for brand in alquilatucarro alquilame alquicarros; do
+     sed -n '128,228p' "packages/ui-${brand}/app/components/Searcher.vue" \
+       > /tmp/searcher-${brand}-calendar.txt
+   done
+   diff /tmp/searcher-alquilatucarro-calendar.txt /tmp/searcher-alquilame-calendar.txt
+   diff /tmp/searcher-alquilatucarro-calendar.txt /tmp/searcher-alquicarros-calendar.txt
+   ```
+   Ambos diffs deben ser **vacíos** (las 3 marcas comparten el mismo bloque de Searcher para el calendario).
+3. Verificar la presencia del nuevo handler en las 3 archives:
+   ```bash
+   grep -c '@update:model-value' packages/ui-*/app/components/Searcher.vue
+   ```
+   - **Si Plan A se aplicó:** debe imprimir `2` en cada archivo (uno por calendar).
+   - **Si Plan B se aplicó:** debe imprimir el mismo conteo en los 3 archivos (la cantidad exacta depende de cómo se factorizó el handler — anotar en Step 2 al aplicar Plan B y propagar el mismo conteo aquí). Lo crítico es que el conteo sea **idéntico entre las 3 marcas**, no un número absoluto.
+4. Ejecutar el e2e en las 3 marcas, con 3 ejecuciones consecutivas por marca para verificar estabilidad (no flakiness):
+   ```bash
+   for brand in alquilatucarro alquilame alquicarros; do
+     for i in 1 2 3; do
+       BRAND=$brand pnpm playwright test searcher-calendar-autoclose --project=chromium
+     done
+   done
+   ```
+   Cada uno de los 9 runs (3 marcas × 3 ejecuciones) debe retornar 7 passed, 0 failed, 0 skipped.
+
+**Acceptance criteria:**
+- `diff` del bloque calendar (líneas 128-228) entre las 3 archives es vacío.
+- `grep -c '@update:model-value'` retorna **el mismo conteo** en cada Searcher.vue (≥2 en Plan A; conteo de Plan B debe ser propagado por igual).
+- E2E pasa en las 3 marcas con 3 ejecuciones consecutivas cada una (9 runs × 7 tests = 63 passed, 0 failed, 0 skipped).
+- `pnpm typecheck` (corre las 3 ui-* en paralelo) y `pnpm lint` pasan.
+- SCEN-001..005 + R1/R2 satisfechos en las 3 marcas, estables a lo largo de las 3 ejecuciones.
+
+---
+
+### Step 4 — Quality gate, dogfood, commit, PR
+
+**Size:** S (~30-45 min)
+**Dependencies:** Step 3
+
+**Approach:**
+1. **`/dogfood`** exploratorio sobre `pnpm dev:alquilatucarro`. Foco específico:
+   - Selección rápida ida-y-vuelta: abrir recogida, seleccionar, abrir devolución, seleccionar — confirmar ambas cierran independientemente.
+   - Teclado: abrir popover, navegar con flechas, Enter en celda — registrar comportamiento (no es scenario formal pero documentar findings).
+   - Reabrir popover ya con fecha seleccionada (no estado inicial) — confirmar Plan A no dispara cierre prematuro en mount post-selección.
+   - Cambio de marca via toggle de URL (si aplica) — sanity check.
+   Issues no críticos van como follow-up tasks; críticos bloquean Step 4.
+2. **`/verification-before-completion`** con evidencia fresca:
+   - Output literal de los 3 comandos `BRAND=… pnpm playwright test ...`.
+   - Output de `pnpm typecheck` y `pnpm lint`.
+   - Resumen `/agent-browser` runtime.
+   - Estado: 21/21 SCEN+sanity satisfechos × 3 marcas.
+   - Reward hacking check: ningún `*.scenarios.md` modificado durante implementación.
+3. Crear branch (sugerido: `fix/searcher-calendar-autoclose`):
+   ```bash
+   git checkout -b fix/searcher-calendar-autoclose
+   ```
+4. Commitear cambios — un solo commit recomendado:
+   ```
+   fix(reservations): cerrar popovers de fecha tras seleccionar día
+
+   Spec: docs/specs/2026-05-06-searcher-calendar-autoclose-design.md
+   Holdout: 7 escenarios (SCEN-001..005 + R1/R2 sanity).
+
+   Cambio: agregar @update:model-value al <u-calendar> dentro del
+   <u-popover> de recogida y devolución en las 3 marcas. Móvil
+   sin cambios (input nativo ya cierra).
+
+   E2E: e2e/searcher-calendar-autoclose.spec.ts cubre los 7 escenarios
+   parametrizado por BRAND env, viewport explícito por describe.
+
+   Out of scope: bug bfcache widget block (issue #25).
+   ```
+5. **`/pull-request`** para crear PR. El skill ejecuta los 4 reviewers (code-reviewer + security-reviewer + edge-case-detector + performance-engineer) en paralelo como gate.
+6. Esperar resultados de los 4 reviewers; remediar issues bloqueantes; abrir PR a `main` cuando estén verdes.
+
+**Acceptance criteria:**
+- `/dogfood` documentado con findings (críticos resueltos antes de Step 4 cierre; no-críticos como follow-up).
+- `/verification-before-completion` retorna 21/21 SCEN+sanity satisfechos con evidencia literal.
+- 1 commit en branch `fix/searcher-calendar-autoclose` con scope `reservations`.
+- PR creado vía `/pull-request`.
+- Los 4 reviewers retornan sin bloqueantes; PR queda listo para revisión humana.
+
+## Testing strategy
+
+- **Unit:** ninguna. Cambio puramente template; no hay lógica nueva.
+- **Integration:** ninguna. Store + composable intactos.
+- **E2E:** `e2e/searcher-calendar-autoclose.spec.ts` — 7 tests, viewport explícito, parametrizado por `BRAND` env. Es el ground truth de satisfacción.
+- **Runtime:** `/agent-browser` antes de Step 2 (selectors) y durante Step 2/4 (UX). `/dogfood` en Step 4.
+- **Regression guard:** E2E en las 3 marcas detecta deriva (R4) y regresión móvil (R5).
+
+## Rollout plan
+
+- **Deploy:** Vercel preview por PR; promoción a producción tras merge a `main` (auto-deploy).
+- **Monitoring:** ningún cambio de métricas. Cambio aislado de UX, no afecta endpoints ni datos.
+- **Rollback:** revert del commit. Cambio aislado a 3 archives + 1 e2e; revert trivial sin migración de datos.
+
+## Risk register
+
+| # | Riesgo | Status / Plan |
+|---|---|---|
+| R1 | Cierre prematuro al abrir popover | Plan A esperado; Plan B (gate `userInteracted`) está restated en Step 2 con código completo. Local al template, sin tocar store/composable. |
+| R2 | Navegación de mes cierra popover | Mismo Plan B que R1 si reproduce. |
+| R3 | bfcache widgets bloqueados | **Out of scope.** Issue [#25](https://github.com/amaw-sas/rentacar-web/issues/25). |
+| R4 | Deriva entre marcas | Step 3 verifica diff vacío de bloque calendar + grep handler count + e2e en las 3. |
+| R5 | Regresión SCEN-005 (+7 días) | Cambio sólo template. SCEN-005 lo guarda. |
+| New: selectores Reka UI inestables | Step 0 spike + fallback `data-testid` autorizado en spec. |
+
+## Estimación
+
+- **Total:** 5 steps, S+M+S+S+S ≈ **3-4 horas** trabajo activo.
+- **Riesgo:** bajo. Cambio mecánico, holdout claro, e2e infra existente.
+- **Bloqueante potencial:** Plan B de R1/R2 (~30 min adicional). Selectores Reka UI inestables (Step 0 lo descubre a 30 min de iniciar).
+
+## Handoff
+
+- **Next:** invocar `/scenario-driven-development` o `/sop-task-generator` para ejecutar Step 0.
+- **Holdout vivo:** `docs/specs/2026-05-06-searcher-calendar-autoclose/scenarios/searcher-calendar-autoclose.scenarios.md`.
+- **Verification gate:** `/verification-before-completion` en Step 4 antes del PR.

--- a/docs/specs/2026-05-06-searcher-calendar-autoclose/implementation/selectors.md
+++ b/docs/specs/2026-05-06-searcher-calendar-autoclose/implementation/selectors.md
@@ -1,0 +1,150 @@
+# Selector Spike — Step 0 Findings
+
+**Date:** 2026-05-06
+**Branch:** main (commit `0e7fc80`)
+**Tool:** `/agent-browser` runtime sobre `pnpm dev:alquilatucarro` (puerto 4000)
+**Page tested:** `http://localhost:4000/armenia` (no se prueban las otras 2 marcas — convención del proyecto: el Searcher es código compartido idéntico entre marcas. La verificación cross-marca queda para Step 3 vía e2e parametrizado por `BRAND`).
+
+## TL;DR
+
+- Selector estable de **estado abierto/cerrado del popover**: `aria-expanded` del trigger button (NOT `[role="dialog"]` directo, aunque éste también funciona). El bug actual: tras click en celda, `aria-expanded` permanece `"true"`.
+- Selector estable de **celda de día clickeable**: `[data-reka-calendar-cell-trigger][data-value="YYYY-MM-DD"]` para targeting determinístico, o `:not([data-disabled]):not([data-unavailable]):not([data-outside-view])` para "primera disponible".
+- Sin cambios necesarios en `Searcher.vue` para selectores estables — TODOS son provistos por Reka UI nativamente. **NO se requieren `data-testid`.**
+
+## Plan corrections derivados de Step 0
+
+| Plan asumía | Realidad observada | Corrección |
+|---|---|---|
+| Tests usan `page.goto('/')` | Homepage usa `<SelectBranch />`, NO `<Searcher />`. Searcher vive en `[city]` (`CityPage.vue:79,91`). | Usar `page.goto('/armenia')` (mismo patrón que `searcher-mobile-label-click.spec.ts:9`). |
+| `#pickup-date` es trigger del popover | `#pickup-date` es el `<u-input-date>` wrapper que contiene 3 spinbuttons (day/month/year) y un trigger button separado. El trigger del popover es `button[aria-label="Seleccione una día de recogida"]`. | Click en el button del popover, NO en `#pickup-date`. Aunque `<u-input-date>` también tiene `@click="pickupDateCalendarOpen = true"` en el wrapper, así que ambos abren el popover. Para tests, preferir el trigger button (semánticamente correcto). |
+| Asserción de cierre vía `[role="dialog"]` desaparece | `[role="dialog"]` cuenta sí va de 1 a 0 al cerrar (confirmado), pero `aria-expanded` en el trigger es más explícito y resistente a cambios de Nuxt UI. | Asertar AMBOS para defensa en profundidad: `aria-expanded="false"` en trigger AND `[role="dialog"]` count == 0. |
+| Día cells via `[role="gridcell"]` | El `<td role="gridcell">` es el wrapper; el clickeable es `<div role="button" data-reka-calendar-cell-trigger>` adentro. Atributos `data-disabled`/`data-unavailable` están en el DIV interno, NO en el TD. | Targetear `[data-reka-calendar-cell-trigger]` directamente, no `[role="gridcell"]`. |
+| Cross-marca en `/` | Las 3 marcas comparten el componente `Searcher.vue`; `Cities` (Supabase) garantiza `/armenia` válido en las 3. | OK. Step 3 e2e con `BRAND` env. |
+
+## DOM observado
+
+### Estado inicial (popover cerrado, 2026-05-06 09:30 hora servidor)
+
+```
+- button "Seleccione una día de recogida" [aria-expanded=false]
+  (3 spinbuttons asociados al input desktop: day=7, month=5, year=2026)
+- button "Seleccione una día de devolución" [aria-expanded=false]
+  (3 spinbuttons: day=14, month=5, year=2026 — pickup +7 días vía watcher)
+```
+
+Hay **2 instancias** de cada `#pickup-date` y `#return-date` en el DOM (CityPage.vue renderiza dos `<Searcher />` — una para desktop, una para mobile, alternando vía `hidden sm:block` / `sm:hidden`). Los tests deben usar `.first()` (desktop) con viewport ≥640px, o `.last()` con viewport <640px (mismo patrón que `searcher-mobile-label-click.spec.ts:17,22,47`).
+
+### Estado abierto
+
+Tras click en `button[aria-label="Seleccione una día de recogida"]`:
+
+```
+- [role="dialog"] count: 1
+- [data-state="open"] count: 2  (trigger + content)
+- [data-reka-popper-content-wrapper] count: 1
+- button "Seleccione una día de recogida" [aria-expanded=true, aria-controls="reka-popover-content-v-0-12-19"]
+- button "Mes anterior" [disabled]  (porque min date = today, no se puede ir antes)
+- button "Mes siguiente"
+- 42 [role="gridcell"] (incluye headers de día de semana, días del mes, padding)
+- N [data-reka-calendar-cell-trigger] (clickeables)
+```
+
+### Estructura de una celda de día clickeable
+
+```html
+<td role="gridcell" aria-disabled="false" data-slot="cell" class="...">
+  <div
+    role="button"
+    aria-label="jueves, 9 de julio de 2026"
+    data-reka-calendar-cell-trigger=""
+    data-value="2026-07-09"
+    data-slot="cellTrigger"
+    tabindex="-1"
+    class="... data-disabled:!text-gray-300 data-disabled:!opacity-40 ...
+           data-unavailable:line-through ...
+           data-today:font-semibold ...
+           data-[selected]:bg-success ..."
+  >9</div>
+</td>
+```
+
+**Atributos de estado** (todos en el DIV interno, no en el TD):
+- `data-disabled` — celda deshabilitada por `min-value` / `max-value`
+- `data-unavailable` — fechas no disponibles (no usado actualmente, futuro)
+- `data-outside-view` — días del mes anterior/siguiente que rellenan la grilla
+- `data-today` — celda del día actual
+- `data-selected` — celda seleccionada actualmente (sólo 1 en el calendar)
+- `data-highlighted` — celda con focus de teclado
+
+### Bug confirmado en runtime
+
+1. Estado inicial: `aria-expanded="false"` en trigger.
+2. Click en trigger → `aria-expanded="true"`, `[role="dialog"]` count = 1.
+3. Click en celda `data-value="2026-05-15"` → spinbuttons cambian a `15/5/2026` y los de devolución a `22/5/2026` (+7 días watcher OK), **PERO** `aria-expanded` sigue en `"true"` y `[role="dialog"]` count sigue en 1. **← este es el bug.**
+4. Click en "Mes siguiente" 2x sin seleccionar → `aria-expanded` permanece `"true"`. ✅ R2 Plan A confirmed: month nav no cierra.
+5. Press Escape → `aria-expanded="false"`, `[role="dialog"]` count = 0. (Cierre por ESC funciona; el caso roto es selección.)
+6. Console: 0 errores.
+
+## Selectores Playwright sugeridos para Step 1
+
+```ts
+// === TRIGGERS DEL POPOVER ===
+const pickupTrigger = page.getByRole('button', { name: 'Seleccione una día de recogida' }).first();
+const returnTrigger = page.getByRole('button', { name: 'Seleccione una día de devolución' }).first();
+
+// === ESTADO ABIERTO/CERRADO ===
+// Preferir aria-expanded (más explícito que [role="dialog"]):
+await expect(pickupTrigger).toHaveAttribute('aria-expanded', 'true');   // abierto
+await expect(pickupTrigger).toHaveAttribute('aria-expanded', 'false');  // cerrado
+// Defensa adicional:
+await expect(page.locator('[role="dialog"]')).toHaveCount(0);           // cerrado
+await expect(page.locator('[role="dialog"]')).toHaveCount(1);           // abierto
+
+// === CELDAS DE DÍA ===
+// Target específico (determinístico):
+const cell = page.locator('[data-reka-calendar-cell-trigger][data-value="2026-05-15"]');
+// Primera celda disponible (no disabled, no outside-view):
+const firstAvailable = page.locator(
+  '[data-reka-calendar-cell-trigger]:not([data-disabled]):not([data-unavailable]):not([data-outside-view])'
+).first();
+// Celda seleccionada actualmente:
+const selected = page.locator('[data-reka-calendar-cell-trigger][data-selected]');
+
+// === NAVEGACIÓN DE MES ===
+const nextMonth = page.getByRole('button', { name: 'Mes siguiente' });
+const prevMonth = page.getByRole('button', { name: 'Mes anterior' });
+
+// === LECTURA DE FECHA SELECCIONADA (para SCEN-005) ===
+// Opción A: leer data-value de la celda con data-selected (requiere abrir popover, NO ideal):
+const selectedISO = await page.locator('[data-reka-calendar-cell-trigger][data-selected]').first().getAttribute('data-value');
+// Opción B (recomendada para SCEN-005): leer los 3 spinbuttons del input de devolución y componer:
+async function readDate(inputId: string) {
+  const wrapper = page.locator(`#${inputId}`).first();
+  const day = await wrapper.getByRole('spinbutton', { name: 'day,' }).textContent();
+  const month = await wrapper.getByRole('spinbutton', { name: /^month,/ }).textContent();
+  const year = await wrapper.getByRole('spinbutton', { name: /^year,/ }).textContent();
+  return new Date(parseInt(year!), parseInt(month!) - 1, parseInt(day!));
+}
+const pickupDate = await readDate('pickup-date');
+const returnDate = await readDate('return-date');
+expect(returnDate.getTime() - pickupDate.getTime()).toBe(7 * 24 * 60 * 60 * 1000);
+```
+
+## Routing decisión
+
+Las 3 marcas comparten:
+- `pages/[city]/index.vue` (proxy a `<CityPage />`)
+- Cities catalog en Supabase (commit `8c8ca8f` — migración firebase→supabase)
+- `armenia` es la ciudad canónica usada en otros e2e (`searcher-mobile-label-click.spec.ts:9`, `extras-null-smoke.spec.ts`, etc.)
+
+`page.goto('/armenia')` funciona en `BRAND={alquilatucarro,alquilame,alquicarros}` porque Cities está poblado para todas. Si `/armenia` falla en `alquilame` o `alquicarros` durante Step 3, sustituir por `/bogota` u otra ciudad común.
+
+## Decisión final del spike
+
+- **NO se requieren `data-testid`** en `Searcher.vue`. Reka UI provee selectores semánticos estables (`aria-expanded`, `data-reka-calendar-cell-trigger`, `data-value`).
+- El plan se actualiza con los selectores específicos arriba antes de Step 1.
+- Plan B de R1/R2 NO necesario por ahora — el comportamiento actual (popover NO cierra al seleccionar día) confirma que `update:model-value` solamente se dispara en cambio del valor, no en otras interacciones del calendar (mes nav, mount). Plan A será suficiente.
+
+## Console errors
+
+Cero errores observados durante toda la sesión de spike. Network panel no inspeccionado en detalle (no hubo señales de fallo).

--- a/docs/specs/2026-05-06-searcher-calendar-autoclose/scenarios/searcher-calendar-autoclose.scenarios.md
+++ b/docs/specs/2026-05-06-searcher-calendar-autoclose/scenarios/searcher-calendar-autoclose.scenarios.md
@@ -1,0 +1,176 @@
+---
+name: searcher-calendar-autoclose
+created_by: pablo+claude
+created_at: 2026-05-06T09:00:00Z
+---
+
+# Searcher: Cierre automático del calendario al seleccionar fecha
+
+Fix de UX para los popovers de fecha (recogida y devolución) en el formulario
+de búsqueda de disponibilidad de categorías (`Searcher.vue`). Hoy el popover
+desktop (`<u-popover>` envolviendo `<u-calendar>`) se abre al hacer click en
+el `<u-input-date>` pero **no cierra** cuando el usuario selecciona un día —
+sólo cierra al click outside. El fix: agregar `@update:model-value="<state> = false"`
+a cada `<u-calendar>` para revertir `v-model:open` del popover ante selección.
+
+Móvil usa `<input type="date">` nativo del SO — fuera de alcance, pero se
+verifica no-regresión.
+
+Spec asociado: `docs/specs/2026-05-06-searcher-calendar-autoclose-design.md`
+(commits `0088e28`, `6203317`).
+
+---
+
+## SCEN-001: Cierre tras selección de fecha de recogida (desktop)
+
+**Given**:
+- Viewport ≥640px (`width: 1280, height: 720` en Playwright; los inputs `#pickup-date` / `#return-date` son visibles, los `*-mobile` ocultos por `sm:hidden`).
+- Página `/` o cualquier ruta que renderiza `<Searcher />` cargada (`pnpm dev:alquilatucarro` u otra marca).
+- El usuario hizo click en `#pickup-date` y el popover abrió: existe un elemento `[role="dialog"]` visible que contiene `<u-calendar>` (Reka UI renderiza el `content` del `<u-popover>` con ese rol).
+
+**When**: El usuario hace click en una celda de día válida del calendario (selector: una celda con `[data-day]` y sin atributo `data-disabled`/`data-unavailable`, idealmente la primera disponible ≥ `minPickupDate`).
+
+**Then**:
+- El popover desaparece del DOM (o pasa a `[data-state="closed"]`/`hidden`); `[role="dialog"]` ya no está visible.
+- El input `#pickup-date` muestra la fecha seleccionada (formato del `<u-input-date>`, p. ej. `MM/DD/YYYY` según locale por defecto).
+- El store Pinia refleja la selección: `useStoreReservationForm().fechaRecogida` es la fecha clickeada en formato ISO esperado por el store.
+- Cero errores en consola, cero requests fallidos en Network panel.
+
+**Evidence**:
+- DOM: `await expect(page.getByRole('dialog')).toBeHidden()` tras el click en la celda.
+- DOM: `await expect(page.locator('#pickup-date')).toHaveValue(/* fecha esperada */)`.
+- Re-runs estables: ejecutar el test 3 veces seguidas, todas pasan sin flakiness.
+
+---
+
+## SCEN-002: Cierre tras selección de fecha de devolución (desktop)
+
+**Given**:
+- Viewport ≥640px.
+- Fecha de recogida ya seleccionada (sea por SCEN-001 previo o por estado inicial); `#return-date` por tanto tiene una fecha por defecto (+7 días vía watcher en `useSearch.ts:151-153`).
+- El usuario hizo click en `#return-date` y el popover de devolución está abierto: `[role="dialog"]` visible conteniendo el `<u-calendar>` con `min-value=minReturnDate` y `max-value=maxReturnDate`.
+
+**When**: El usuario hace click en una celda válida (entre `minReturnDate` y `maxReturnDate`, sin `data-disabled`).
+
+**Then**:
+- El popover de devolución desaparece (`[role="dialog"]` no visible).
+- `#return-date` muestra la fecha seleccionada.
+- `useStoreReservationForm().fechaDevolucion` refleja la selección.
+- El popover de recogida sigue cerrado (no se abre por efecto colateral).
+
+**Evidence**:
+- DOM: `await expect(page.getByRole('dialog')).toBeHidden()` tras click.
+- DOM: `await expect(page.locator('#return-date')).toHaveValue(/* fecha esperada */)`.
+- DOM: el popover trigger de recogida no muestra `aria-expanded="true"`.
+
+---
+
+## SCEN-003: Independencia entre popovers
+
+**Given**:
+- Viewport ≥640px.
+- Ambos popovers cerrados al cargar.
+- El usuario abrió únicamente el popover de recogida (click en `#pickup-date`); existe un único `[role="dialog"]` visible asociado al input de recogida.
+
+**When**: El usuario selecciona una fecha válida en el calendario de recogida.
+
+**Then**:
+- El popover de recogida cierra (`[role="dialog"]` previamente visible ya no lo está).
+- El popover de devolución permanece cerrado: no aparece un nuevo `[role="dialog"]` visible.
+- Sólo `useStoreReservationForm().fechaRecogida` cambia con el click directo. (`fechaDevolucion` puede actualizarse vía watcher SCEN-005 — eso es comportamiento legítimo, no apertura de popover.)
+
+**Evidence**:
+- DOM: `await expect(page.getByRole('dialog')).toHaveCount(0)` o `toBeHidden()` tras la selección — ningún popover queda abierto.
+- Inspección visual con `/agent-browser`: tras la selección, ambos `<u-input-date>` muestran sólo el input, sin overlay de calendario.
+
+---
+
+## SCEN-004: Móvil intacto
+
+**Given**:
+- Viewport <640px (Playwright: `viewport: { width: 375, height: 812 }`, iPhone 13/14 size).
+- Página renderiza `<Searcher />`.
+
+**When**: El usuario carga la página y observa los inputs de fecha.
+
+**Then**:
+- `#pickup-date-mobile` y `#return-date-mobile` son visibles y tienen atributo `type="date"` (input nativo del navegador/SO).
+- `#pickup-date` y `#return-date` (variantes desktop) están ocultos por la clase `hidden sm:block` en sus contenedores.
+- El cambio del valor de los inputs móviles vía API de Playwright (`page.locator('#pickup-date-mobile').fill('2026-06-15')`) actualiza `useStoreReservationForm().fechaRecogida` y dispara el watcher de +7 días en `useSearch.ts:151-153`, igual que hoy.
+- No se ejercita el picker nativo del SO (Playwright no controla overlays del sistema); este escenario verifica el contrato de DOM, no la UX del picker nativo.
+
+**Evidence**:
+- DOM: `await expect(page.locator('#pickup-date-mobile')).toBeVisible()` y `toHaveAttribute('type', 'date')`.
+- DOM: `await expect(page.locator('#return-date-mobile')).toBeVisible()`.
+- DOM: el contenedor desktop tiene `class*="hidden"` en este viewport.
+- Comportamiento: tras `fill()` en `#pickup-date-mobile`, asertar que el input de devolución refleja una fecha 7 días posterior.
+
+---
+
+## SCEN-005: Watcher de fecha por defecto preservado
+
+**Given**:
+- Viewport ≥640px.
+- Estado inicial: ninguna fecha seleccionada por el usuario, `fechaRecogida` y `fechaDevolucion` con valores por defecto del store al montarse `<Searcher />`.
+- El popover de recogida está abierto.
+
+**When**: El usuario selecciona una fecha de recogida en el calendario (ejemplo: hoy + 14 días).
+
+**Then**:
+- El popover de recogida cierra (vía SCEN-001).
+- `useStoreReservationForm().fechaDevolucion` se setea automáticamente a `fechaRecogida + 7 días` (comportamiento de `useSearch.ts:151-153` intacto, ya que el fix sólo agrega un event handler al template, no toca store ni composable).
+- El popover de devolución permanece cerrado a pesar del cambio programático de `fechaDevolucion` (SCEN-003 reforzado).
+- Ambos `<u-input-date>` muestran las dos fechas correctas tras la única acción del usuario.
+
+**Evidence**:
+- Store: `useStoreReservationForm().fechaDevolucion` evaluada después del click ≡ `fechaRecogida + 7 días`.
+- DOM: `#return-date` muestra la fecha calculada sin que el usuario haya tocado ese input.
+- DOM: `[role="dialog"]` cuenta total = 0 tras la acción.
+
+---
+
+## SCEN-001 + R1 sanity: no-cierre prematuro al abrir el popover
+
+**Given**: Viewport ≥640px, ningún popover abierto, fecha de recogida con valor por defecto.
+
+**When**: El usuario hace click en `#pickup-date` para abrir el popover y NO interactúa más durante 1 segundo.
+
+**Then**: El popover sigue abierto (R1 Plan A asume que `<u-calendar>` no emite `update:model-value` al montarse con el valor del store). Si este escenario falla, el spec autoriza activar R1 Plan B (`userInteracted` guard).
+
+**Evidence**: `await expect(page.getByRole('dialog')).toBeVisible()` tras `await page.waitForTimeout(1000)`.
+
+---
+
+## SCEN-001 + R2 sanity: navegación de mes no cierra el popover
+
+**Given**: Viewport ≥640px, popover de recogida abierto, calendario mostrando el mes actual.
+
+**When**: El usuario hace click 2 veces en el control "next month" del calendario sin seleccionar día.
+
+**Then**: El popover sigue abierto. `month-controls`/`year-controls` mutan `focusedValue` interno de Reka UI, no `modelValue`, por lo que no debe disparar `@update:model-value`.
+
+**Evidence**: tras los 2 clicks, `await expect(page.getByRole('dialog')).toBeVisible()`. El header del calendario muestra el mes +2 respecto al actual.
+
+---
+
+## Non-goals (explícito)
+
+- **Refactor a componente compartido `DatePickerField`**: la duplicación de `Searcher.vue` entre las 3 marcas existe; NO se aborda aquí. Introducir abstracción para 2 líneas/archivo viola YAGNI.
+- **Encadenar apertura del popover de devolución tras seleccionar recogida**: descartado durante brainstorming. La fecha de devolución se setea automáticamente vía watcher (+7 días) sin abrir UI adicional.
+- **Fix del bug bfcache (R3)**: tras retroceder desde `/reservado/{reserveCode}` los widgets quedan bloqueados; tracked en [issue #25](https://github.com/amaw-sas/rentacar-web/issues/25). NO se cierra con este spec.
+- **Typo `aria-label="Seleccione una día"`** (líneas 140, 204 de `Searcher.vue`): pre-existente, fuera de alcance.
+- **Picker nativo móvil**: Playwright no controla overlays del SO; SCEN-004 verifica DOM contract, no UX del picker.
+
+---
+
+## Verification matrix (mapping a archivos)
+
+| Scenario | Test file | Viewport | Marca |
+|---|---|---|---|
+| SCEN-001 | `e2e/searcher-calendar-autoclose.spec.ts` | desktop (1280×720) | `BRAND=alquilatucarro` (mín.); idealmente las 3 |
+| SCEN-002 | mismo | desktop | mismo |
+| SCEN-003 | mismo | desktop | mismo |
+| SCEN-004 | mismo | mobile (375×812) | mismo |
+| SCEN-005 | mismo | desktop | mismo |
+| R1 sanity | mismo | desktop | mismo |
+| R2 sanity | mismo | desktop | mismo |

--- a/docs/specs/2026-05-06-searcher-calendar-autoclose/summary.md
+++ b/docs/specs/2026-05-06-searcher-calendar-autoclose/summary.md
@@ -1,0 +1,51 @@
+# Planning Summary — Searcher Calendar Autoclose
+
+**Date:** 2026-05-06
+**Goal:** Cerrar automáticamente los popovers de fecha (recogida y devolución) en `Searcher.vue` cuando el usuario selecciona un día en el calendario desktop. Móvil ya funciona vía input nativo.
+
+## Artifacts created
+
+- `docs/specs/2026-05-06-searcher-calendar-autoclose-design.md` (commits `0088e28`, `6203317`) — spec aprobado tras 2 iteraciones de reviewer
+- `docs/specs/2026-05-06-searcher-calendar-autoclose/scenarios/searcher-calendar-autoclose.scenarios.md` (commit `df3f819`) — holdout SDD con 7 escenarios (SCEN-001..005 + R1/R2 sanity)
+- `docs/specs/2026-05-06-searcher-calendar-autoclose/implementation/plan.md` — plan de 5 steps tras 2 iteraciones de reviewer
+- `docs/specs/2026-05-06-searcher-calendar-autoclose/summary.md` — este documento
+- Issue [#25](https://github.com/amaw-sas/rentacar-web/issues/25) — bug bfcache widgets bloqueados (R3, fuera de alcance)
+
+Artefactos de brainstorming/research/idea-honing **NO** se duplicaron — el spec aprobado consolida toda esa información (decisión, alternativas, riesgos, scope).
+
+## Key decisions
+
+1. **Approach: `@update:model-value` event en `<u-calendar>`** — descarta watcher sobre el ref del store (R1: dispara ante mutaciones programáticas como el watcher +7 días) y eventos no contractuales (`@day-select`).
+2. **Sin encadenamiento de popovers** — al seleccionar recogida, el popover de devolución NO se abre automáticamente. El watcher existente (`useSearch.ts:151-153`) llena la fecha de devolución +7 días; eso es suficiente.
+3. **Sin componente compartido `DatePickerField`** — YAGNI explícito. Cambio mecánico de 2 líneas × 3 archivos no justifica abstracción.
+4. **R3 (bfcache) tracked aparte** — issue #25. Este spec NO lo aborda; sólo el handler `pageshow` existente ya tenía intención de mitigarlo y persiste el bug.
+5. **TDD con e2e (red→green)** — Step 1 escribe el test que falla; Step 2 lo hace pasar. Sin tests nuevos en logic (el cambio es puramente template).
+6. **Step 0 selector spike** — antes de escribir tests, descubrir DOM real de Reka UI calendar para evitar selectores ciegos. Fallback: agregar `data-testid` (autorizado en spec).
+
+## Complexity estimate
+
+- **Overall:** S/M (cambio aislado, holdout claro, e2e infra existente)
+- **Duration:** 3-4 horas trabajo activo (5 steps: S+M+S+S+S)
+- **Risk level:** Bajo. Bloqueante potencial si Plan B de R1/R2 reproduce (~30 min adicional).
+
+## Recommended next steps
+
+1. Invocar `/scenario-driven-development` para ejecutar Step 0 (selector spike) con el holdout vivo.
+2. Avanzar Steps 1-3 (TDD red, fix alquilatucarro, mirror) bajo SDD.
+3. Step 4: `/dogfood` + `/verification-before-completion` + `/pull-request`.
+4. Tras merge: trabajar issue #25 (bfcache) por separado — no bloquea este fix.
+
+## Open questions
+
+- **Plan B necesario para R1/R2?** — Plan A asume Nuxt UI v4 emite `update:model-value` sólo en cambio. Plan B (gate `userInteracted`) listo si Step 2 runtime sorprende. Resuelto en runtime, no antes.
+- **Selectores Reka UI estables?** — pendiente de Step 0. Si no, agregar `data-testid` (decisión consciente, no fragilidad).
+
+## Status
+
+| Etapa | Estado |
+|---|---|
+| Brainstorming | ✅ aprobado |
+| Spec + reviewer loop | ✅ aprobado (iter 2) |
+| Holdout extraction | ✅ commit `df3f819` |
+| Implementation plan + reviewer loop | ✅ aprobado (iter 2) |
+| Implementation execution | ⏳ pendiente — Step 0 |

--- a/e2e/searcher-calendar-autoclose.spec.ts
+++ b/e2e/searcher-calendar-autoclose.spec.ts
@@ -1,0 +1,155 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// Holdout: docs/specs/2026-05-06-searcher-calendar-autoclose/scenarios/
+//          searcher-calendar-autoclose.scenarios.md
+// Spec:    docs/specs/2026-05-06-searcher-calendar-autoclose-design.md
+// Selectors: docs/specs/2026-05-06-searcher-calendar-autoclose/implementation/
+//            selectors.md (Step 0 spike)
+//
+// Two <Searcher /> instances render in CityPage.vue (lines 79 + 91): one for
+// desktop (hidden sm:block), one for mobile (sm:hidden). Tests use .first()
+// at desktop viewport and .last() at mobile viewport — same convention as
+// e2e/searcher-mobile-label-click.spec.ts.
+
+const PICKUP_TRIGGER = 'button[aria-label="Seleccione una día de recogida"]';
+const RETURN_TRIGGER = 'button[aria-label="Seleccione una día de devolución"]';
+const AVAILABLE_DAY =
+  '[data-reka-calendar-cell-trigger]:not([data-disabled]):not([data-unavailable]):not([data-outside-view]):not([data-selected])';
+
+// `#pickup-date` and `#return-date` are hidden <input> elements that mirror
+// the date in ISO format ("YYYY-MM-DD") via v-model. Read their `value`
+// attribute directly — locale-independent and always parseable.
+async function readDateISO(page: Page, inputId: string): Promise<string> {
+  const value = await page.locator(`#${inputId}`).first().getAttribute('value');
+  return value || '';
+}
+
+test.describe('Searcher calendar autoclose - desktop', () => {
+  test.use({ viewport: { width: 1280, height: 720 } });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/armenia');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('SCEN-001: cierra popover de recogida tras seleccionar día', async ({ page }) => {
+    const trigger = page.locator(PICKUP_TRIGGER).first();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    await trigger.click();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    await expect(page.locator('[role="dialog"]')).toHaveCount(1);
+
+    await page.locator(AVAILABLE_DAY).first().click();
+
+    // Post-fix expectations: popover closes after day selection
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await expect(page.locator('[role="dialog"]')).toHaveCount(0);
+  });
+
+  test('SCEN-002: cierra popover de devolución tras seleccionar día', async ({ page }) => {
+    const trigger = page.locator(RETURN_TRIGGER).first();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    await trigger.click();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    await expect(page.locator('[role="dialog"]')).toHaveCount(1);
+
+    await page.locator(AVAILABLE_DAY).first().click();
+
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await expect(page.locator('[role="dialog"]')).toHaveCount(0);
+  });
+
+  test('SCEN-003: seleccionar recogida no abre popover de devolución', async ({ page }) => {
+    const pickupTrigger = page.locator(PICKUP_TRIGGER).first();
+    const returnTrigger = page.locator(RETURN_TRIGGER).first();
+
+    await pickupTrigger.click();
+    await expect(pickupTrigger).toHaveAttribute('aria-expanded', 'true');
+    await expect(returnTrigger).toHaveAttribute('aria-expanded', 'false');
+
+    await page.locator(AVAILABLE_DAY).first().click();
+
+    // Pickup closes (SCEN-001), return stays closed (no chaining)
+    await expect(pickupTrigger).toHaveAttribute('aria-expanded', 'false');
+    await expect(returnTrigger).toHaveAttribute('aria-expanded', 'false');
+    await expect(page.locator('[role="dialog"]')).toHaveCount(0);
+  });
+
+  test('SCEN-005: seleccionar recogida setea devolución +7 días sin abrir su popover', async ({ page }) => {
+    const pickupTrigger = page.locator(PICKUP_TRIGGER).first();
+    const returnTrigger = page.locator(RETURN_TRIGGER).first();
+
+    await pickupTrigger.click();
+
+    // Read target ISO from the cell we're about to click — locale-independent
+    const targetCell = page.locator(AVAILABLE_DAY).first();
+    const targetISO = await targetCell.getAttribute('data-value');
+    expect(targetISO).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+    await targetCell.click();
+
+    // Pickup popover closes; return popover stays closed (no auto-open)
+    await expect(pickupTrigger).toHaveAttribute('aria-expanded', 'false');
+    await expect(returnTrigger).toHaveAttribute('aria-expanded', 'false');
+
+    // Compute expected return date from ISO components (timezone-safe)
+    const [py, pm, pd] = targetISO!.split('-').map((n) => parseInt(n, 10));
+    const pickupLocal = new Date(py, pm - 1, pd);
+    const returnLocal = new Date(pickupLocal);
+    returnLocal.setDate(pickupLocal.getDate() + 7);
+    const expectedReturnISO =
+      `${returnLocal.getFullYear()}-` +
+      `${String(returnLocal.getMonth() + 1).padStart(2, '0')}-` +
+      `${String(returnLocal.getDate()).padStart(2, '0')}`;
+
+    expect(await readDateISO(page, 'pickup-date')).toBe(targetISO);
+    expect(await readDateISO(page, 'return-date')).toBe(expectedReturnISO);
+  });
+
+  test('R1 sanity: popover permanece abierto al abrir sin seleccionar día', async ({ page }) => {
+    const trigger = page.locator(PICKUP_TRIGGER).first();
+    await trigger.click();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    await page.waitForTimeout(1000);
+
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    await expect(page.locator('[role="dialog"]')).toHaveCount(1);
+  });
+
+  test('R2 sanity: navegar mes no cierra popover', async ({ page }) => {
+    const trigger = page.locator(PICKUP_TRIGGER).first();
+    await trigger.click();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    const nextMonth = page.getByRole('button', { name: 'Mes siguiente' });
+    await nextMonth.click();
+    await nextMonth.click();
+
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    await expect(page.locator('[role="dialog"]')).toHaveCount(1);
+  });
+});
+
+test.describe('Searcher calendar autoclose - mobile', () => {
+  test.use({ viewport: { width: 375, height: 812 } });
+
+  test('SCEN-004: inputs móviles type=date visibles, desktop ocultos', async ({ page }) => {
+    await page.goto('/armenia');
+    await page.waitForLoadState('networkidle');
+
+    const mobilePickup = page.locator('#pickup-date-mobile').last();
+    const mobileReturn = page.locator('#return-date-mobile').last();
+
+    await expect(mobilePickup).toBeVisible();
+    await expect(mobilePickup).toHaveAttribute('type', 'date');
+    await expect(mobileReturn).toBeVisible();
+    await expect(mobileReturn).toHaveAttribute('type', 'date');
+
+    // Desktop variant is hidden via `hidden sm:block` parent at this viewport
+    const desktopPickup = page.locator('#pickup-date').first();
+    await expect(desktopPickup).toBeHidden();
+  });
+});

--- a/packages/ui-alquicarros/app/components/Searcher.vue
+++ b/packages/ui-alquicarros/app/components/Searcher.vue
@@ -155,6 +155,7 @@
                                     :year-controls="false"
                                     :prev-month="{ color: 'gray', variant: 'soft' }"
                                     :next-month="{ color: 'gray', variant: 'soft' }"
+                                    @update:model-value="pickupDateCalendarOpen = false"
                                 />
                             </template>
                         </u-popover>
@@ -220,6 +221,7 @@
                                     :year-controls="false"
                                     :prev-month="{ color: 'gray', variant: 'soft' }"
                                     :next-month="{ color: 'gray', variant: 'soft' }"
+                                    @update:model-value="returnDateCalendarOpen = false"
                                 />
                             </template>
                         </u-popover>

--- a/packages/ui-alquilame/app/components/Searcher.vue
+++ b/packages/ui-alquilame/app/components/Searcher.vue
@@ -155,6 +155,7 @@
                                     :year-controls="false"
                                     :prev-month="{ color: 'gray', variant: 'soft' }"
                                     :next-month="{ color: 'gray', variant: 'soft' }"
+                                    @update:model-value="pickupDateCalendarOpen = false"
                                 />
                             </template>
                         </u-popover>
@@ -220,6 +221,7 @@
                                     :year-controls="false"
                                     :prev-month="{ color: 'gray', variant: 'soft' }"
                                     :next-month="{ color: 'gray', variant: 'soft' }"
+                                    @update:model-value="returnDateCalendarOpen = false"
                                 />
                             </template>
                         </u-popover>

--- a/packages/ui-alquilatucarro/app/components/Searcher.vue
+++ b/packages/ui-alquilatucarro/app/components/Searcher.vue
@@ -155,6 +155,7 @@
                                     :year-controls="false"
                                     :prev-month="{ color: 'gray', variant: 'soft' }"
                                     :next-month="{ color: 'gray', variant: 'soft' }"
+                                    @update:model-value="pickupDateCalendarOpen = false"
                                 />
                             </template>
                         </u-popover>
@@ -220,6 +221,7 @@
                                     :year-controls="false"
                                     :prev-month="{ color: 'gray', variant: 'soft' }"
                                     :next-month="{ color: 'gray', variant: 'soft' }"
+                                    @update:model-value="returnDateCalendarOpen = false"
                                 />
                             </template>
                         </u-popover>


### PR DESCRIPTION
## Summary

Fix UX: en `Searcher.vue` desktop el `<u-popover>` envolvente del `<u-calendar>` abría correctamente al click pero **no cerraba** cuando el usuario seleccionaba un día — sólo cerraba al click outside. Móvil (input `type=date` nativo) ya funcionaba.

**Fix:** agregar `@update:model-value="<state> = false"` al `<u-calendar>` interno, +2 líneas por archivo en las 3 marcas. Sin tocar store, composable, ni server.

## Spec, holdout, plan

- **Spec aprobado** (2 reviewer iterations): `docs/specs/2026-05-06-searcher-calendar-autoclose-design.md`
- **Holdout SDD** (commit antes del código): `docs/specs/2026-05-06-searcher-calendar-autoclose/scenarios/searcher-calendar-autoclose.scenarios.md`
- **Plan ejecución** (5 steps): `docs/specs/2026-05-06-searcher-calendar-autoclose/implementation/plan.md`
- **Step 0 spike**: `docs/specs/2026-05-06-searcher-calendar-autoclose/implementation/selectors.md` (DOM real de Reka UI calendar)

## Scenarios cubiertos (7)

| # | Scenario | Test name |
|---|---|---|
| SCEN-001 | Cierre popover recogida tras seleccionar día | desktop |
| SCEN-002 | Cierre popover devolución tras seleccionar día | desktop |
| SCEN-003 | Independencia entre popovers | desktop |
| SCEN-004 | Móvil intacto (DOM contract) | mobile 375×812 |
| SCEN-005 | Watcher +7 días preservado | desktop |
| R1 sanity | Popover permanece abierto sin interacción | desktop |
| R2 sanity | Navegar mes no cierra popover | desktop |

## Test plan

- [x] `BRAND=alquilatucarro pnpm playwright test searcher-calendar-autoclose --project=chromium` → 7/7 × 3 runs estable
- [x] `BRAND=alquilame pnpm playwright test searcher-calendar-autoclose --project=chromium` → 7/7 × 3 runs estable
- [x] `BRAND=alquicarros pnpm playwright test searcher-calendar-autoclose --project=chromium` → 7/7 × 3 runs estable
- [x] `BRAND=alquilatucarro pnpm playwright test searcher --project=chromium` → 9/9 (incluye no-regresión `searcher-mobile-label-click.spec.ts`)
- [x] `/agent-browser` dogfood: selección rápida ida/vuelta, reabrir con preselect, fresh mount — sin glitches
- [x] Console: cero errores. Network: cero failures.

**Total verificación:** 9 runs × 7 tests = 63 passed estables.

## Reviewers (4 paralelo)

| Reviewer | Resultado |
|---|---|
| Code | PASS, 4 Minor (no blockers) |
| Security | PASS, 0 findings |
| Edge cases | 0 Critical, 1 HIGH, 2 Medium |
| Performance | 0 Critical, 1 HIGH, 1 Medium |

**0 blockers** per definición (Critical-from-code/edge/perf OR High-from-security). Los HIGH son mejoras no regresiones — documentados como follow-ups.

## Follow-ups conocidos (no bloquean este PR)

- **Edge case HIGH:** si usuario abre popover devolución, NO selecciona, abre popover recogida y selecciona día → return queda abierto con la fecha auto +7 días. NO es regresión (mismo comportamiento pre-fix). Fix posible (cerrar ambos popovers en pickup) deviates del Option A elegido en brainstorming.
- **e2e Medium:** `:not([data-selected])` puede match 0 cells si today+1 cae el último día del mes (~1 día/mes flaky). Mitigación: navegar mes en test.
- **Performance Medium:** `waitForTimeout(1000)` en R1 sanity. Reemplazable por re-aserción inmediata.
- **R3 (bfcache widgets bloqueados tras retroceder desde `/reservado/{code}`):** tracked en #25, fuera de alcance de este PR.

## Out of scope (YAGNI / explícito)

- Refactor componente compartido `DatePickerField` entre marcas
- Encadenar apertura del popover de devolución tras seleccionar recogida
- Fix de bfcache (#25)
- Typo pre-existente `aria-label="Seleccione una día"`

## Branches afectadas

`fix/searcher-calendar-autoclose` → `main`. 6 commits: 4 docs + 1 spike + 1 fix code (+e2e). Code delta: +161 LOC. Total ΔLOC: +968 (mayoría docs/specs/plan).

## Closes / refs

Refs #25 (R3 bfcache, fuera de alcance — sigue abierto para trabajo futuro).