### PR TITLE
fix(tarifas): hide gamas without monthly pricing from /tarifas + teaser

### DIFF
--- a/packages/logic/src/composables/useTariffs.ts
+++ b/packages/logic/src/composables/useTariffs.ts
@@ -73,10 +73,15 @@ export function buildTariffs(categories: CategoryData[], todayDate?: string): Ta
     const pricing = findActivePricingForDay(cat.month_prices, today)
     if (!pricing) continue
 
-    if (!firstActivePricing) firstActivePricing = pricing
-
     const monthly1k = pricing['1k_kms']
     const monthly2k = pricing['2k_kms']
+
+    // Skip categories whose monthly pricing was cleared (no longer eligible
+    // for monthly rentals). Both plans must be zero — partial-zero is kept
+    // since the UI toggle still surfaces the available plan.
+    if (monthly1k <= 0 && monthly2k <= 0) continue
+
+    if (!firstActivePricing) firstActivePricing = pricing
     const code = String(cat.id)
 
     gamas.push({

--- a/packages/logic/tests/useTariffs.test.ts
+++ b/packages/logic/tests/useTariffs.test.ts
@@ -73,23 +73,23 @@ describe('buildTariffs', () => {
 
   it('reads kmExtra from category.extra_km_charge (E_C1)', () => {
     const cats = [
-      makeCategory('C', { extraKm: 700, prices: [{}] }),
-      makeCategory('GC', { extraKm: 900, prices: [{}] }),
-      makeCategory('GY', { extraKm: 1100, prices: [{}] }),
+      makeCategory('C', { extraKm: 700, prices: [{ '1k_kms': 1 }] }),
+      makeCategory('GC', { extraKm: 900, prices: [{ '1k_kms': 1 }] }),
+      makeCategory('GY', { extraKm: 1100, prices: [{ '1k_kms': 1 }] }),
     ]
     const byCode = Object.fromEntries(buildTariffs(cats, TODAY).gamas.map((g) => [g.code, g.kmExtra]))
     expect(byCode).toEqual({ C: 700, GC: 900, GY: 1100 })
   })
 
   it('returns kmExtra=null when extra_km_charge is 0 (unconfigured) (E_C3)', () => {
-    const cats = [makeCategory('XX', { extraKm: 0, prices: [{}] })]
+    const cats = [makeCategory('XX', { extraKm: 0, prices: [{ '1k_kms': 1 }] })]
     const result = buildTariffs(cats, TODAY)
     expect(result.gamas[0].kmExtra).toBeNull()
   })
 
   it('reflects DB changes without code change (E_C1 dynamic)', () => {
-    const before = buildTariffs([makeCategory('C', { extraKm: 700, prices: [{}] })], TODAY)
-    const after = buildTariffs([makeCategory('C', { extraKm: 850, prices: [{}] })], TODAY)
+    const before = buildTariffs([makeCategory('C', { extraKm: 700, prices: [{ '1k_kms': 1 }] })], TODAY)
+    const after = buildTariffs([makeCategory('C', { extraKm: 850, prices: [{ '1k_kms': 1 }] })], TODAY)
     expect(before.gamas[0].kmExtra).toBe(700)
     expect(after.gamas[0].kmExtra).toBe(850)
   })
@@ -138,6 +138,32 @@ describe('buildTariffs', () => {
       }),
     ]
     const result = buildTariffs(cats, TODAY)
+    expect(result.gamas.map((g) => g.code)).toEqual(['C'])
+  })
+
+  it('skips categories whose active pricing has both plans at zero (FL/FU/GL/LU case)', () => {
+    const cats = [
+      makeCategory('C',  { prices: [{ '1k_kms': 3806000, '2k_kms': 4252000 }] }),
+      makeCategory('FL', { prices: [{ '1k_kms': 0,       '2k_kms': 0       }] }),
+      makeCategory('FU', { prices: [{ '1k_kms': 0,       '2k_kms': 0       }] }),
+    ]
+    const result = buildTariffs(cats, TODAY)
+    expect(result.gamas.map((g) => g.code)).toEqual(['C'])
+  })
+
+  it('keeps categories with only one plan priced (partial-zero)', () => {
+    const cats = [makeCategory('X', { prices: [{ '1k_kms': 3000000, '2k_kms': 0 }] })]
+    const result = buildTariffs(cats, TODAY)
+    expect(result.gamas.map((g) => g.code)).toEqual(['X'])
+  })
+
+  it('derives period from the first non-skipped gama, not from a zero-priced one', () => {
+    const cats = [
+      makeCategory('FL', { prices: [{ init_date: '2026-04-01', end_date: '2026-12-31', '1k_kms': 0, '2k_kms': 0 }] }),
+      makeCategory('C',  { prices: [{ init_date: '2026-05-01', end_date: '2026-05-31', '1k_kms': 3806000, '2k_kms': 4252000 }] }),
+    ]
+    const result = buildTariffs(cats, TODAY)
+    expect(result.period?.label).toBe('1 May – 31 May 2026')
     expect(result.gamas.map((g) => g.code)).toEqual(['C'])
   })
 


### PR DESCRIPTION
## Summary

- `useTariffs.buildTariffs` now skips categories whose active `category_pricing` row has `monthly_1k_price <= 0` AND `monthly_2k_price <= 0` (partial-zero kept — the UI toggle still surfaces the available plan).
- Fixes two visible defects produced by the categories FL, FU, GL, LU after their monthly pricing was cleared in Supabase:
  - **`/tarifas`** showed 4 rows with `$ 0 / $ 0`.
  - **`MonthlyRatesTeaser`** (home) rendered *"Arriendos mensuales desde **$0/día**"* because `Math.min(plan1k.daily)` included zero rows.
- Aligns with the existing `useStoreSearchData.monthlyCategoryExclusion` pattern (`SCEN-A excludes FU, FL, GL, LU from monthly availability`) — same business rule, now extended to the rates view.

## What changed

| File | Change |
|---|---|
| `packages/logic/src/composables/useTariffs.ts` | Add 1 guard in `buildTariffs` loop; reorder `firstActivePricing` assignment so the period label derives from a kept gama. |
| `packages/logic/tests/useTariffs.test.ts` | +3 SDD tests (skip both-zero, keep partial-zero, period from non-skipped gama). 3 pre-existing `kmExtra` tests had fixtures updated from `prices: [{}]` to `prices: [{ '1k_kms': 1 }]` so they satisfy the new active-pricing precondition; assertions unchanged. |

## Blast radius

- Affects only `ui-alquilatucarro` (the only brand consuming `useTariffs` via `pages/tarifas.vue` and `components/MonthlyRatesTeaser.vue`).
- `/api/rentacar-data`, transformers, `pickPriceForDate`, daily-rate flows: untouched. The 4 categories remain available for daily rentals; the filter is scoped to the monthly rates view.
- If pricing for FL/FU/GL/LU is loaded back into Supabase, the gamas reappear automatically without code change.

## Verification (today, 2026-05-08)

| Check | Evidence |
|---|---|
| Unit tests | `pnpm --filter @rentacar-main/logic exec vitest run useTariffs` → **16 passed** |
| Full logic suite | `pnpm --filter @rentacar-main/logic exec vitest run` → **204 passed** (33 files), 0 failed |
| `/tarifas` plan 1k (agent-browser) | 8 rows: C, CX, F, FX, G4, GC, GY, LE — no `$ 0` |
| `/tarifas` plan 2k toggle | 8 rows with valid 2k prices (e.g. C $4.252.000, GY $16.836.000) |
| Period label | `1 May – 31 May 2026` |
| `MonthlyRatesTeaser` (home) | `$126.867/día` (gama C minimum) — was `$0/día` |
| Console / network | 0 errors, 0 4xx/5xx |

## Test plan

- [ ] Run `pnpm --filter @rentacar-main/logic test` → 204 passed.
- [ ] Open `/tarifas` on alquilatucarro preview → confirm 8 rows, no `$ 0`, period reads `1 May – 31 May 2026`.
- [ ] Toggle to "2.000 kms" → confirm same 8 gamas, no `$ 0`.
- [ ] Open `/` → `MonthlyRatesTeaser` reads `Arriendos mensuales desde $126.867/día`.
- [ ] When admin re-loads pricing for any of FL/FU/GL/LU in Supabase, that gama reappears in `/tarifas` without redeploy.