### PR TITLE
refactor(city-page): move WhatsApp copy trigger from clipboard icon to LocationIcon pin

### DIFF
--- a/packages/ui-alquicarros/app/components/CityPage.vue
+++ b/packages/ui-alquicarros/app/components/CityPage.vue
@@ -25,7 +25,15 @@
           <span class="flex flex-row justify-center items-baseline gap-2 text-4xl md:text-5xl lg:text-7xl lg:whitespace-nowrap" style="letter-spacing: -0.025em;">
             <span class="size-8 md:size-10 lg:size-14" aria-hidden="true"></span>
             {{ city?.name }}
-            <LocationIcon cls="text-red-600 size-8 md:size-10 lg:size-14 translate-y-1" />
+            <button
+              type="button"
+              class="cursor-pointer rounded transition-transform hover:scale-110 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+              aria-label="Copiar datos de búsqueda para WhatsApp"
+              title="Copiar datos de búsqueda para WhatsApp"
+              @click="copySearchToWhatsapp"
+            >
+              <LocationIcon cls="text-red-600 size-8 md:size-10 lg:size-14 translate-y-1" />
+            </button>
           </span>
           {{ ' ' }}
           <span class="block text-2xl md:text-3xl lg:text-4xl text-white colombia-sweep" style="letter-spacing: 0.025em;">Colombia</span>
@@ -37,20 +45,9 @@
           <div class="mb-1 text-white text-xl">
             Consulta disponibilidad y precios
           </div>
-          <div class="flex items-center justify-center gap-2">
-            <p class="text-white text-sm">
-              Elige ciudades, fechas y horarios y renta un vehículo por días, semanas o el tiempo que necesites
-            </p>
-            <UButton
-              icon="i-heroicons-clipboard-document"
-              size="xs"
-              color="neutral"
-              variant="ghost"
-              class="text-white shrink-0"
-              aria-label="Copiar datos de búsqueda para WhatsApp"
-              @click="copySearchToWhatsapp"
-            />
-          </div>
+          <p class="text-white text-sm">
+            Elige ciudades, fechas y horarios y renta un vehículo por días, semanas o el tiempo que necesites
+          </p>
         </div>
       </template>
       <template #default>
@@ -60,20 +57,9 @@
             <div class="mb-1 text-white text-xl">
               Consulta disponibilidad y precios
             </div>
-            <div class="flex items-center justify-center gap-2">
-              <p class="text-white text-sm">
-                Elige ciudades, fechas y horarios y renta un vehículo por días, semanas o el tiempo que necesites
-              </p>
-              <UButton
-                icon="i-heroicons-clipboard-document"
-                size="xs"
-                color="neutral"
-                variant="ghost"
-                class="text-white shrink-0"
-                aria-label="Copiar datos de búsqueda para WhatsApp"
-                @click="copySearchToWhatsapp"
-              />
-            </div>
+            <p class="text-white text-sm">
+              Elige ciudades, fechas y horarios y renta un vehículo por días, semanas o el tiempo que necesites
+            </p>
           </div>
           <!-- Wrapper con altura fija para prevenir layout shift durante hidratación -->
           <div class="h-[410px] w-full">

--- a/packages/ui-alquicarros/app/components/__tests__/CityPage.test.ts
+++ b/packages/ui-alquicarros/app/components/__tests__/CityPage.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const source = readFileSync(
+  fileURLToPath(new URL('../CityPage.vue', import.meta.url)),
+  'utf8',
+)
+
+describe('CityPage — copy-to-WhatsApp trigger lives on the LocationIcon (pin)', () => {
+  it('does not render the legacy clipboard UButton', () => {
+    expect(source).not.toMatch(/i-heroicons-clipboard-document/)
+  })
+
+  it('wraps the LocationIcon in a <button> bound to copySearchToWhatsapp', () => {
+    const pattern = /<button\b[^>]*@click="copySearchToWhatsapp"[^>]*>[\s\S]*?<LocationIcon\b[\s\S]*?\/>[\s\S]*?<\/button>/
+    expect(source).toMatch(pattern)
+  })
+
+  it('exposes the pin button to assistive tech with a Spanish aria-label', () => {
+    expect(source).toMatch(/<button\b[^>]*aria-label="Copiar datos de búsqueda para WhatsApp"/)
+  })
+
+  it('keeps the useShareSearchParams binding so the handler is still wired', () => {
+    expect(source).toMatch(/copyToWhatsapp:\s*copySearchToWhatsapp\s*\}\s*=\s*useShareSearchParams\(\)/)
+  })
+})

--- a/packages/ui-alquilame/app/components/CityPage.vue
+++ b/packages/ui-alquilame/app/components/CityPage.vue
@@ -25,7 +25,15 @@
           <span class="flex flex-row justify-center items-baseline gap-2 text-4xl md:text-5xl lg:text-7xl lg:whitespace-nowrap" style="letter-spacing: -0.025em;">
             <span class="size-8 md:size-10 lg:size-14" aria-hidden="true"></span>
             {{ city?.name }}
-            <LocationIcon cls="text-red-600 size-8 md:size-10 lg:size-14 translate-y-1" />
+            <button
+              type="button"
+              class="cursor-pointer rounded transition-transform hover:scale-110 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+              aria-label="Copiar datos de búsqueda para WhatsApp"
+              title="Copiar datos de búsqueda para WhatsApp"
+              @click="copySearchToWhatsapp"
+            >
+              <LocationIcon cls="text-red-600 size-8 md:size-10 lg:size-14 translate-y-1" />
+            </button>
           </span>
           {{ ' ' }}
           <span class="block text-2xl md:text-3xl lg:text-4xl text-white colombia-sweep" style="letter-spacing: 0.025em;">Colombia</span>
@@ -37,20 +45,9 @@
           <div class="mb-1 text-white text-xl">
             Consulta disponibilidad y precios
           </div>
-          <div class="flex items-center justify-center gap-2">
-            <p class="text-white text-sm">
-              Elige ciudades, fechas y horarios y renta un vehículo por días, semanas o el tiempo que necesites
-            </p>
-            <UButton
-              icon="i-heroicons-clipboard-document"
-              size="xs"
-              color="neutral"
-              variant="ghost"
-              class="text-white shrink-0"
-              aria-label="Copiar datos de búsqueda para WhatsApp"
-              @click="copySearchToWhatsapp"
-            />
-          </div>
+          <p class="text-white text-sm">
+            Elige ciudades, fechas y horarios y renta un vehículo por días, semanas o el tiempo que necesites
+          </p>
         </div>
       </template>
       <template #default>
@@ -60,20 +57,9 @@
             <div class="mb-1 text-white text-xl">
               Consulta disponibilidad y precios
             </div>
-            <div class="flex items-center justify-center gap-2">
-              <p class="text-white text-sm">
-                Elige ciudades, fechas y horarios y renta un vehículo por días, semanas o el tiempo que necesites
-              </p>
-              <UButton
-                icon="i-heroicons-clipboard-document"
-                size="xs"
-                color="neutral"
-                variant="ghost"
-                class="text-white shrink-0"
-                aria-label="Copiar datos de búsqueda para WhatsApp"
-                @click="copySearchToWhatsapp"
-              />
-            </div>
+            <p class="text-white text-sm">
+              Elige ciudades, fechas y horarios y renta un vehículo por días, semanas o el tiempo que necesites
+            </p>
           </div>
           <!-- Wrapper con altura fija para prevenir layout shift durante hidratación -->
           <div class="h-[410px] w-full">

--- a/packages/ui-alquilame/app/components/__tests__/CityPage.test.ts
+++ b/packages/ui-alquilame/app/components/__tests__/CityPage.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const source = readFileSync(
+  fileURLToPath(new URL('../CityPage.vue', import.meta.url)),
+  'utf8',
+)
+
+describe('CityPage — copy-to-WhatsApp trigger lives on the LocationIcon (pin)', () => {
+  it('does not render the legacy clipboard UButton', () => {
+    expect(source).not.toMatch(/i-heroicons-clipboard-document/)
+  })
+
+  it('wraps the LocationIcon in a <button> bound to copySearchToWhatsapp', () => {
+    const pattern = /<button\b[^>]*@click="copySearchToWhatsapp"[^>]*>[\s\S]*?<LocationIcon\b[\s\S]*?\/>[\s\S]*?<\/button>/
+    expect(source).toMatch(pattern)
+  })
+
+  it('exposes the pin button to assistive tech with a Spanish aria-label', () => {
+    expect(source).toMatch(/<button\b[^>]*aria-label="Copiar datos de búsqueda para WhatsApp"/)
+  })
+
+  it('keeps the useShareSearchParams binding so the handler is still wired', () => {
+    expect(source).toMatch(/copyToWhatsapp:\s*copySearchToWhatsapp\s*\}\s*=\s*useShareSearchParams\(\)/)
+  })
+})

--- a/packages/ui-alquilatucarro/app/components/CityPage.vue
+++ b/packages/ui-alquilatucarro/app/components/CityPage.vue
@@ -23,7 +23,15 @@
           <span class="flex flex-row justify-center items-baseline gap-2 text-4xl md:text-5xl lg:text-7xl lg:whitespace-nowrap" style="letter-spacing: -0.025em;">
             <span class="size-8 md:size-10 lg:size-14" aria-hidden="true"></span>
             {{ city?.name }}
-            <LocationIcon cls="text-red-600 size-8 md:size-10 lg:size-14 translate-y-1" />
+            <button
+              type="button"
+              class="cursor-pointer rounded transition-transform hover:scale-110 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+              aria-label="Copiar datos de búsqueda para WhatsApp"
+              title="Copiar datos de búsqueda para WhatsApp"
+              @click="copySearchToWhatsapp"
+            >
+              <LocationIcon cls="text-red-600 size-8 md:size-10 lg:size-14 translate-y-1" />
+            </button>
           </span>
           {{ ' ' }}
           <span class="block text-2xl md:text-3xl lg:text-4xl text-white colombia-sweep" style="letter-spacing: 0.025em;">Colombia</span>
@@ -35,20 +43,9 @@
           <div class="mb-1 text-white text-xl">
             Consulta disponibilidad y precios
           </div>
-          <div class="flex items-center justify-center gap-2">
-            <p class="text-white text-sm">
-              Elige ciudades, fechas y horarios y renta un vehículo por días, semanas o el tiempo que necesites
-            </p>
-            <UButton
-              icon="i-heroicons-clipboard-document"
-              size="xs"
-              color="neutral"
-              variant="ghost"
-              class="text-white shrink-0"
-              aria-label="Copiar datos de búsqueda para WhatsApp"
-              @click="copySearchToWhatsapp"
-            />
-          </div>
+          <p class="text-white text-sm">
+            Elige ciudades, fechas y horarios y renta un vehículo por días, semanas o el tiempo que necesites
+          </p>
         </div>
       </template>
       <template #default>
@@ -58,20 +55,9 @@
             <div class="mb-1 text-white text-xl">
               Consulta disponibilidad y precios
             </div>
-            <div class="flex items-center justify-center gap-2">
-              <p class="text-white text-sm">
-                Elige ciudades, fechas y horarios y renta un vehículo por días, semanas o el tiempo que necesites
-              </p>
-              <UButton
-                icon="i-heroicons-clipboard-document"
-                size="xs"
-                color="neutral"
-                variant="ghost"
-                class="text-white shrink-0"
-                aria-label="Copiar datos de búsqueda para WhatsApp"
-                @click="copySearchToWhatsapp"
-              />
-            </div>
+            <p class="text-white text-sm">
+              Elige ciudades, fechas y horarios y renta un vehículo por días, semanas o el tiempo que necesites
+            </p>
           </div>
           <!-- Wrapper con altura fija para prevenir layout shift durante hidratación -->
           <div class="h-[410px] w-full">

--- a/packages/ui-alquilatucarro/app/components/__tests__/CityPage.test.ts
+++ b/packages/ui-alquilatucarro/app/components/__tests__/CityPage.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const source = readFileSync(
+  fileURLToPath(new URL('../CityPage.vue', import.meta.url)),
+  'utf8',
+)
+
+describe('CityPage — copy-to-WhatsApp trigger lives on the LocationIcon (pin)', () => {
+  it('does not render the legacy clipboard UButton', () => {
+    expect(source).not.toMatch(/i-heroicons-clipboard-document/)
+  })
+
+  it('wraps the LocationIcon in a <button> bound to copySearchToWhatsapp', () => {
+    const pattern = /<button\b[^>]*@click="copySearchToWhatsapp"[^>]*>[\s\S]*?<LocationIcon\b[\s\S]*?\/>[\s\S]*?<\/button>/
+    expect(source).toMatch(pattern)
+  })
+
+  it('exposes the pin button to assistive tech with a Spanish aria-label', () => {
+    expect(source).toMatch(/<button\b[^>]*aria-label="Copiar datos de búsqueda para WhatsApp"/)
+  })
+
+  it('keeps the useShareSearchParams binding so the handler is still wired', () => {
+    expect(source).toMatch(/copyToWhatsapp:\s*copySearchToWhatsapp\s*\}\s*=\s*useShareSearchParams\(\)/)
+  })
+})


### PR DESCRIPTION
## Summary

Relocates the **"copy search params for WhatsApp"** trigger from a dedicated clipboard `UButton` to the existing `LocationIcon` (pin) that sits next to each city name in the hero. The handler (`copySearchToWhatsapp` from `useShareSearchParams`) is unchanged — only its trigger element moves. Applied across all three franchise UI packages.

## What changed

- `LocationIcon` is now wrapped in a `<button @click="copySearchToWhatsapp">` with Spanish `aria-label` + `title`, pointer cursor, hover scale, and visible focus ring.
- The two clipboard `UButton` instances (mobile + desktop variants) per file are gone, along with the `flex items-center justify-center gap-2` wrapper that no longer adds value.
- New `CityPage.test.ts` per package locks the binding (negative + positive source-shape assertions, matching the existing `Searcher.test.ts` convention).

Files: `packages/ui-{alquicarros,alquilame,alquilatucarro}/app/components/CityPage.vue` (+ sibling `__tests__/CityPage.test.ts`).

## Verification evidence

- **Vitest**: logic 135/135 · ui-alquicarros 34/34 · ui-alquilame 34/34 · ui-alquilatucarro 153/153 — green across the board, including the new tests.
- **Runtime browser check** (`/agent-browser` on `http://localhost:4001/bogota`):
  - Pin renders as `button "Copiar datos de búsqueda para WhatsApp"` in the accessibility tree.
  - Click → `navigator.clipboard.writeText` called with the expected WhatsApp message:
    ```
    *Consulta de alquiler de carro*

    📍 Lugar: Bogotá Aeropuerto
    📅 Recogida: 10 de mayo de 2026, 12:00 p. m.
    📅 Devolución: 17 de mayo de 2026, 12:00 p. m.
    🗓 7 días
    ```
  - Toast displays "Datos copiados / Pégalos en WhatsApp para compartir tu búsqueda".
  - Console: only pre-existing `@nuxt/image` screen-size warnings, no errors. Network: no 4xx/5xx.

## Quality-gate findings (4-agent parallel review)

### Important — to address before merge or in follow-up

**WCAG 2.5.3 "Label in Name" regression on the hero `<h1>`.** The pin button now lives inside `UPageHero`'s `#title` slot (which renders as `<h1>`). The accessible-name algorithm walks the subtree, so screen readers announce the heading as `"ALQUILER DE CARROS EN BOGOTÁ Copiar datos de búsqueda para WhatsApp COLOMBIA"` — the action label leaks into the heading.

Recommended follow-up: render the pin button as a sibling of `UPageHero` (or absolute-positioned overlay) so the heading's accessible name reverts to just the city.

### Product call

**Discoverability**: a clipboard icon advertises "click to copy" universally; a location pin doesn't. Mobile loses the hover affordance entirely. Worth measuring share-rate before/after; a one-time tooltip/coach-mark may be warranted.

### Pre-existing concerns surfaced (not caused by this PR — separate ticket)

- `useShareSearchParams` calls `useStoreReservationForm()` and `useToast()` at composable setup, which runs during SSR. The same file's author already deferred `useStoreSearchData()` to `onMounted` to avoid the SSR Pinia error. Risk is unchanged by this PR (the composable was already invoked at setup with the old clipboard button), but worth tracking.
- Pin click before the reservation store hydrates produces an empty WhatsApp message + a green "Datos copiados" toast (`buildWhatsappMessage` filters out falsy fields with no minimum-content guard). Same exposure window existed with the old clipboard button.

### Clean
- Security: no findings (static strings, no new data flow, no new attack surface).
- Performance: no findings (pure markup swap, one-time render).

## Test plan

- [x] Verify the pin in `/bogota` (and at least one other city) on desktop: hover scale, focus ring on Tab, click → toast + clipboard.
- [x] Verify on mobile viewport (no hover, ensure tap area is comfortable).
- [x] Smoke-test the same on `ui-alquilame` and `ui-alquilatucarro` builds.
- [x] Confirm the WhatsApp message format remains correct after a real search (with both pickup and return locations selected).

