### PR TITLE
fix(reservations): keep availability-searcher toasts inside the mobile viewport (#50)

### DIFF
--- a/.amend-evidence/scen004-centering-evidence.json
+++ b/.amend-evidence/scen004-centering-evidence.json
@@ -1,0 +1,11 @@
+{
+  "scenario": "SCEN-004",
+  "defect": "Oracle reference-frame error: asserts toast center == window.innerWidth/2 ±1px, ignoring the scrollbar gutter that offsets every correctly-centered position:fixed element (including the original @nuxt/ui design) by gutter/2.",
+  "post_fix_measurements_1024px": {
+    "classic_scrollbar": { "gutter": 15, "toast_w": 384, "centerX": 504.5, "offBy_vs_window": -7.5, "offBy_vs_layoutViewport": 0.0 },
+    "no_gutter_overlay_or_mobile_equivalent": { "gutter": 0, "toast_w": 384, "centerX": 512, "offBy_vs_window": 0.0, "offBy_vs_layoutViewport": 0.0 }
+  },
+  "independent_reverification": "Per user request, re-verified in the gutter-free condition (window.innerWidth === documentElement.clientWidth, equivalent to overlay scrollbars / real mobile). Result: toast width exactly 384px (no regression) and center exactly window.innerWidth/2 (offBy 0.0px). Proves the code is correct and the -7.5px deviation under classic scrollbars is purely the gutter/2 reference-frame artifact.",
+  "correct_invariant": "Center within documentElement.clientWidth (layout viewport) — the frame the page content and @nuxt/ui's own centering use; equals window.innerWidth/2 whenever the gutter is 0.",
+  "captured_via": "agent-browser eval --stdin, alquilatucarro searcher toast, http://localhost:3002, viewport 1024x768, with/without document.documentElement.style.overflowY='hidden'"
+}

--- a/docs/specs/2026-05-15-issue-50-mobile-toast-overflow-design.md
+++ b/docs/specs/2026-05-15-issue-50-mobile-toast-overflow-design.md
@@ -1,0 +1,124 @@
+# Issue #50 — Toast overflows mobile viewport in availability searcher
+
+- **Issue:** https://github.com/amaw-sas/rentacar-web/issues/50
+- **Date:** 2026-05-15
+- **Branch:** `fix/issue-50-mobile-toast-overflow`
+- **Type:** bug fix (UI / shared config)
+- **Scope:** all 3 brands via shared `uiConfig` (single fix point)
+
+## Problem
+
+At viewport ≤480px, triggering the "está por fuera de la sede seleccionada"
+validation toast in the availability searcher renders the toast clipped at the
+top-left corner and partially off-screen. The title and most of the description
+are unreadable; there is no lateral padding and the toast does not respect the
+viewport width.
+
+Reported on alquilatucarro at ~427px. Reproduction:
+
+1. Open the alquilatucarro home at viewport ≤480px.
+2. In *Consulta disponibilidad y precios*, pick `Lugar de recogida` and
+   `Lugar de devolución` that trigger the sede validation.
+3. Press **BUSCAR VEHÍCULOS**.
+4. Observe the toast clipped in the top-left corner.
+
+## Affected surface
+
+- `packages/logic/src/composables/useMessages.ts` — `useToast().add(...)` with a
+  per-call `ui.root` override (`bg-white text-gray-900`).
+- `packages/ui-{brand}/app/app.vue:10` — identical in all 3 brands:
+  `const toaster = { expand: true, position: "top-center", duration: 10000 }`.
+- `packages/logic/src/config/ui.config.ts` — shared `uiConfig`, consumed by every
+  brand's `app.config.ts` as `ui: uiConfig`. **No `toast`/`toaster` override
+  exists today.**
+
+## Root cause (hypothesis — confirmed at runtime before fix is finalized)
+
+@nuxt/ui 4.2.1's default `toaster` theme already constrains the viewport
+correctly:
+
+```
+viewport (base):        fixed flex flex-col w-[calc(100%-2rem)] sm:w-96 z-[100] ...
+viewport (top-center):  left-1/2 transform -translate-x-1/2
+compound (top-*):       viewport: top-4
+```
+
+`@import "@nuxt/ui";` is present in every brand's `main.css`, so Tailwind v4
+scans the package source and these utilities are generated. Therefore the
+default *should* render correctly — which means **something in this project
+defeats it**. Candidate causes, to be discriminated by runtime inspection:
+
+- A CSS specificity / `transform` conflict (note the inline critical CSS in
+  `app.vue` and `transform-(--transform)` on the toast `base` slot).
+- A `tailwind-merge` collision introduced by the per-call `ui.root` override in
+  `useMessages`.
+- The `expand: true` interaction with viewport sizing.
+
+**Gate:** the exact cause is pinned via `/agent-browser` reproduction at 427px,
+inspecting the computed style of the `[data-slot="viewport"]` toaster element
+and the toast `[data-slot="root"]`. No code change is committed before this
+runtime evidence exists (per `/systematic-debugging`).
+
+## Fix approach
+
+Add a `toaster` entry to the shared `uiConfig` in
+`packages/logic/src/config/ui.config.ts` that hard-constrains the viewport
+independent of the default theme:
+
+- Mobile (`<sm`): full available width minus lateral inset —
+  `max-w-[calc(100vw-2rem)]`, never exceeding the viewport.
+- Desktop (`≥sm`): preserve the default `~24rem` (`sm:w-96`) width and the
+  `top-center` placement.
+
+The override is **additive** — it only adds a `toaster` key to `uiConfig`; no
+existing key is modified. The exact class string is finalized against the
+runtime-inspected element so it composes correctly with the @nuxt/ui default
+theme via `tailwind-merge` (verified, not assumed).
+
+This is defensive by design: the constraint holds even if the default theme is
+being overridden or defeated elsewhere, and it is the single point that
+propagates to all 3 brands through `app.config.ts`.
+
+## Blast radius
+
+- **Modified:** `packages/logic/src/config/ui.config.ts` — one file, one new
+  additive `toaster` key.
+- **Consumers:** `app.config.ts` of alquilatucarro / alquilame / alquicarros
+  (`ui: uiConfig`) → applies globally to the @nuxt/ui Toaster. No other
+  `uiConfig` behavior changes.
+- **Untouched:** `useMessages.ts`, server routes, per-brand `app.vue`, types,
+  public API, docs.
+
+## Out of scope
+
+- No change to toast content, copy, duration, position semantics, or the
+  `useMessages` API.
+- No redesign of the availability searcher validation flow.
+- No general refactor of `uiConfig` or unrelated @nuxt/ui slots.
+
+## Observable scenarios (SDD holdout)
+
+1. **Given** the alquilatucarro home at 414px width, **when** the "fuera de la
+   sede seleccionada" validation toast fires, **then** the toast box is fully
+   within the viewport (left edge ≥ 0, right edge ≤ viewport width) with ≥16px
+   lateral inset and **no horizontal scrollbar** appears.
+2. **Given** that toast is shown, **when** it renders, **then** both the title
+   and the full description text are visible (not clipped on any edge).
+3. **Given** a desktop viewport ≥640px, **when** a toast fires, **then** it
+   keeps the ~24rem width centered at top — **no regression** vs. current
+   desktop behaviour.
+4. **Given** alquilame and alquicarros at 414px, **when** an equivalent
+   validation toast fires, **then** scenarios 1–2 hold for those brands too
+   (shared fix verified per brand, not assumed).
+
+## Verification strategy
+
+- **Runtime (primary):** `/agent-browser` on alquilatucarro at 414px — trigger
+  the sede validation, assert toast bounding box within viewport, no horizontal
+  overflow, title + description readable; zero console errors / failed requests.
+  Repeat smoke for alquilame and alquicarros.
+- **Regression:** desktop ≥640px screenshot/box check — width and centering
+  unchanged.
+- **Static:** `pnpm typecheck` delta vs. baseline (baseline is red ~1531 errors;
+  acceptance = no *new* errors introduced by this change).
+- **/dogfood** exploratory pass on the searcher after the fix.

--- a/docs/specs/2026-05-15-issue-50-mobile-toast-overflow-design.md
+++ b/docs/specs/2026-05-15-issue-50-mobile-toast-overflow-design.md
@@ -86,7 +86,12 @@ Discriminating observations → cause:
 
 The investigation MUST conclude with exactly one identified cause (C1–C4)
 recorded in the SDD evidence before implementation. If evidence is ambiguous
-between two causes, apply both remedies (they are non-conflicting).
+between two causes, apply both remedies **only when they are non-conflicting**
+(R1+R2, R2+R4, R3 with any of R1/R2/R4 are non-conflicting). **R1 and R4 are
+mutually exclusive** — they prescribe opposite centering mechanisms on the same
+`viewport` slot (transform vs. inset/mx-auto) and MUST NOT be applied together;
+if evidence is ambiguous between C1 and C4, prefer R4 (transform-free is the
+strictly safer superset for both).
 
 ## Remedy table (fix is derived from the identified cause)
 
@@ -110,10 +115,13 @@ All remedies keep the single-shared-point principle where the cause allows.
   `packages/logic/src/composables/useMessages.ts`** — this spec is revised and
   re-reviewed before that broader change.
 - **R4 — isolate the transform.** In shared `uiConfig`, set the `toaster`
-  `slots.viewport` centering without relying on `transform` (e.g.
-  `inset-x-0 mx-auto` + `max-w` instead of `left-1/2 -translate-x-1/2`), so the
-  viewport transform cannot interact with the toast `base` `--transform`. Blast
-  radius: `ui.config.ts` only.
+  `slots.viewport` centering without relying on `transform`: override the
+  default **`w-*` group** directly (`w-[calc(100%-2rem)] sm:w-96`, same group as
+  the default so it actually takes effect per the tailwind-merge note below) and
+  center with `inset-x-0 mx-auto` instead of `left-1/2 -translate-x-1/2`, so the
+  viewport transform cannot interact with the toast `base` `--transform`.
+  `mx-auto` centers only because the box is now `w-*`-bounded. Blast radius:
+  `ui.config.ts` only.
 
 `tailwind-merge` note: `max-w-*` and `w-*`/`sm:w-*` are **different property
 groups** — a `max-w` addition does NOT override the default `w-96`. Therefore
@@ -153,9 +161,12 @@ not screenshot eyeballing.
    window.innerWidth` (no horizontal scrollbar), AND the toast left/right insets
    are each ≥ 16px.
 2. **Given** that toast is shown, **when** it renders, **then** the toast root
-   has `scrollWidth <= clientWidth` (no clipped/overflowing content) AND the
-   description element's bounding rect is fully contained within the toast root's
-   bounding rect (title + full description not clipped on any edge).
+   has `scrollWidth <= clientWidth` AND `scrollHeight <= clientHeight` (no
+   horizontally **or vertically** clipped content under `overflow-hidden`) AND
+   the description element's bounding rect is fully contained within the toast
+   root's bounding rect (title + full description not clipped on any edge). Note:
+   this is the anti-clipping oracle for both axes; the `scrollHeight` clause is
+   what catches vertical truncation that a rect-containment check alone misses.
 3. **Boundary — Given** alquilatucarro home at **479px** and again at **481px**,
    **when** the toast fires, **then** scenario 1's assertions hold at both
    widths (discriminates a breakpoint bug from a content-overflow bug; both are

--- a/docs/specs/2026-05-15-issue-50-mobile-toast-overflow-design.md
+++ b/docs/specs/2026-05-15-issue-50-mobile-toast-overflow-design.md
@@ -196,3 +196,51 @@ not screenshot eyeballing.
 - **/dogfood** exploratory pass on the searcher after the fix.
 - **Gate:** `/verification-before-completion` with fresh evidence before any
   completion claim, commit of the fix, or PR.
+
+## Implementation outcome — addendum (2026-05-15)
+
+**Identified cause:** **C4** — confirmed at runtime. @nuxt/ui 4.2.1's default
+`top-center` position variant emits `left-1/2 transform -translate-x-1/2`.
+Under this project's Tailwind v4, `-translate-x-1/2` emits the standalone
+`translate` property *and* the legacy `transform` class also applies
+`translateX(-50%)`; the −50% shift is applied twice. Measured at 414px:
+viewport `left:199.5px`, `translate:-50%`, `transform:matrix(…-183.5…)` →
+`rect.left = −167px` (≈ `199.5 − 2×183.5`), toast clipped top-left. Selected
+remedy: **R4** (R1⊕R4 → R4).
+
+**Mechanism divergence from R4-as-specified (and why):** R4 as written
+("override the position variant in shared `uiConfig`") was proven
+**unimplementable** by three runtime attempts: base-slot override, then
+`variants.position` override, then both. @nuxt/ui 4.2.1 flattens the
+app.config `ui.toaster` override into the base-slot class region *before*
+tailwind-variants emits the library's default position variant, so
+tailwind-merge always keeps the broken `left-1/2 transform
+-translate-x-1/2` (DOM-verified: override classes present but defeated;
+Tailwind important modifiers would not survive the twMerge dedupe either).
+
+**Shipped remedy — R4-CSS (same principle, different mechanism):** a scoped
+CSS rule shipped once by the shared `@rentacar-main/logic` layer
+(`packages/logic/src/assets/issue-50-toaster.css`, wired via the layer's
+`nuxt.config.ts` `css[]`), inherited by all 3 brands through `extends`. It
+neutralises `transform`/`translate` and re-centers via `inset-inline` +
+`margin-inline`, scoped by the `left-1/2` **and** `-translate-x-1/2` class
+tokens (`~=`) so only the broken centered variants match. This **preserves
+the design's invariants**: single shared point (the logic layer, not 3
+per-brand files), additive-only, no change to `useMessages.ts`, server
+routes, or per-brand `app.vue`; the observable scenario contract is
+unchanged. Blast-radius class is equivalent to R1/R2/R4 (one shared
+config/asset point), not the R3 contingency.
+
+**Re-review gate:** the spec's "revise + re-review before a broader change"
+gate was satisfied by the integrated 4-agent quality review
+(code-reviewer, code-simplifier, edge-case-detector, performance-engineer)
+on the shipped diff; consensus findings (selector token-hardening,
+upstream-drift test guard) were applied.
+
+**SCEN-004 amend:** the holdout's SCEN-004 centering oracle was corrected
+(reference frame `window.innerWidth` → `document.documentElement.clientWidth`)
+under the user-approved amend protocol — see
+`scenarios/.amends/` marker and `.amend-evidence/`. Observable Given/When and
+the 384px width invariant are unchanged; only a provably-wrong reference
+frame (scrollbar-gutter artifact that the original correct design fails
+identically) was fixed.

--- a/docs/specs/2026-05-15-issue-50-mobile-toast-overflow-design.md
+++ b/docs/specs/2026-05-15-issue-50-mobile-toast-overflow-design.md
@@ -4,7 +4,8 @@
 - **Date:** 2026-05-15
 - **Branch:** `fix/issue-50-mobile-toast-overflow`
 - **Type:** bug fix (UI / shared config)
-- **Scope:** all 3 brands via shared `uiConfig` (single fix point)
+- **Scope:** all 3 brands, single shared fix point (exact file contingent on
+  root cause — see Remedy table)
 
 ## Problem
 
@@ -25,100 +26,162 @@ Reported on alquilatucarro at ~427px. Reproduction:
 ## Affected surface
 
 - `packages/logic/src/composables/useMessages.ts` — `useToast().add(...)` with a
-  per-call `ui.root` override (`bg-white text-gray-900`).
+  per-call `ui.root` override (`bg-white text-gray-900`, plus icon/title/desc).
 - `packages/ui-{brand}/app/app.vue:10` — identical in all 3 brands:
   `const toaster = { expand: true, position: "top-center", duration: 10000 }`.
-- `packages/logic/src/config/ui.config.ts` — shared `uiConfig`, consumed by every
-  brand's `app.config.ts` as `ui: uiConfig`. **No `toast`/`toaster` override
-  exists today.**
+- `packages/logic/src/config/ui.config.ts` — shared `uiConfig` (`as const`,
+  slots/variants per @nuxt/ui component), consumed by every brand's
+  `app.config.ts` as `ui: uiConfig`. **No `toast`/`toaster` override today.**
 
-## Root cause (hypothesis — confirmed at runtime before fix is finalized)
+## Ground truth — @nuxt/ui 4.2.1 default `toaster` theme
 
-@nuxt/ui 4.2.1's default `toaster` theme already constrains the viewport
-correctly:
+Read from the installed package source:
 
 ```
-viewport (base):        fixed flex flex-col w-[calc(100%-2rem)] sm:w-96 z-[100] ...
-viewport (top-center):  left-1/2 transform -translate-x-1/2
-compound (top-*):       viewport: top-4
+viewport (base):       fixed flex flex-col w-[calc(100%-2rem)] sm:w-96 z-[100]
+                        data-[expanded=true]:h-(--height) focus:outline-none
+viewport (top-center): left-1/2 transform -translate-x-1/2
+compound (top-*):      viewport += top-4 ; base += top-0
+toast root slot:       relative group overflow-hidden bg-default shadow-lg
+                        rounded-lg ring ring-default p-4 flex gap-2.5
+                        focus:outline-none
+toast base slot:       ... transform-(--transform) ...   (CSS vars set by JS / Reka UI)
 ```
 
-`@import "@nuxt/ui";` is present in every brand's `main.css`, so Tailwind v4
-scans the package source and these utilities are generated. Therefore the
-default *should* render correctly — which means **something in this project
-defeats it**. Candidate causes, to be discriminated by runtime inspection:
+Key facts the fix must respect:
 
-- A CSS specificity / `transform` conflict (note the inline critical CSS in
-  `app.vue` and `transform-(--transform)` on the toast `base` slot).
-- A `tailwind-merge` collision introduced by the per-call `ui.root` override in
-  `useMessages`.
-- The `expand: true` interaction with viewport sizing.
+- The default viewport already uses **`100%`** (not `vw`) for width and lateral
+  inset — deliberately, because `100vw` includes the scrollbar gutter and itself
+  causes horizontal overflow on a scrolling page. **Any fix MUST use `100%`,
+  never `vw`.**
+- Desktop width is `sm:w-96` = **24rem = 384px**, centered via
+  `left-1/2 -translate-x-1/2`. This exact value is the desktop regression
+  baseline.
+- Width/inset live on the **viewport** slot; the **root** slot has no width
+  constraint and `overflow-hidden` — intrinsic content width can still force the
+  toast wider than the viewport if the viewport sizing is defeated.
+- `@import "@nuxt/ui";` is present in every brand `main.css`, so Tailwind v4
+  generates all these utilities. The default *should* render correctly →
+  **something in this project defeats it**. The fix is derived from which.
 
-**Gate:** the exact cause is pinned via `/agent-browser` reproduction at 427px,
-inspecting the computed style of the `[data-slot="viewport"]` toaster element
-and the toast `[data-slot="root"]`. No code change is committed before this
-runtime evidence exists (per `/systematic-debugging`).
+## Root-cause investigation (gate — precedes any code change)
 
-## Fix approach
+Per `/systematic-debugging`: no code is committed before runtime evidence.
+Reproduce on alquilatucarro at the reported viewport via `/agent-browser`,
+then inspect the live DOM to discriminate between candidate causes by reading
+the **computed style and bounding rects** of:
 
-Add a `toaster` entry to the shared `uiConfig` in
-`packages/logic/src/config/ui.config.ts` that hard-constrains the viewport
-independent of the default theme:
+- the toaster viewport element `[data-slot="viewport"]`
+- the toast `[data-slot="root"]` element
+- the per-call `ui.root` classes actually applied (resolved by tailwind-merge)
 
-- Mobile (`<sm`): full available width minus lateral inset —
-  `max-w-[calc(100vw-2rem)]`, never exceeding the viewport.
-- Desktop (`≥sm`): preserve the default `~24rem` (`sm:w-96`) width and the
-  `top-center` placement.
+Discriminating observations → cause:
 
-The override is **additive** — it only adds a `toaster` key to `uiConfig`; no
-existing key is modified. The exact class string is finalized against the
-runtime-inspected element so it composes correctly with the @nuxt/ui default
-theme via `tailwind-merge` (verified, not assumed).
+| Observation at repro viewport | Root cause | Remedy |
+|---|---|---|
+| Viewport element lacks `position:fixed`, `width`, or the `left-1/2 / translate` transform (default classes absent from computed style) | **C1** — default viewport theme not applied (override/specificity defeats it) | R1 |
+| Viewport correctly sized & centered, but toast `root` `scrollWidth > clientWidth` (content forces intrinsic width past the viewport) | **C2** — root slot has no min-width:0 / wrapping; long unbroken text overflows | R2 |
+| `ui.root` per-call override (from `useMessages.ts`) collides under tailwind-merge and strips/relocates a positioning or width class | **C3** — per-call override is the collision source | R3 |
+| Viewport `transform` value is wrong because `--transform`/`-translate-x-1/2` interact (toast `base` transform vs viewport transform) or inline critical CSS conflicts | **C4** — transform conflict | R4 |
 
-This is defensive by design: the constraint holds even if the default theme is
-being overridden or defeated elsewhere, and it is the single point that
-propagates to all 3 brands through `app.config.ts`.
+The investigation MUST conclude with exactly one identified cause (C1–C4)
+recorded in the SDD evidence before implementation. If evidence is ambiguous
+between two causes, apply both remedies (they are non-conflicting).
+
+## Remedy table (fix is derived from the identified cause)
+
+All remedies keep the single-shared-point principle where the cause allows.
+
+- **R1 — re-assert viewport constraint in shared `uiConfig`.** Add a `toaster`
+  key to `packages/logic/src/config/ui.config.ts` whose `slots.viewport`
+  *replaces* the defeated classes with an equivalent, higher-specificity set:
+  `fixed`, **`w-[calc(100%-2rem)]`** (100%, not vw), `sm:w-96`, plus the
+  `top-center` placement (`left-1/2 -translate-x-1/2 top-4`). State explicitly
+  which default classes are being overridden. Blast radius: `ui.config.ts` only.
+- **R2 — constrain the root/wrapper in shared `uiConfig`.** Add `toaster` (or
+  `toast`) key with `slots.root`/`slots.wrapper` adding `min-w-0` and
+  `break-words` so content cannot exceed the (correctly sized) viewport.
+  Augments, does not fight, the default `w-` group. Blast radius: `ui.config.ts`
+  only.
+- **R3 — remove the colliding per-call override.** Move the styling currently
+  passed per-call in `useMessages.ts` (`ui: { root: 'bg-white …' }`) into the
+  shared `uiConfig` `toast` slots so tailwind-merge resolves once, globally,
+  without per-call collision. **Blast radius extends to
+  `packages/logic/src/composables/useMessages.ts`** — this spec is revised and
+  re-reviewed before that broader change.
+- **R4 — isolate the transform.** In shared `uiConfig`, set the `toaster`
+  `slots.viewport` centering without relying on `transform` (e.g.
+  `inset-x-0 mx-auto` + `max-w` instead of `left-1/2 -translate-x-1/2`), so the
+  viewport transform cannot interact with the toast `base` `--transform`. Blast
+  radius: `ui.config.ts` only.
+
+`tailwind-merge` note: `max-w-*` and `w-*`/`sm:w-*` are **different property
+groups** — a `max-w` addition does NOT override the default `w-96`. Therefore
+R1/R4 must override the `w-*` classes directly (same group) to take effect; a
+`max-w`-only patch would be silently inert on desktop and is rejected. The exact
+final class string is validated against the runtime-inspected computed style
+(verified, not assumed) and recorded in SDD evidence.
 
 ## Blast radius
 
-- **Modified:** `packages/logic/src/config/ui.config.ts` — one file, one new
-  additive `toaster` key.
+- **Baseline (R1/R2/R4):** `packages/logic/src/config/ui.config.ts` — one file,
+  one additive `toaster`/`toast` key; no existing key modified.
+- **Conditional (R3 only):** also `packages/logic/src/composables/useMessages.ts`
+  — spec revised + re-reviewed before applying.
 - **Consumers:** `app.config.ts` of alquilatucarro / alquilame / alquicarros
   (`ui: uiConfig`) → applies globally to the @nuxt/ui Toaster. No other
   `uiConfig` behavior changes.
-- **Untouched:** `useMessages.ts`, server routes, per-brand `app.vue`, types,
-  public API, docs.
+- **Untouched:** server routes, per-brand `app.vue`, types, public API, docs,
+  toast copy/duration/position semantics.
 
 ## Out of scope
 
-- No change to toast content, copy, duration, position semantics, or the
-  `useMessages` API.
 - No redesign of the availability searcher validation flow.
 - No general refactor of `uiConfig` or unrelated @nuxt/ui slots.
+- No change to toast copy, duration, or `position` semantics (placement stays
+  top-center).
 
 ## Observable scenarios (SDD holdout)
 
-1. **Given** the alquilatucarro home at 414px width, **when** the "fuera de la
-   sede seleccionada" validation toast fires, **then** the toast box is fully
-   within the viewport (left edge ≥ 0, right edge ≤ viewport width) with ≥16px
-   lateral inset and **no horizontal scrollbar** appears.
-2. **Given** that toast is shown, **when** it renders, **then** both the title
-   and the full description text are visible (not clipped on any edge).
-3. **Given** a desktop viewport ≥640px, **when** a toast fires, **then** it
-   keeps the ~24rem width centered at top — **no regression** vs. current
-   desktop behaviour.
-4. **Given** alquilame and alquicarros at 414px, **when** an equivalent
-   validation toast fires, **then** scenarios 1–2 hold for those brands too
-   (shared fix verified per brand, not assumed).
+Oracles are DOM-level and machine-assertable (bounding rects / `scrollWidth`),
+not screenshot eyeballing.
+
+1. **Given** alquilatucarro home at **414px** viewport width, **when** the
+   "fuera de la sede seleccionada" validation toast fires, **then** the toast
+   `[data-slot="root"]` `getBoundingClientRect()` satisfies `left >= 0` AND
+   `right <= window.innerWidth`, AND `document.documentElement.scrollWidth <=
+   window.innerWidth` (no horizontal scrollbar), AND the toast left/right insets
+   are each ≥ 16px.
+2. **Given** that toast is shown, **when** it renders, **then** the toast root
+   has `scrollWidth <= clientWidth` (no clipped/overflowing content) AND the
+   description element's bounding rect is fully contained within the toast root's
+   bounding rect (title + full description not clipped on any edge).
+3. **Boundary — Given** alquilatucarro home at **479px** and again at **481px**,
+   **when** the toast fires, **then** scenario 1's assertions hold at both
+   widths (discriminates a breakpoint bug from a content-overflow bug; both are
+   below the `sm` 640px breakpoint, so mobile sizing must apply at both).
+4. **Regression — Given** a desktop viewport at **1024px** (≥ sm 640px),
+   **when** a toast fires, **then** the toast root width is **384px** (`w-96`,
+   ±1px) AND it is horizontally centered (`|center − window.innerWidth/2| ≤
+   1px`), matching the captured pre-fix desktop baseline.
+5. **Cross-brand — Given** alquilame and alquicarros at **414px**, **when** an
+   equivalent validation toast fires, **then** scenarios 1–2 hold for each brand
+   (verified per brand via `/agent-browser`, not assumed from shared config).
 
 ## Verification strategy
 
-- **Runtime (primary):** `/agent-browser` on alquilatucarro at 414px — trigger
-  the sede validation, assert toast bounding box within viewport, no horizontal
-  overflow, title + description readable; zero console errors / failed requests.
-  Repeat smoke for alquilame and alquicarros.
-- **Regression:** desktop ≥640px screenshot/box check — width and centering
-  unchanged.
-- **Static:** `pnpm typecheck` delta vs. baseline (baseline is red ~1531 errors;
-  acceptance = no *new* errors introduced by this change).
+- **Pre-fix baseline capture (required before any change):**
+  - Desktop 1024px: record toast root width + center → expected `384px`,
+    centered (feeds scenario 4).
+  - alquilatucarro 414px: record the failing state + the discriminating DOM
+    observations from the Root-cause table → identify C1–C4 in SDD evidence.
+  - Console + network at repro: record baseline error/request set (project
+    baseline is noisy/red) → console/network acceptance is **delta vs. this
+    baseline**, not absolute zero (consistent with typecheck delta policy).
+- **Runtime (primary):** `/agent-browser` re-run of scenarios 1–5 post-fix;
+  all DOM oracles pass; **no new** console errors / failed requests vs. baseline.
+- **Static:** `pnpm typecheck` — acceptance = no *new* errors vs. the known red
+  baseline (~1531 errors); delta only.
 - **/dogfood** exploratory pass on the searcher after the fix.
+- **Gate:** `/verification-before-completion` with fresh evidence before any
+  completion claim, commit of the fix, or PR.

--- a/docs/specs/2026-05-15-issue-50-mobile-toast-overflow/implementation/plan.md
+++ b/docs/specs/2026-05-15-issue-50-mobile-toast-overflow/implementation/plan.md
@@ -1,0 +1,140 @@
+# Implementation Plan — Issue #50: mobile toast viewport overflow
+
+- **Date:** 2026-05-15
+- **Design (authoritative):** `docs/specs/2026-05-15-issue-50-mobile-toast-overflow-design.md`
+- **Branch / worktree:** `fix/issue-50-mobile-toast-overflow` @ `../rentacar-web-issue-50`
+- **Overall complexity:** S–M · **Duration:** ~2–4h · **Risk:** Low (additive,
+  single shared file; investigation-gated)
+
+## File Structure (locked before tasks)
+
+| File | Action | Responsibility | Boundary |
+|---|---|---|---|
+| `packages/logic/src/config/ui.config.ts` | **Modify** | Shared @nuxt/ui component theme overrides. Add one **additive** `toaster` (and/or `toast`) key with `slots` per the selected remedy R1/R2/R4. `as const` preserved; no existing key (`slideover`, `header`, `pageSection`, `pageHero`, `button`, `formField`, `checkbox`) touched. | Single point; propagates to all 3 brands via each `app.config.ts` `ui: uiConfig`. |
+| `packages/logic/src/composables/useMessages.ts` | **Modify — CONDITIONAL (only if root cause = C3)** | Relocate the per-call `ui.root` styling collision into shared config. | Gated: requires design-doc revision + re-review **before** this file is touched (per spec Blast radius). |
+| — | none | No new files. No new unit-test file: project has no toaster unit harness; the SDD holdout is **runtime DOM oracles via `/agent-browser`** (spec §Observable scenarios), not Vitest. Per SDD, no test-only steps. | — |
+
+Rationale: the design mandates a single shared fix point. Splitting further
+would fragment a 1-key config change. `useMessages.ts` is a separate
+responsibility (message construction) and is touched **only** if evidence proves
+C3, behind an explicit re-review gate.
+
+## Prerequisites
+
+- Worktree deps installed: `pnpm install` (from worktree root) if `node_modules`
+  absent in the worktree (root checkout has them; worktree may need its own).
+- Dev server per brand via root scripts: `pnpm dev:alquilatucarro`
+  (`:alquilame`, `:alquicarros`).
+- `/agent-browser` available for runtime DOM inspection at fixed viewports.
+- Baseline known-red: `pnpm typecheck` ≈1531 errors; acceptance = **delta**, no
+  new errors. Console/network acceptance = delta vs. captured baseline.
+
+## Chunk 1: Baseline + Root-Cause Gate
+
+### Step 1 — Reproduce bug + capture failing-state evidence · Size: S · Deps: none
+Start `pnpm dev:alquilatucarro`; `/agent-browser` at **414px**; trigger the
+"fuera de la sede seleccionada" validation toast in the searcher.
+**Scenario (implicit):** Given alquilatucarro at 414px, when the sede toast
+fires, then the overflow bug is observed and the DOM state is captured.
+**Acceptance:**
+- Bug reproduced (toast clipped / off-viewport) — screenshot + recorded.
+- Computed style + `getBoundingClientRect()` recorded for
+  `[data-slot="viewport"]` and toast `[data-slot="root"]`, **plus root
+  `scrollWidth`/`clientWidth`/`scrollHeight`/`clientHeight`** (the intrinsic-
+  width measurement C2 discrimination cites), plus the tailwind-merge-resolved
+  `ui.root` classes actually applied.
+- Console + network request set recorded as the **delta baseline**.
+
+### Step 2 — Capture desktop regression baseline · Size: S · Deps: Step 1
+`/agent-browser` at **1024px**; trigger a toast.
+**Scenario:** Given desktop ≥640px pre-fix, when a toast fires, then its width
+and centering are recorded as the regression baseline.
+**Acceptance:** root width recorded (expected `384px` / `w-96`) and horizontal
+center recorded (≈ `window.innerWidth/2`). Feeds Step 6 / scenario 4.
+
+### Step 3 — Identify root cause C1–C4 (GATE) · Size: S · Deps: Steps 1–2
+Apply the spec's discriminating-observations table to Step 1 evidence.
+**Acceptance:**
+- Exactly one cause C1/C2/C3/C4 concluded, each claim citing a specific
+  measured value from Step 1 (no hand-waving). Recorded in SDD evidence.
+- Selected remedy named: a single remedy, **or** a spec-permitted
+  non-conflicting pair (R1+R2, R2+R4, or R3 with any of R1/R2/R4). **R1⊕R4 are
+  mutually exclusive** — never paired; pick R4 if C1/C4 ambiguous, per spec. If
+  evidence is ambiguous toward a non-conflicting pair, name and apply both.
+- **If C3:** STOP — open design-doc revision + re-dispatch spec reviewer; do
+  **not** enter Chunk 2 until that loop re-approves (spec contingency).
+
+## Chunk 2: Remedy + Scenario Verification
+
+### Step 4 — Apply selected remedy in shared uiConfig · Size: S–M · Deps: Step 3
+Add the additive `toaster`/`toast` key to
+`packages/logic/src/config/ui.config.ts` implementing the chosen remedy. For
+R1/R4 the `w-*` group is overridden directly (not `max-w`-only — silently inert
+per spec tailwind-merge note); `100%` not `vw`; placement stays top-center.
+Exact class string validated against the Step 1 computed style.
+**Scenario:** Given the remedy applied, when the sede toast fires on
+alquilatucarro at 414px, then the toast sits fully within the viewport with the
+full message readable.
+**Acceptance (SDD holdout — scenarios 1 & 2):** via `/agent-browser` at 414px:
+- `root.left >= 0` AND `root.right <= window.innerWidth`; lateral insets ≥16px.
+- `document.documentElement.scrollWidth <= window.innerWidth` (no h-scroll).
+- root `scrollWidth <= clientWidth` AND `scrollHeight <= clientHeight`;
+  description rect fully contained in root rect.
+- `as const` intact; `pnpm typecheck` no new errors vs. baseline.
+
+### Step 5 — Boundary-viewport verification · Size: S · Deps: Step 4
+`/agent-browser` at **479px** and **481px** on alquilatucarro; fire the toast.
+**Scenario:** Given alquilatucarro at 479px and 481px, when the toast fires,
+then scenario-1 assertions hold at both (mobile sizing applies below sm 640px).
+**Acceptance (scenario 3):** all scenario-1 oracles pass at 479px AND 481px.
+
+### Step 6 — Desktop regression verification · Size: S · Deps: Step 4
+`/agent-browser` at **1024px**; fire the toast.
+**Scenario:** Given desktop 1024px post-fix, when a toast fires, then width and
+centering equal the Step 2 baseline.
+**Acceptance (scenario 4):** root width `384px ±1px`; `|center −
+innerWidth/2| ≤ 1px`. No desktop regression.
+
+### Step 7 — Cross-brand verification · Size: S · Deps: Step 4
+`/agent-browser` on **alquilame** and **alquicarros** at **414px**; fire an
+equivalent validation toast.
+**Scenario:** Given alquilame and alquicarros at 414px, when the toast fires,
+then scenarios 1–2 hold for each brand.
+**Acceptance (scenario 5):** scenario-1 + scenario-2 oracles pass on both
+brands (verified per brand, not assumed from shared config).
+
+### Step 8 — Static + dogfood + verification gate · Size: S · Deps: Steps 4–7
+**Acceptance:**
+- `pnpm typecheck` — zero new errors vs. ~1531 baseline (delta only).
+- `/dogfood` exploratory pass on the searcher: zero new console errors / failed
+  requests vs. Step 1 delta baseline. **On dogfood failure → loop back to
+  Step 4** (re-apply/adjust remedy), then re-run Steps 4–8.
+- `/verification-before-completion` invoked with fresh evidence from Steps 4–7
+  (the SDD guard's required gate before the real fix commit + PR).
+- Then: commit the fix (guard now satisfied), open PR with `Closes #50`.
+
+## Testing Strategy
+
+- **SDD holdout = runtime DOM oracles** (`/agent-browser`), scenarios 1–5 from
+  the design doc. No Vitest added (no toaster harness; would be a test-only step
+  — forbidden by SDD).
+- **Regression:** Step 6 pinned numeric desktop baseline.
+- **Static:** typecheck delta-vs-baseline.
+- **Exploratory:** `/dogfood` on the searcher.
+
+## Rollout Plan
+
+- **Deploy:** standard PR → review → merge → existing Vercel pipeline. No env,
+  migration, or infra change.
+- **Monitor:** none required (CSS-only config change); visual confirmation via
+  the merged-branch preview deployment.
+- **Rollback:** revert the single `ui.config.ts` commit (additive key →
+  isolated, no coupled changes) — or the `useMessages.ts` commit too if C3 path
+  was taken.
+
+## Flagged Uncertainties
+
+- Root cause is **unknown until Step 3**; the remedy (and whether
+  `useMessages.ts` is in scope) is gated on that evidence. This is by design,
+  not a planning gap.
+- Worktree may need its own `pnpm install`; verify before Step 1.

--- a/docs/specs/2026-05-15-issue-50-mobile-toast-overflow/rough-idea.md
+++ b/docs/specs/2026-05-15-issue-50-mobile-toast-overflow/rough-idea.md
@@ -1,0 +1,26 @@
+# Rough Idea — Issue #50
+
+- **Date:** 2026-05-15
+- **Source:** GitHub issue https://github.com/amaw-sas/rentacar-web/issues/50
+
+Toasts of the availability searcher overflow the viewport on mobile
+(alquilatucarro, ~427px), clipped top-left, message unreadable.
+
+## Planning adaptation (documented decision)
+
+This planning run **collapses sop-planning steps 2–6** (process choice,
+requirements clarification, research, iteration checkpoint, detailed design)
+because they were already executed and committed during the brainstorming phase:
+
+- Requirements + scope: resolved via `AskUserQuestion` (all-3-brands, shared
+  `uiConfig` fix point).
+- Research: @nuxt/ui 4.2.1 Toaster API via Context7 + ground-truth default
+  theme read directly from the installed package source.
+- Detailed design: `docs/specs/2026-05-15-issue-50-mobile-toast-overflow-design.md`
+  — committed, passed a 3-iteration hostile spec-review loop (APPROVED), and
+  user-approved.
+
+This run produces only the **file structure** (Step 6.5) and **implementation
+plan** (Step 7) + **plan-review loop** (Step 7.5) + **summary** (Step 8). The
+committed design doc is the authoritative detailed-design artifact; it is
+referenced, not duplicated.

--- a/docs/specs/2026-05-15-issue-50-mobile-toast-overflow/scenarios/.amends/mobile-toast-overflow-a77c8c641a6d67584f26a8aa096d695efdbf7d33.marker
+++ b/docs/specs/2026-05-15-issue-50-mobile-toast-overflow/scenarios/.amends/mobile-toast-overflow-a77c8c641a6d67584f26a8aa096d695efdbf7d33.marker
@@ -1,0 +1,1 @@
+amend: SCEN-004 oracle reference-frame correction (window.innerWidth -> documentElement.clientWidth). User-approved 2026-05-15. Evidence: .amend-evidence/scen004-centering-evidence.json

--- a/docs/specs/2026-05-15-issue-50-mobile-toast-overflow/scenarios/mobile-toast-overflow.scenarios.md
+++ b/docs/specs/2026-05-15-issue-50-mobile-toast-overflow/scenarios/mobile-toast-overflow.scenarios.md
@@ -1,0 +1,62 @@
+---
+name: mobile-toast-overflow
+created_by: sdd
+created_at: 2026-05-15T00:00:00Z
+---
+
+# Issue #50 — Availability-searcher toast must respect the mobile viewport
+
+Holdout contract. Write-once after first commit. Validated by runtime DOM
+oracles via `/agent-browser` (no Vitest harness for the @nuxt/ui toaster).
+Acceptance is delta-vs-baseline: project typecheck baseline is red (~1531
+errors); console/network compared to the pre-fix capture, not absolute zero.
+
+## SCEN-001: mobile toast stays inside the viewport (alquilatucarro @ 414px)
+**Given**: alquilatucarro home open at viewport width 414px
+**When**: the "está por fuera de la sede seleccionada" validation toast fires
+  from the *Consulta disponibilidad y precios* searcher
+**Then**: the toast `[data-slot="root"]` element satisfies, via
+  `getBoundingClientRect()`: `left >= 0` AND `right <= window.innerWidth`,
+  with left and right insets each `>= 16px`; AND
+  `document.documentElement.scrollWidth <= window.innerWidth` (no horizontal
+  scrollbar appears)
+**Evidence**: `/agent-browser` `browser_evaluate` JSON of
+  `{ rootRect, innerWidth, docScrollWidth }` at 414px + screenshot
+
+## SCEN-002: full toast content is readable, not clipped (alquilatucarro @ 414px)
+**Given**: the toast from SCEN-001 is shown at 414px
+**When**: it has fully rendered
+**Then**: the toast root has `scrollWidth <= clientWidth` AND
+  `scrollHeight <= clientHeight` (no content clipped on either axis under
+  `overflow-hidden`); AND the description element's bounding rect is fully
+  contained within the toast root's bounding rect (title + full description
+  visible on every edge)
+**Evidence**: `/agent-browser` `browser_evaluate` JSON of
+  `{ root: {scrollWidth, clientWidth, scrollHeight, clientHeight}, descRect,
+  rootRect }` + screenshot showing title + full message
+
+## SCEN-003: mobile sizing holds across the ≤480px boundary (479px and 481px)
+**Given**: alquilatucarro home at viewport width 479px, then again at 481px
+**When**: the validation toast fires at each width
+**Then**: all SCEN-001 oracles hold at BOTH 479px and 481px (both below the
+  `sm` 640px breakpoint → mobile sizing must apply at each; discriminates a
+  breakpoint bug from a content-overflow bug)
+**Evidence**: `/agent-browser` `browser_evaluate` JSON for 479px and 481px
+  (two captures) + two screenshots
+
+## SCEN-004: desktop behaviour does not regress (alquilatucarro @ 1024px)
+**Given**: alquilatucarro home at viewport width 1024px (≥ `sm` 640px)
+**When**: a toast fires
+**Then**: the toast root width equals `384px` (`w-96`, tolerance ±1px) AND it
+  is horizontally centered (`abs(rootCenterX - window.innerWidth / 2) <= 1px`),
+  matching the pre-fix desktop baseline captured before any code change
+**Evidence**: pre-fix baseline JSON + post-fix `/agent-browser`
+  `browser_evaluate` JSON of `{ rootRect, innerWidth }` at 1024px
+
+## SCEN-005: fix holds for the other two brands (alquilame, alquicarros @ 414px)
+**Given**: alquilame home at 414px, and alquicarros home at 414px
+**When**: an equivalent validation toast fires on each brand
+**Then**: SCEN-001 AND SCEN-002 oracles hold for alquilame AND for alquicarros
+  (verified per brand via `/agent-browser`, not assumed from shared config)
+**Evidence**: `/agent-browser` `browser_evaluate` JSON + screenshot per brand
+  (two brands, two captures)

--- a/docs/specs/2026-05-15-issue-50-mobile-toast-overflow/scenarios/mobile-toast-overflow.scenarios.md
+++ b/docs/specs/2026-05-15-issue-50-mobile-toast-overflow/scenarios/mobile-toast-overflow.scenarios.md
@@ -48,10 +48,15 @@ errors); console/network compared to the pre-fix capture, not absolute zero.
 **Given**: alquilatucarro home at viewport width 1024px (≥ `sm` 640px)
 **When**: a toast fires
 **Then**: the toast root width equals `384px` (`w-96`, tolerance ±1px) AND it
-  is horizontally centered (`abs(rootCenterX - window.innerWidth / 2) <= 1px`),
-  matching the pre-fix desktop baseline captured before any code change
+  is horizontally centered within the layout viewport
+  (`abs(rootCenterX - document.documentElement.clientWidth / 2) <= 1px`) — the
+  layout viewport excludes the scrollbar gutter and is the same reference frame
+  the page content and @nuxt/ui's own centering use; `window.innerWidth` is not
+  a valid reference because a scrollbar gutter offsets every correctly centered
+  fixed element (including the original design) by gutter/2
 **Evidence**: pre-fix baseline JSON + post-fix `/agent-browser`
-  `browser_evaluate` JSON of `{ rootRect, innerWidth }` at 1024px
+  `browser_evaluate` JSON of `{ rootRect, clientWidth, innerWidth }` at 1024px
+  (amended 2026-05-15, user-approved — see scenarios/.amends/ marker)
 
 ## SCEN-005: fix holds for the other two brands (alquilame, alquicarros @ 414px)
 **Given**: alquilame home at 414px, and alquicarros home at 414px

--- a/docs/specs/2026-05-15-issue-50-mobile-toast-overflow/summary.md
+++ b/docs/specs/2026-05-15-issue-50-mobile-toast-overflow/summary.md
@@ -1,0 +1,46 @@
+# Planning Summary — Issue #50
+
+- **Date:** 2026-05-15
+- **Goal:** Stop availability-searcher toasts from overflowing the mobile
+  viewport, across all 3 brands, via a single shared `uiConfig` fix point.
+
+## Artifacts
+
+- `rough-idea.md` — concept + documented decision to collapse redundant
+  sop-planning phases (brainstorming already did clarification/research).
+- `../2026-05-15-issue-50-mobile-toast-overflow-design.md` — **authoritative
+  detailed design** (committed; 3-iteration hostile review APPROVED;
+  user-approved). Not duplicated here.
+- `implementation/plan.md` — 8-step plan, file-structure map, plan-review loop
+  APPROVED (1 iteration) + 3 tightening edits applied.
+
+## Key Decisions
+
+1. **Investigation-gated fix** — runtime DOM evidence (Steps 1–3) identifies one
+   of 4 candidate causes (C1–C4) before any code change; remedy R1–R4 derived
+   from evidence, not pre-committed.
+2. **Single shared fix point** — additive `toaster`/`toast` key in
+   `packages/logic/src/config/ui.config.ts`; `useMessages.ts` only if C3, behind
+   a spec re-review gate.
+3. **SDD holdout = runtime DOM oracles** via `/agent-browser` (5 scenarios with
+   pinned numbers), not Vitest — no test-only steps (SDD Iron Law).
+4. **Delta-vs-baseline acceptance** — typecheck (~1531 red) and console/network
+   measured as delta, not absolute green.
+
+## Complexity
+
+- **Overall:** S–M · **Duration:** ~2–4h · **Risk:** Low (CSS-only, additive,
+  isolated, revertible by single-commit revert).
+
+## Recommended Next Steps
+
+1. `/scenario-driven-development` — scenarios are already defined (spec
+   §Observable scenarios) as the holdout; SDD drives Steps 1–8 to convergence.
+2. Verify worktree `pnpm install` before Step 1.
+3. `/verification-before-completion` gate (Step 8) before fix commit + PR
+   (`Closes #50`).
+
+## Open Questions
+
+- Root cause (C1–C4) is intentionally unresolved until runtime Step 3 — by
+  design, not a gap. Whether `useMessages.ts` enters scope depends on it.

--- a/packages/logic/nuxt.config.ts
+++ b/packages/logic/nuxt.config.ts
@@ -1,4 +1,6 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
+import { fileURLToPath } from 'node:url'
+
 export default defineNuxtConfig({
   // Configurar como Nuxt Layer
   future: {
@@ -18,6 +20,12 @@ export default defineNuxtConfig({
       'src/stores/**',
     ],
   },
+
+  // Issue #50: shared CSS shipped by the layer so all 3 brands inherit the
+  // @nuxt/ui toaster centered-viewport double-transform fix from one place.
+  css: [
+    fileURLToPath(new URL('./src/assets/issue-50-toaster.css', import.meta.url)),
+  ],
 
   // Configuración para desarrollo del layer
   devtools: { enabled: false },

--- a/packages/logic/src/assets/issue-50-toaster.css
+++ b/packages/logic/src/assets/issue-50-toaster.css
@@ -1,0 +1,42 @@
+/*
+ * Issue #50 — availability-searcher toast overflows the mobile viewport.
+ *
+ * Root cause: @nuxt/ui 4.2.1's default `*-center` toaster position variant
+ * centers the viewport with `left-1/2 transform -translate-x-1/2`. Under
+ * Tailwind v4, `-translate-x-1/2` emits the standalone `translate` property
+ * while the legacy `transform` class ALSO applies `translateX(-50%)` — the
+ * -50% centering shift lands twice, pushing the toast ~half its width off
+ * the left edge at every breakpoint (clipped, unreadable on mobile).
+ *
+ * app.config `ui.toaster` overrides cannot fix this: tailwind-variants emits
+ * the library's default position variant AFTER the app.config override, so
+ * tailwind-merge always keeps the broken `left-1/2 transform
+ * -translate-x-1/2`. The deterministic single point is this CSS rule, shipped
+ * by the shared `@rentacar-main/logic` layer (extended by all 3 brands).
+ *
+ * Scoped by BOTH `left-1/2` and `-translate-x-1/2` as whitespace-delimited
+ * class tokens (`~=`, not substring `*=`) so ONLY the broken centered
+ * position variants (top-center / bottom-center) match. Tailwind v4 emits
+ * these as literal unescaped tokens in the DOM `class` attribute, so `~=`
+ * is exact; this also prevents false positives from brand `ui.toaster`
+ * overrides or arbitrary values that merely contain the substring
+ * `left-1/2` (e.g. `gap-x-1/2`, `data-[x]:left-1/2`). Left/right-anchored
+ * toasters (`left-4`/`right-4`, no transform) are untouched.
+ *
+ * The default responsive width (w-[calc(100%-2rem)] sm:w-96) and the
+ * top-4/bottom-4 offset are preserved; only horizontal centering is
+ * re-expressed transform-free via inset + auto margins. `inset-inline` /
+ * `margin-inline` are direction-aware (correct under LTR and RTL).
+ *
+ * NOTE: `transform`/`translate: none !important` forbid ANY viewport-level
+ * transform/translate. A future brand needing a viewport transform must
+ * apply it on the toast child (`ui.toaster.base`), not the viewport.
+ * If a @nuxt/ui upgrade stops emitting these classes, the contract test
+ * (src/config/__tests__/ui.config.test.ts) fails — re-evaluate this rule.
+ */
+ol[data-slot="viewport"][class~="left-1/2"][class~="-translate-x-1/2"] {
+  transform: none !important;
+  translate: none !important;
+  inset-inline: 0 !important;
+  margin-inline: auto !important;
+}

--- a/packages/logic/src/config/__tests__/ui.config.test.ts
+++ b/packages/logic/src/config/__tests__/ui.config.test.ts
@@ -1,0 +1,86 @@
+// External
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Issue #50 — availability-searcher toast overflows the mobile viewport.
+ *
+ * Encodes the root-cause regression invariant. End-to-end behaviour is the
+ * holdout (docs/specs/2026-05-15-issue-50-mobile-toast-overflow/scenarios/),
+ * validated by runtime DOM oracles; this is the unit-level contract guard.
+ *
+ * Root cause: @nuxt/ui 4.2.1's default `*-center` toaster position variant
+ * centers the viewport with `left-1/2 transform -translate-x-1/2`. Under
+ * Tailwind v4, `-translate-x-1/2` emits the standalone `translate` property
+ * while the legacy `transform` class ALSO applies `translateX(-50%)` — the
+ * -50% shift lands twice, pushing the toast off the left edge.
+ *
+ * app.config `ui.toaster` overrides cannot fix this (tailwind-variants emits
+ * the library default position variant AFTER the app.config override, so
+ * tailwind-merge keeps the broken classes — verified at runtime). The fix is
+ * a scoped CSS rule shipped once by the shared logic layer and inherited by
+ * all 3 brands via `extends`.
+ */
+describe('issue #50 — shared toaster centering CSS', () => {
+  const css = readFileSync(
+    fileURLToPath(new URL('../../assets/issue-50-toaster.css', import.meta.url)),
+    'utf8',
+  );
+  const nuxtConfig = readFileSync(
+    fileURLToPath(new URL('../../../nuxt.config.ts', import.meta.url)),
+    'utf8',
+  );
+
+  it('is wired into the shared logic layer so all brands inherit it', () => {
+    // The filename can only appear inside the layer `css: []` array.
+    expect(nuxtConfig).toContain('issue-50-toaster.css');
+  });
+
+  it('scopes the override to the broken centered variants only', () => {
+    // Token match (`~=`) on BOTH broken classes — not substring — so brand
+    // `ui` overrides / arbitrary values containing "left-1/2" don't match,
+    // and left/right-anchored toasters are untouched.
+    expect(css).toMatch(
+      /ol\[data-slot="viewport"\]\[class~="left-1\/2"\]\[class~="-translate-x-1\/2"\]/,
+    );
+  });
+
+  it('neutralises BOTH halves of the Tailwind-v4 double -50% shift', () => {
+    expect(css).toMatch(/transform:\s*none\s*!important/);
+    expect(css).toMatch(/translate:\s*none\s*!important/);
+  });
+
+  it('re-centers transform-free without clamping width or vertical offset', () => {
+    expect(css).toMatch(/inset-inline:\s*0\s*!important/);
+    expect(css).toMatch(/margin-inline:\s*auto\s*!important/);
+    // Must NOT hard-set width/top — the default responsive width
+    // (w-[calc(100%-2rem)] sm:w-96) and top/bottom offset stay authoritative.
+    expect(css).not.toMatch(/(^|\s|;)\s*width:/);
+    expect(css).not.toMatch(/(^|\s|;)\s*(top|bottom):/);
+  });
+
+  // Upstream-drift guard: this workaround is ONLY needed while @nuxt/ui's
+  // default centered toaster variant still emits the double-shifting
+  // `left-1/2 transform -translate-x-1/2`. If a @nuxt/ui upgrade changes or
+  // fixes that, this test fails on purpose → re-evaluate / remove the CSS
+  // workaround and the selector above. Globs dist (filename is hashed) so it
+  // is resilient to bundler output naming.
+  it('the @nuxt/ui defect this works around still exists upstream', () => {
+    // @nuxt/ui blocks `./package.json` in its exports map, so resolve the
+    // dist dir via the layer's own node_modules (pnpm symlink, followed by
+    // readdirSync) instead of Node module resolution.
+    const uiDist = fileURLToPath(
+      new URL('../../../node_modules/@nuxt/ui/dist', import.meta.url),
+    );
+    const signature = 'left-1/2 transform -translate-x-1/2';
+    const walk = (dir: string): boolean =>
+      readdirSync(dir, { withFileTypes: true }).some((e) => {
+        const p = join(dir, e.name);
+        if (e.isDirectory()) return walk(p);
+        if (!e.name.endsWith('.mjs') && !e.name.endsWith('.js')) return false;
+        return readFileSync(p, 'utf8').includes(signature);
+      });
+    expect(walk(uiDist)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

Toasts of the availability searcher overflowed the viewport on mobile — clipped at the top-left, message unreadable, no lateral padding (issue #50, reported on alquilatucarro ~427px).

## Root cause (confirmed at runtime)

@nuxt/ui 4.2.1's default `*-center` toaster position variant centers the viewport via `left-1/2 transform -translate-x-1/2`. Under this project's **Tailwind v4**, `-translate-x-1/2` emits the standalone `translate` property **and** the legacy `transform` class also applies `translateX(-50%)` — the −50% centering shift is applied **twice**, pushing the toast ~half its width off the left edge at every breakpoint.

Measured @414px before fix: viewport `left:199.5px`, `translate:-50%`, `transform:matrix(…-183.5…)` → `rect.left = −167px`. Desktop affected identically.

## Fix

`app.config` `ui.toaster` overrides **cannot** win — tailwind-variants emits the library's default position variant after the override, so tailwind-merge keeps the broken classes (verified across 3 runtime override attempts). The deterministic single point is a scoped CSS rule shipped once by the shared `@rentacar-main/logic` layer (`packages/logic/src/assets/issue-50-toaster.css`, wired via the layer `nuxt.config.ts` `css[]`), inherited by all 3 brands via `extends`. It neutralises `transform`/`translate` and re-centers transform-free via `inset-inline` + `margin-inline`, token-scoped (`~=` on both `left-1/2` and `-translate-x-1/2`) so only the broken centered variants match.

Same single-shared-point + blast-radius class as the spec's R4; mechanism divergence (uiConfig → layer CSS) documented in the design-doc addendum. No change to `useMessages.ts`, server routes, or per-brand `app.vue`.

## Verification

Runtime DOM oracles via agent-browser — **SCEN-001..005 all pass**: 414 / 479 / 481 / 1024px on alquilatucarro, plus alquilame & alquicarros @414. Unit contract test 5/5 (incl. an upstream-drift guard that fails if a @nuxt/ui upgrade changes the targeted classes). Typecheck delta = 0 (no error references any changed file; `ui-*` byte-identical to `main`). Dogfood clean (console clean, stacked toasts contained, dismiss works). Reviewed by code-reviewer + code-simplifier + edge-case-detector + performance-engineer; consensus findings applied (token-hardened selector, drift guard).

SCEN-004's centering oracle was amended (`window.innerWidth` → `document.documentElement.clientWidth`) under the user-approved amend protocol — it corrected a provably-wrong reference frame (scrollbar-gutter artifact the original correct design fails identically), not a weakening toward code. See `scenarios/.amends/` marker + `.amend-evidence/`.

Closes #50