### PR TITLE
perf(rentacar-data): bound upstream fetch with 8s timeout + document client singletons

### DIFF
--- a/packages/logic/server/api/rentacar-data.get.ts
+++ b/packages/logic/server/api/rentacar-data.get.ts
@@ -1,46 +1,21 @@
 import { useSupabaseClient } from '../utils/supabase'
+import { fetchRentacarData, RentacarDataTimeoutError } from '../utils/rentacarDataFetch'
 import { transformCategories, transformBranches, transformExtras, transformVehicleCategories, transformCities, transformFranchiseTestimonials } from '../utils/transformers'
 
 export default defineCachedEventHandler(async () => {
   const supabase = useSupabaseClient()
 
-  const [categoriesResult, locationsResult, companyResult, citiesResult, franchisesResult] = await Promise.all([
-    supabase
-      .from('vehicle_categories')
-      .select('*, category_models(*), category_pricing(*)')
-      .eq('status', 'active')
-      .order('code'),
-
-    supabase
-      .from('locations')
-      .select('id, code, name, city, slug, schedule, status, cities(slug)')
-      .eq('status', 'active')
-      .order('name'),
-
-    supabase
-      .from('rental_companies')
-      .select('extra_driver_day_price, baby_seat_day_price, wash_price, wash_onsite_price, wash_deep_price, wash_deep_upholstery_price')
-      .eq('code', 'localiza')
-      .single(),
-
-    supabase
-      .from('cities')
-      .select('slug, name, description, testimonials')
-      .eq('status', 'active')
-      .order('name'),
-
-    // TODO(perf): each brand's SSR payload includes all 3 brands' testimonials
-    // (~14KB cross-brand bloat per render). Acceptable while testimonials are
-    // static and small; revisit when this stops being true (e.g., before the
-    // Google Maps Reviews integration). Per-brand filter would require either
-    // a dynamic cache key based on rentacarFranchise or a brand-aware wrapper
-    // route — both are larger changes than this issue's scope (#11).
-    supabase
-      .from('franchises')
-      .select('code, testimonials')
-      .eq('status', 'active')
-      .order('code'),
-  ])
+  // NOTE(perf #11): each brand's SSR payload still includes all 3 brands'
+  // testimonials (~14KB cross-brand bloat per render) via the franchises
+  // query inside fetchRentacarData. Acceptable while testimonials are static
+  // and small; revisit before the Google Maps Reviews integration.
+  const [categoriesResult, locationsResult, companyResult, citiesResult, franchisesResult] =
+    await fetchRentacarData(supabase).catch((err) => {
+      if (err instanceof RentacarDataTimeoutError) {
+        throw createError({ statusCode: 504, statusMessage: 'rentacar-data upstream timeout' })
+      }
+      throw err
+    })
 
   if (categoriesResult.error) {
     throw createError({ statusCode: 500, message: `Categories query failed: ${categoriesResult.error.message}` })

--- a/packages/logic/server/utils/__tests__/rentacarDataFetch.test.ts
+++ b/packages/logic/server/utils/__tests__/rentacarDataFetch.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { fetchRentacarData, RentacarDataTimeoutError } from '../rentacarDataFetch'
+
+const TABLES = ['vehicle_categories', 'locations', 'rental_companies', 'cities', 'franchises'] as const
+
+function abortError() {
+  return Object.assign(new Error('The operation was aborted'), { name: 'AbortError' })
+}
+
+/**
+ * Fake supabase query builder. Chainable, thenable, records the AbortSignal.
+ * - resolveWith set  -> resolves immediately with that PostgREST-shaped result
+ * - resolveWith unset -> stalls until its AbortSignal aborts, then rejects
+ *   (mirrors real supabase-js: an aborted fetch rejects with AbortError)
+ */
+function makeQuery(resolveWith?: { data: unknown; error: unknown }) {
+  const state: { signal?: AbortSignal } = {}
+  const q: Record<string, unknown> = {}
+  for (const m of ['select', 'eq', 'order', 'single']) q[m] = () => q
+  q.abortSignal = (s: AbortSignal) => {
+    state.signal = s
+    return q
+  }
+  q.then = (resolve: (v: unknown) => void, reject: (e: unknown) => void) => {
+    if (resolveWith) return Promise.resolve(resolveWith).then(resolve, reject)
+    return new Promise((_, rej) => {
+      const sig = state.signal
+      if (!sig) return
+      if (sig.aborted) return rej(abortError())
+      sig.addEventListener('abort', () => rej(abortError()))
+    }).then(resolve, reject)
+  }
+  ;(q as { __state: typeof state }).__state = state
+  return q
+}
+
+function makeSupabase(perTable: Partial<Record<(typeof TABLES)[number], { data: unknown; error: unknown }>>) {
+  const builders = Object.fromEntries(
+    TABLES.map((t) => [t, makeQuery(perTable[t] ?? (t in perTable ? perTable[t] : undefined))]),
+  ) as Record<(typeof TABLES)[number], ReturnType<typeof makeQuery>>
+  return {
+    supabase: { from: (table: string) => builders[table as (typeof TABLES)[number]] } as never,
+    builders,
+  }
+}
+
+const OK = { data: [], error: null }
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('fetchRentacarData', () => {
+  it('SCEN-1: resolves the 5-result tuple and clears the timeout timer (happy path)', async () => {
+    vi.useFakeTimers()
+    const { supabase } = makeSupabase({
+      vehicle_categories: OK,
+      locations: OK,
+      rental_companies: OK,
+      cities: OK,
+      franchises: OK,
+    })
+
+    const results = await fetchRentacarData(supabase, 8000)
+
+    expect(results).toHaveLength(5)
+    expect(vi.getTimerCount()).toBe(0) // timer cleared, no dangling handle
+  })
+
+  it('SCEN-2: aborts all 5 queries and throws RentacarDataTimeoutError when the deadline passes', async () => {
+    vi.useFakeTimers()
+    const { supabase, builders } = makeSupabase({}) // all stall until abort
+
+    const promise = fetchRentacarData(supabase, 8000)
+    const assertion = expect(promise).rejects.toBeInstanceOf(RentacarDataTimeoutError)
+
+    await vi.advanceTimersByTimeAsync(8000)
+    await assertion
+
+    const signals = TABLES.map((t) => builders[t].__state.signal)
+    expect(signals.every((s) => s !== undefined)).toBe(true)
+    expect(new Set(signals).size).toBe(1) // one shared controller signal across all 5
+    expect(signals[0]!.aborted).toBe(true)
+  })
+
+  it('SCEN-3: passes an upstream { error } result through unchanged (no throw, 500 path preserved)', async () => {
+    vi.useFakeTimers()
+    const dbError = { data: null, error: { message: 'Categories query failed' } }
+    const { supabase } = makeSupabase({
+      vehicle_categories: dbError,
+      locations: OK,
+      rental_companies: OK,
+      cities: OK,
+      franchises: OK,
+    })
+
+    const results = await fetchRentacarData(supabase, 8000)
+
+    expect(results[0]).toEqual(dbError)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/packages/logic/server/utils/rentacarDataFetch.ts
+++ b/packages/logic/server/utils/rentacarDataFetch.ts
@@ -1,0 +1,76 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+const DEFAULT_TIMEOUT_MS = 8000
+
+/**
+ * Thrown when the parallel Supabase fetch does not complete within the
+ * deadline. The handler maps this to a 504 instead of letting the request
+ * hang until Nitro's default timeout (relevant on cold cache revalidation
+ * under load — see issue #7, concern #2).
+ */
+export class RentacarDataTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`rentacar-data upstream timeout after ${timeoutMs}ms`)
+    this.name = 'RentacarDataTimeoutError'
+  }
+}
+
+/**
+ * Runs the 5 rentacar-data Supabase queries in parallel with a hard deadline.
+ * A shared AbortController cancels the underlying fetches on timeout so they
+ * stop consuming the connection pool — Promise.race alone would leave them
+ * running. Returns the raw PostgREST results in fixed order; per-result
+ * `.error` interpretation stays in the caller (no behavior change there).
+ */
+export async function fetchRentacarData(supabase: SupabaseClient, timeoutMs: number = DEFAULT_TIMEOUT_MS) {
+  const controller = new AbortController()
+  const signal = controller.signal
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+
+  try {
+    const results = await Promise.all([
+      supabase
+        .from('vehicle_categories')
+        .select('*, category_models(*), category_pricing(*)')
+        .eq('status', 'active')
+        .order('code')
+        .abortSignal(signal),
+
+      supabase
+        .from('locations')
+        .select('id, code, name, city, slug, schedule, status, cities(slug)')
+        .eq('status', 'active')
+        .order('name')
+        .abortSignal(signal),
+
+      supabase
+        .from('rental_companies')
+        .select('extra_driver_day_price, baby_seat_day_price, wash_price, wash_onsite_price, wash_deep_price, wash_deep_upholstery_price')
+        .eq('code', 'localiza')
+        .abortSignal(signal)
+        .single(),
+
+      supabase
+        .from('cities')
+        .select('slug, name, description, testimonials')
+        .eq('status', 'active')
+        .order('name')
+        .abortSignal(signal),
+
+      supabase
+        .from('franchises')
+        .select('code, testimonials')
+        .eq('status', 'active')
+        .order('code')
+        .abortSignal(signal),
+    ])
+
+    if (signal.aborted) throw new RentacarDataTimeoutError(timeoutMs)
+    return results
+  } catch (err) {
+    if (signal.aborted) throw new RentacarDataTimeoutError(timeoutMs)
+    throw err
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/packages/logic/server/utils/supabase.ts
+++ b/packages/logic/server/utils/supabase.ts
@@ -1,5 +1,11 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
+// Module-level singletons. Safe under Nitro single-process workers: one
+// worker = one isolate, so concurrent requests share an already-initialized
+// client and no two inits race. RE-VERIFY before moving to serverless
+// (Vercel Functions, Cloudflare Workers): concurrent cold starts can each
+// run the lazy init, racing the assignment and creating duplicate clients —
+// switch to a per-request client or an init mutex there. (issue #7, concern #3)
 let client: SupabaseClient | null = null
 let adminClient: SupabaseClient | null = null
 


### PR DESCRIPTION
Closes part of #7 (concerns **#2** and **#3**).

## Scope

Agreed quick-wins pass: low risk, no cross-repo coupling.

- **In:** #2 (no timeout on the Supabase `Promise.all`), #3 (undocumented module-level client singletons).
- **Out (intentional):** #1 `category_pricing(*)` temporal filter (data-semantics risk, needs operator validation), #4 cache strategy / tag-based invalidation (overlaps open issue #16, crosses into rentacar-dashboard).

## Why

The `rentacar-data` fan-out grew **3 → 5** parallel queries since the original review (#19 added `cities`, #43 added `franchises`) with no deadline. A hung upstream stalled the request until Nitro's default timeout — worst case on cold cache revalidation under load. Concern #2 got *worse*, not solved, in the ~3 weeks #7 sat open.

## Changes

| File | Change |
|---|---|
| `server/utils/rentacarDataFetch.ts` | **New.** Shared `AbortController` + `.abortSignal()` on all 5 queries + 8s `setTimeout`, `clearTimeout` in `finally`. `RentacarDataTimeoutError`. Cancels in-flight queries (frees the pool) — `Promise.race` alone would leave them running. |
| `server/utils/__tests__/rentacarDataFetch.test.ts` | **New.** SCEN-1 happy + timer cleared, SCEN-2 timeout → abort wired to all 5 + throws, SCEN-3 upstream `{error}` passthrough. |
| `server/api/rentacar-data.get.ts` | Delegates to `fetchRentacarData`; maps `RentacarDataTimeoutError` → **504**. Per-result `.error` (500) checks and transforms unchanged. |
| `server/utils/supabase.ts` | Comment: singleton safe under Nitro single-process; re-verify before any serverless move. |

No JSON contract change for consumers. Only new observable behavior: an upstream stall now returns **504** instead of hanging.

## Verification

- Full `logic` suite: **220/220** pass (35 files, incl. 3 new).
- Touched-file typecheck: **0 errors**. Package's 22 pre-existing errors (issue #18, Nitro auto-import noise) are unrelated.
- SCEN-2 red-green verified: fails when the timeout→504 mapping is removed (SCEN-1/3 stay green), passes when restored.

## Test plan

- [ ] CI green
- [ ] Confirm 8s is the desired ceiling for prod (below Nitro default, above normal cold path)