### PR TITLE
refactor(storage): rename firebase-storage → blob-storage, drop dead getFirebaseApp

### DIFF
--- a/docs/specs/blob-storage-rename/scenarios/blob-storage-rename.scenarios.md
+++ b/docs/specs/blob-storage-rename/scenarios/blob-storage-rename.scenarios.md
@@ -1,0 +1,44 @@
+---
+name: blob-storage-rename
+created_by: pablo-diaz
+created_at: 2026-05-19T00:00:00Z
+---
+
+# Blob storage rename — regression contract
+
+Behavior-preserving refactor. Holdout = existing storage behavior stays
+satisfied AND the rename is complete and clean. Baseline = `origin/main`
+(495d2f0). Project typecheck baseline is red (~1531 errors, cross-brand
+drift) — SCEN-006 uses delta-vs-baseline, never absolute green.
+
+## SCEN-001: storage API unchanged under the new module path
+**Given**: `server/utils/firebase-storage.ts` renamed to `server/utils/blob-storage.ts` in the 3 brand packages
+**When**: the storage unit suite (`server/utils/__tests__/vercel-blob-storage.test.ts`) runs importing from `../blob-storage`
+**Then**: every storage test that passed on baseline still passes; no assertion weakened, skipped, or deleted
+**Evidence**: vitest output for the storage suite — pass count ≥ baseline pass count, same test names
+
+## SCEN-002: no source references the old module name
+**When**: grep `firebase-storage` over `packages/**` excluding `.nuxt/` and `node_modules/`
+**Then**: zero matches — utils, importers, and `vi.mock(...)` paths across all 3 brands all updated
+**Evidence**: `grep -rn 'firebase-storage' packages | grep -v .nuxt | grep -v node_modules` → empty
+
+## SCEN-003: dead Firebase stub removed
+**When**: grep `getFirebaseApp` and `firebaseStorageBucket` over `packages/**` excluding `.nuxt/`/`node_modules/`
+**Then**: zero matches — the throwing `getFirebaseApp()` export and its test mocks are gone
+**Evidence**: grep output → empty
+
+## SCEN-004: blog endpoint suites unaffected
+**Given**: `[slug].delete`, `upload-image.post`, `wordpress-sync.post` tests mocked the storage module
+**When**: those suites run after the rename
+**Then**: pass count ≥ baseline pass count for the same suites (delta-vs-baseline; baseline may be non-green)
+**Evidence**: vitest output, baseline run vs post-change run, side by side
+
+## SCEN-005: out-of-scope artifacts untouched
+**When**: `git diff --name-only origin/main` after the change
+**Then**: the list contains no `firebase.json` and no `.firebaserc` (Firebase Hosting config explicitly out of scope)
+**Evidence**: `git diff --name-only origin/main` output
+
+## SCEN-006: import resolution intact (delta vs baseline)
+**When**: `pnpm --filter ui-alquilatucarro typecheck` after the change
+**Then**: no NEW `TS2307` / module-not-found error referencing the `blob-storage` path; total error count not higher than baseline by any error attributable to the rename
+**Evidence**: typecheck output, baseline vs post-change error count + absence of new blob-storage path errors

--- a/packages/ui-alquicarros/nuxt.config.ts
+++ b/packages/ui-alquicarros/nuxt.config.ts
@@ -577,7 +577,7 @@ export default defineNuxtConfig({
         '/gana',
         '/gana/terminos-condiciones',
         '/gana/politicas-privacidad',
-        // Blog — SSR (not prerendered: content comes from Firebase Storage at runtime)
+        // Blog — SSR (not prerendered: content comes from Vercel Blob at runtime)
       ]
     }
   },

--- a/packages/ui-alquicarros/server/api/blog/debug.get.ts
+++ b/packages/ui-alquicarros/server/api/blog/debug.get.ts
@@ -1,4 +1,4 @@
-import { listFilesInStorage } from '../../utils/firebase-storage'
+import { listFilesInStorage } from '../../utils/blob-storage'
 
 /**
  * GET /api/blog/debug

--- a/packages/ui-alquicarros/server/api/blog/post/[slug].delete.ts
+++ b/packages/ui-alquicarros/server/api/blog/post/[slug].delete.ts
@@ -1,4 +1,4 @@
-import { downloadFromStorage, deleteFromStorage } from '../../../utils/firebase-storage'
+import { downloadFromStorage, deleteFromStorage } from '../../../utils/blob-storage'
 import { invalidateCache } from '../../../plugins/content-dynamic-loader'
 import { logger } from '../../../utils/logger'
 import { BlogApiError, handleBlogApiError } from '../../../utils/error-handler'

--- a/packages/ui-alquicarros/server/api/blog/post/[slug].get.ts
+++ b/packages/ui-alquicarros/server/api/blog/post/[slug].get.ts
@@ -6,7 +6,7 @@ import { handleBlogApiError, BlogApiError } from '../../../utils/error-handler'
 /**
  * GET /api/blog/post/:slug
  *
- * Public endpoint. Serves a single blog post from Firebase Storage cache,
+ * Public endpoint. Serves a single blog post from Vercel Blob cache,
  * parsed as a Nuxt Content-compatible document for ContentRenderer.
  */
 export default defineEventHandler(async (event) => {

--- a/packages/ui-alquicarros/server/api/blog/upload-image.post.ts
+++ b/packages/ui-alquicarros/server/api/blog/upload-image.post.ts
@@ -2,7 +2,7 @@ import { defineEventHandler, readMultipartFormData } from 'h3'
 import sharp from 'sharp'
 import { createHash } from 'crypto'
 import { optimizeImage } from '../../utils/image-optimizer'
-import { uploadToStorage } from '../../utils/firebase-storage'
+import { uploadToStorage } from '../../utils/blob-storage'
 import { logger } from '../../utils/logger'
 import { BlogApiError, handleBlogApiError } from '../../utils/error-handler'
 

--- a/packages/ui-alquicarros/server/api/blog/upload-image.post.ts
+++ b/packages/ui-alquicarros/server/api/blog/upload-image.post.ts
@@ -67,7 +67,7 @@ export default defineEventHandler(async (event) => {
     const filename = `${timestamp}-${hash}.webp`
     const storagePath = `blog-images/${type}/${filename}`
 
-    // Upload to Firebase Storage
+    // Upload to Vercel Blob
     const publicUrl = await uploadToStorage(
       optimizedResult.buffer,
       storagePath,

--- a/packages/ui-alquicarros/server/api/blog/wordpress-sync.post.ts
+++ b/packages/ui-alquicarros/server/api/blog/wordpress-sync.post.ts
@@ -1,6 +1,6 @@
 import { defineEventHandler, readBody } from 'h3'
 import { transformWordPressToNuxt, type WordPressPost } from '../../utils/wordpress-to-nuxt'
-import { uploadToStorage } from '../../utils/firebase-storage'
+import { uploadToStorage } from '../../utils/blob-storage'
 import { logger } from '../../utils/logger'
 import { handleBlogApiError, BlogApiError } from '../../utils/error-handler'
 

--- a/packages/ui-alquicarros/server/api/blog/wordpress-sync.post.ts
+++ b/packages/ui-alquicarros/server/api/blog/wordpress-sync.post.ts
@@ -8,7 +8,7 @@ import { handleBlogApiError, BlogApiError } from '../../utils/error-handler'
  * POST /api/blog/wordpress-sync
  *
  * Receives WordPress REST API payload and transforms it to Nuxt Content format.
- * Stores the result as markdown file in Firebase Storage.
+ * Stores the result as markdown file in Vercel Blob.
  *
  * Request body: WordPress REST API post object
  * Response: { success, filename, path, size }
@@ -40,7 +40,7 @@ export default defineEventHandler(async (event) => {
     const markdownContent = `${nuxtPost.frontmatter}\n\n${nuxtPost.body}`
     const markdownBuffer = Buffer.from(markdownContent, 'utf-8')
 
-    // Upload to Firebase Storage (brand-scoped path)
+    // Upload to Vercel Blob (brand-scoped path)
     const franchise = useRuntimeConfig().public.rentacarFranchise
     const storagePath = `blog-posts/${franchise}/${nuxtPost.slug}.md`
     await uploadToStorage(

--- a/packages/ui-alquicarros/server/plugins/content-dynamic-loader.ts
+++ b/packages/ui-alquicarros/server/plugins/content-dynamic-loader.ts
@@ -1,4 +1,4 @@
-import { downloadFromStorage, listFilesInStorage } from '../utils/firebase-storage'
+import { downloadFromStorage, listFilesInStorage } from '../utils/blob-storage'
 import { logger } from '../utils/logger'
 
 const cache = {

--- a/packages/ui-alquicarros/server/utils/blob-storage.ts
+++ b/packages/ui-alquicarros/server/utils/blob-storage.ts
@@ -1,12 +1,8 @@
 /**
- * Blog storage via Vercel Blob (replaces Firebase Storage stubs)
+ * Blog storage via Vercel Blob
  * Requires BLOB_READ_WRITE_TOKEN env var (auto-set by Vercel Blob integration)
  */
 import { put, del, list, get } from '@vercel/blob'
-
-export function getFirebaseApp() {
-  throw new Error('Firebase Admin is deprecated. Use Vercel Blob for storage.')
-}
 
 export async function uploadToStorage(data: Buffer, path: string, contentType: string): Promise<string> {
   const blob = await put(path, data, {

--- a/packages/ui-alquilame/nuxt.config.ts
+++ b/packages/ui-alquilame/nuxt.config.ts
@@ -576,7 +576,7 @@ export default defineNuxtConfig({
         '/gana',
         '/gana/terminos-condiciones',
         '/gana/politicas-privacidad',
-        // Blog — SSR (not prerendered: content comes from Firebase Storage at runtime)
+        // Blog — SSR (not prerendered: content comes from Vercel Blob at runtime)
       ]
     }
   },

--- a/packages/ui-alquilame/server/api/blog/debug.get.ts
+++ b/packages/ui-alquilame/server/api/blog/debug.get.ts
@@ -1,4 +1,4 @@
-import { listFilesInStorage } from '../../utils/firebase-storage'
+import { listFilesInStorage } from '../../utils/blob-storage'
 
 /**
  * GET /api/blog/debug

--- a/packages/ui-alquilame/server/api/blog/post/[slug].delete.ts
+++ b/packages/ui-alquilame/server/api/blog/post/[slug].delete.ts
@@ -1,4 +1,4 @@
-import { downloadFromStorage, deleteFromStorage } from '../../../utils/firebase-storage'
+import { downloadFromStorage, deleteFromStorage } from '../../../utils/blob-storage'
 import { invalidateCache } from '../../../plugins/content-dynamic-loader'
 import { logger } from '../../../utils/logger'
 import { BlogApiError, handleBlogApiError } from '../../../utils/error-handler'

--- a/packages/ui-alquilame/server/api/blog/post/[slug].get.ts
+++ b/packages/ui-alquilame/server/api/blog/post/[slug].get.ts
@@ -6,7 +6,7 @@ import { handleBlogApiError, BlogApiError } from '../../../utils/error-handler'
 /**
  * GET /api/blog/post/:slug
  *
- * Public endpoint. Serves a single blog post from Firebase Storage cache,
+ * Public endpoint. Serves a single blog post from Vercel Blob cache,
  * parsed as a Nuxt Content-compatible document for ContentRenderer.
  */
 export default defineEventHandler(async (event) => {

--- a/packages/ui-alquilame/server/api/blog/upload-image.post.ts
+++ b/packages/ui-alquilame/server/api/blog/upload-image.post.ts
@@ -2,7 +2,7 @@ import { defineEventHandler, readMultipartFormData } from 'h3'
 import sharp from 'sharp'
 import { createHash } from 'crypto'
 import { optimizeImage } from '../../utils/image-optimizer'
-import { uploadToStorage } from '../../utils/firebase-storage'
+import { uploadToStorage } from '../../utils/blob-storage'
 import { logger } from '../../utils/logger'
 import { BlogApiError, handleBlogApiError } from '../../utils/error-handler'
 

--- a/packages/ui-alquilame/server/api/blog/upload-image.post.ts
+++ b/packages/ui-alquilame/server/api/blog/upload-image.post.ts
@@ -67,7 +67,7 @@ export default defineEventHandler(async (event) => {
     const filename = `${timestamp}-${hash}.webp`
     const storagePath = `blog-images/${type}/${filename}`
 
-    // Upload to Firebase Storage
+    // Upload to Vercel Blob
     const publicUrl = await uploadToStorage(
       optimizedResult.buffer,
       storagePath,

--- a/packages/ui-alquilame/server/api/blog/wordpress-sync.post.ts
+++ b/packages/ui-alquilame/server/api/blog/wordpress-sync.post.ts
@@ -1,6 +1,6 @@
 import { defineEventHandler, readBody } from 'h3'
 import { transformWordPressToNuxt, type WordPressPost } from '../../utils/wordpress-to-nuxt'
-import { uploadToStorage } from '../../utils/firebase-storage'
+import { uploadToStorage } from '../../utils/blob-storage'
 import { logger } from '../../utils/logger'
 import { handleBlogApiError, BlogApiError } from '../../utils/error-handler'
 

--- a/packages/ui-alquilame/server/api/blog/wordpress-sync.post.ts
+++ b/packages/ui-alquilame/server/api/blog/wordpress-sync.post.ts
@@ -8,7 +8,7 @@ import { handleBlogApiError, BlogApiError } from '../../utils/error-handler'
  * POST /api/blog/wordpress-sync
  *
  * Receives WordPress REST API payload and transforms it to Nuxt Content format.
- * Stores the result as markdown file in Firebase Storage.
+ * Stores the result as markdown file in Vercel Blob.
  *
  * Request body: WordPress REST API post object
  * Response: { success, filename, path, size }
@@ -40,7 +40,7 @@ export default defineEventHandler(async (event) => {
     const markdownContent = `${nuxtPost.frontmatter}\n\n${nuxtPost.body}`
     const markdownBuffer = Buffer.from(markdownContent, 'utf-8')
 
-    // Upload to Firebase Storage (brand-scoped path)
+    // Upload to Vercel Blob (brand-scoped path)
     const franchise = useRuntimeConfig().public.rentacarFranchise
     const storagePath = `blog-posts/${franchise}/${nuxtPost.slug}.md`
     await uploadToStorage(

--- a/packages/ui-alquilame/server/plugins/content-dynamic-loader.ts
+++ b/packages/ui-alquilame/server/plugins/content-dynamic-loader.ts
@@ -1,4 +1,4 @@
-import { downloadFromStorage, listFilesInStorage } from '../utils/firebase-storage'
+import { downloadFromStorage, listFilesInStorage } from '../utils/blob-storage'
 import { logger } from '../utils/logger'
 
 const cache = {

--- a/packages/ui-alquilame/server/utils/blob-storage.ts
+++ b/packages/ui-alquilame/server/utils/blob-storage.ts
@@ -1,12 +1,8 @@
 /**
- * Blog storage via Vercel Blob (replaces Firebase Storage stubs)
+ * Blog storage via Vercel Blob
  * Requires BLOB_READ_WRITE_TOKEN env var (auto-set by Vercel Blob integration)
  */
 import { put, del, list, get } from '@vercel/blob'
-
-export function getFirebaseApp() {
-  throw new Error('Firebase Admin is deprecated. Use Vercel Blob for storage.')
-}
 
 export async function uploadToStorage(data: Buffer, path: string, contentType: string): Promise<string> {
   const blob = await put(path, data, {

--- a/packages/ui-alquilatucarro/app/pages/blog/[...slug].vue
+++ b/packages/ui-alquilatucarro/app/pages/blog/[...slug].vue
@@ -372,7 +372,7 @@ const slug = computed(() => {
   return Array.isArray(params) ? params.join('/') : params
 })
 
-// Fetch the blog post from Firebase Storage via API (dynamic posts)
+// Fetch the blog post from Vercel Blob via API (dynamic posts)
 const { data: post } = await useAsyncData(`blog-${slug.value}`, () =>
   $fetch<BlogPost>(`/api/blog/post/${slug.value}`)
     .catch(() => null)

--- a/packages/ui-alquilatucarro/app/pages/blog/index.vue
+++ b/packages/ui-alquilatucarro/app/pages/blog/index.vue
@@ -300,7 +300,7 @@ function clearTag() {
   router.push({ query })
 }
 
-// Query all blog posts from Firebase Storage via API
+// Query all blog posts from Vercel Blob via API
 const { data: allPosts } = await useAsyncData('blog-posts', async () => {
   const result = await $fetch<{ success: boolean; posts: BlogPost[] }>('/api/blog/posts')
   return result?.posts ?? []

--- a/packages/ui-alquilatucarro/nuxt.config.ts
+++ b/packages/ui-alquilatucarro/nuxt.config.ts
@@ -593,7 +593,7 @@ export default defineNuxtConfig({
         '/gana',
         '/gana/terminos-condiciones',
         '/gana/politicas-privacidad',
-        // Blog — SSR (not prerendered: content comes from Firebase Storage at runtime)
+        // Blog — SSR (not prerendered: content comes from Vercel Blob at runtime)
       ]
     }
   },
@@ -625,7 +625,7 @@ export default defineNuxtConfig({
       { loc: '/floridablanca', changefreq: 'monthly', priority: 0.8 },
       { loc: '/palmira', changefreq: 'monthly', priority: 0.8 },
       { loc: '/soledad', changefreq: 'monthly', priority: 0.8 },
-      // Blog — estáticas porque queryCollectionWithEvent falla en Firebase runtime
+      // Blog — estáticas porque queryCollectionWithEvent falla en runtime
       { loc: '/blog', changefreq: 'weekly', priority: 0.8 },
       { loc: '/blog/requisitos-alquilar-carro-colombia', changefreq: 'monthly', priority: 0.7 },
       { loc: '/blog/pico-y-placa-colombia-2026', changefreq: 'monthly', priority: 0.7 },

--- a/packages/ui-alquilatucarro/server/api/blog/__tests__/upload-image.post.test.ts
+++ b/packages/ui-alquilatucarro/server/api/blog/__tests__/upload-image.post.test.ts
@@ -21,7 +21,7 @@ vi.mock('~/server/utils/image-optimizer', () => ({
 }))
 
 // Mock firebase storage
-vi.mock('~/server/utils/firebase-storage', () => ({
+vi.mock('~/server/utils/blob-storage', () => ({
   uploadToStorage: (...args: any[]) => mockUploadToStorage(...args)
 }))
 

--- a/packages/ui-alquilatucarro/server/api/blog/__tests__/wordpress-sync.post.test.ts
+++ b/packages/ui-alquilatucarro/server/api/blog/__tests__/wordpress-sync.post.test.ts
@@ -18,7 +18,7 @@ vi.mock('~/server/utils/wordpress-to-nuxt', () => ({
   transformWordPressToNuxt: vi.fn()
 }))
 
-vi.mock('~/server/utils/firebase-storage', () => ({
+vi.mock('~/server/utils/blob-storage', () => ({
   uploadToStorage: vi.fn()
 }))
 
@@ -73,7 +73,7 @@ vi.stubGlobal('useRuntimeConfig', vi.fn(() => ({
 // Import handler after mocks
 import handler from '../wordpress-sync.post'
 import { transformWordPressToNuxt } from '~/server/utils/wordpress-to-nuxt'
-import { uploadToStorage } from '~/server/utils/firebase-storage'
+import { uploadToStorage } from '~/server/utils/blob-storage'
 import { logger } from '~/server/utils/logger'
 import { handleBlogApiError } from '~/server/utils/error-handler'
 import { readBody } from 'h3'

--- a/packages/ui-alquilatucarro/server/api/blog/debug.get.ts
+++ b/packages/ui-alquilatucarro/server/api/blog/debug.get.ts
@@ -1,4 +1,4 @@
-import { listFilesInStorage } from '../../utils/firebase-storage'
+import { listFilesInStorage } from '../../utils/blob-storage'
 
 /**
  * GET /api/blog/debug

--- a/packages/ui-alquilatucarro/server/api/blog/post/[slug].delete.ts
+++ b/packages/ui-alquilatucarro/server/api/blog/post/[slug].delete.ts
@@ -1,4 +1,4 @@
-import { downloadFromStorage, deleteFromStorage } from '../../../utils/firebase-storage'
+import { downloadFromStorage, deleteFromStorage } from '../../../utils/blob-storage'
 import { invalidateCache } from '../../../plugins/content-dynamic-loader'
 import { logger } from '../../../utils/logger'
 import { BlogApiError, handleBlogApiError } from '../../../utils/error-handler'

--- a/packages/ui-alquilatucarro/server/api/blog/post/[slug].get.ts
+++ b/packages/ui-alquilatucarro/server/api/blog/post/[slug].get.ts
@@ -6,7 +6,7 @@ import { handleBlogApiError, BlogApiError } from '../../../utils/error-handler'
 /**
  * GET /api/blog/post/:slug
  *
- * Public endpoint. Serves a single blog post from Firebase Storage cache,
+ * Public endpoint. Serves a single blog post from Vercel Blob cache,
  * parsed as a Nuxt Content-compatible document for ContentRenderer.
  */
 export default defineEventHandler(async (event) => {

--- a/packages/ui-alquilatucarro/server/api/blog/post/__tests__/[slug].delete.test.ts
+++ b/packages/ui-alquilatucarro/server/api/blog/post/__tests__/[slug].delete.test.ts
@@ -5,18 +5,16 @@ import type { H3Event } from 'h3'
 const mockGetRouterParam = vi.fn()
 const mockDefineEventHandler = vi.fn((handler) => handler)
 const mockUseRuntimeConfig = vi.fn(() => ({
-  public: { rentacarFranchise: 'alquilatucarro' },
-  firebaseStorageBucket: 'test-bucket.appspot.com'
+  public: { rentacarFranchise: 'alquilatucarro' }
 }))
 global.getRouterParam = mockGetRouterParam as any
 global.defineEventHandler = mockDefineEventHandler as any
 global.useRuntimeConfig = mockUseRuntimeConfig as any
 
-// Mock firebase-storage
+// Mock blob-storage
 const mockDownloadFromStorage = vi.fn()
 const mockDeleteFromStorage = vi.fn()
-vi.mock('../../../../utils/firebase-storage', () => ({
-  getFirebaseApp: vi.fn(() => ({})),
+vi.mock('../../../../utils/blob-storage', () => ({
   downloadFromStorage: (...args: any[]) => mockDownloadFromStorage(...args),
   deleteFromStorage: (...args: any[]) => mockDeleteFromStorage(...args),
 }))

--- a/packages/ui-alquilatucarro/server/api/blog/upload-image.post.ts
+++ b/packages/ui-alquilatucarro/server/api/blog/upload-image.post.ts
@@ -2,7 +2,7 @@ import { defineEventHandler, readMultipartFormData } from 'h3'
 import sharp from 'sharp'
 import { createHash } from 'crypto'
 import { optimizeImage } from '../../utils/image-optimizer'
-import { uploadToStorage } from '../../utils/firebase-storage'
+import { uploadToStorage } from '../../utils/blob-storage'
 import { logger } from '../../utils/logger'
 import { BlogApiError, handleBlogApiError } from '../../utils/error-handler'
 

--- a/packages/ui-alquilatucarro/server/api/blog/upload-image.post.ts
+++ b/packages/ui-alquilatucarro/server/api/blog/upload-image.post.ts
@@ -67,7 +67,7 @@ export default defineEventHandler(async (event) => {
     const filename = `${timestamp}-${hash}.webp`
     const storagePath = `blog-images/${type}/${filename}`
 
-    // Upload to Firebase Storage
+    // Upload to Vercel Blob
     const publicUrl = await uploadToStorage(
       optimizedResult.buffer,
       storagePath,

--- a/packages/ui-alquilatucarro/server/api/blog/wordpress-sync.post.ts
+++ b/packages/ui-alquilatucarro/server/api/blog/wordpress-sync.post.ts
@@ -1,6 +1,6 @@
 import { defineEventHandler, readBody } from 'h3'
 import { transformWordPressToNuxt, type WordPressPost } from '../../utils/wordpress-to-nuxt'
-import { uploadToStorage } from '../../utils/firebase-storage'
+import { uploadToStorage } from '../../utils/blob-storage'
 import { logger } from '../../utils/logger'
 import { handleBlogApiError, BlogApiError } from '../../utils/error-handler'
 

--- a/packages/ui-alquilatucarro/server/api/blog/wordpress-sync.post.ts
+++ b/packages/ui-alquilatucarro/server/api/blog/wordpress-sync.post.ts
@@ -8,7 +8,7 @@ import { handleBlogApiError, BlogApiError } from '../../utils/error-handler'
  * POST /api/blog/wordpress-sync
  *
  * Receives WordPress REST API payload and transforms it to Nuxt Content format.
- * Stores the result as markdown file in Firebase Storage.
+ * Stores the result as markdown file in Vercel Blob.
  *
  * Request body: WordPress REST API post object
  * Response: { success, filename, path, size }
@@ -40,7 +40,7 @@ export default defineEventHandler(async (event) => {
     const markdownContent = `${nuxtPost.frontmatter}\n\n${nuxtPost.body}`
     const markdownBuffer = Buffer.from(markdownContent, 'utf-8')
 
-    // Upload to Firebase Storage (brand-scoped path)
+    // Upload to Vercel Blob (brand-scoped path)
     const franchise = useRuntimeConfig().public.rentacarFranchise
     const storagePath = `blog-posts/${franchise}/${nuxtPost.slug}.md`
     await uploadToStorage(

--- a/packages/ui-alquilatucarro/server/middleware/blog-cache-control.ts
+++ b/packages/ui-alquilatucarro/server/middleware/blog-cache-control.ts
@@ -1,7 +1,7 @@
 /**
  * Blog Cache-Control Middleware
  *
- * Blog post pages are SSR'd from Firebase Storage at runtime. Caching them in
+ * Blog post pages are SSR'd from Vercel Blob at runtime. Caching them in
  * the CDN is dangerous: a cold-start failure rendering "Artículo no encontrado"
  * gets cached for 1h, making valid posts inaccessible on every direct URL access.
  *
@@ -11,7 +11,7 @@
 export default defineEventHandler((event) => {
   const path = event.path
 
-  // Individual post pages and their API endpoints — dynamic SSR from Firebase Storage
+  // Individual post pages and their API endpoints — dynamic SSR from Vercel Blob
   if (
     /^\/blog\/.+/.test(path) ||
     /^\/api\/blog\/post\/.+/.test(path)

--- a/packages/ui-alquilatucarro/server/plugins/content-dynamic-loader.ts
+++ b/packages/ui-alquilatucarro/server/plugins/content-dynamic-loader.ts
@@ -1,4 +1,4 @@
-import { downloadFromStorage, listFilesInStorage } from '../utils/firebase-storage'
+import { downloadFromStorage, listFilesInStorage } from '../utils/blob-storage'
 import { logger } from '../utils/logger'
 
 const cache = {

--- a/packages/ui-alquilatucarro/server/utils/__tests__/vercel-blob-storage.test.ts
+++ b/packages/ui-alquilatucarro/server/utils/__tests__/vercel-blob-storage.test.ts
@@ -13,7 +13,7 @@ vi.mock('@vercel/blob', () => ({
   list: (...args: any[]) => mockList(...args),
 }))
 
-describe('Vercel Blob storage (firebase-storage.ts)', () => {
+describe('Vercel Blob storage (blob-storage.ts)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.resetModules()
@@ -26,7 +26,7 @@ describe('Vercel Blob storage (firebase-storage.ts)', () => {
         pathname: 'blog-images/featured/test.webp',
       })
 
-      const { uploadToStorage } = await import('../firebase-storage')
+      const { uploadToStorage } = await import('../blob-storage')
       const buffer = Buffer.from('test image data')
       const result = await uploadToStorage(buffer, 'blog-images/featured/test.webp', 'image/webp')
 
@@ -50,7 +50,7 @@ describe('Vercel Blob storage (firebase-storage.ts)', () => {
       })
       mockGet.mockResolvedValue({ stream, blob: { pathname: 'test.md' } })
 
-      const { downloadFromStorage } = await import('../firebase-storage')
+      const { downloadFromStorage } = await import('../blob-storage')
       const result = await downloadFromStorage('blog-posts/brand/test.md')
 
       expect(result.toString('utf-8')).toBe('# Test markdown')
@@ -60,7 +60,7 @@ describe('Vercel Blob storage (firebase-storage.ts)', () => {
     it('throws when blob not found', async () => {
       mockGet.mockResolvedValue(null)
 
-      const { downloadFromStorage } = await import('../firebase-storage')
+      const { downloadFromStorage } = await import('../blob-storage')
       await expect(downloadFromStorage('nonexistent.md')).rejects.toThrow('Blob not found')
     })
   })
@@ -69,7 +69,7 @@ describe('Vercel Blob storage (firebase-storage.ts)', () => {
     it('deletes by path or URL', async () => {
       mockDel.mockResolvedValue(undefined)
 
-      const { deleteFromStorage } = await import('../firebase-storage')
+      const { deleteFromStorage } = await import('../blob-storage')
       await deleteFromStorage('blog-posts/brand/test.md')
 
       expect(mockDel).toHaveBeenCalledWith('blog-posts/brand/test.md')
@@ -86,7 +86,7 @@ describe('Vercel Blob storage (firebase-storage.ts)', () => {
         hasMore: false,
       })
 
-      const { listFilesInStorage } = await import('../firebase-storage')
+      const { listFilesInStorage } = await import('../blob-storage')
       const result = await listFilesInStorage('blog-posts/brand/')
 
       expect(result).toEqual(['blog-posts/brand/post-1.md', 'blog-posts/brand/post-2.md'])
@@ -105,7 +105,7 @@ describe('Vercel Blob storage (firebase-storage.ts)', () => {
           hasMore: false,
         })
 
-      const { listFilesInStorage } = await import('../firebase-storage')
+      const { listFilesInStorage } = await import('../blob-storage')
       const result = await listFilesInStorage('blog-posts/brand/')
 
       expect(result).toEqual(['blog-posts/brand/post-1.md', 'blog-posts/brand/post-2.md'])
@@ -115,7 +115,7 @@ describe('Vercel Blob storage (firebase-storage.ts)', () => {
     it('returns empty array when no blobs', async () => {
       mockList.mockResolvedValue({ blobs: [], hasMore: false })
 
-      const { listFilesInStorage } = await import('../firebase-storage')
+      const { listFilesInStorage } = await import('../blob-storage')
       const result = await listFilesInStorage('blog-posts/brand/')
 
       expect(result).toEqual([])

--- a/packages/ui-alquilatucarro/server/utils/blob-storage.ts
+++ b/packages/ui-alquilatucarro/server/utils/blob-storage.ts
@@ -1,12 +1,8 @@
 /**
- * Blog storage via Vercel Blob (replaces Firebase Storage stubs)
+ * Blog storage via Vercel Blob
  * Requires BLOB_READ_WRITE_TOKEN env var (auto-set by Vercel Blob integration)
  */
 import { put, del, list, get } from '@vercel/blob'
-
-export function getFirebaseApp() {
-  throw new Error('Firebase Admin is deprecated. Use Vercel Blob for storage.')
-}
 
 export async function uploadToStorage(data: Buffer, path: string, contentType: string): Promise<string> {
   const blob = await put(path, data, {


### PR DESCRIPTION
## Qué

Renombra el util de storage del blog `server/utils/firebase-storage.ts` → `blob-storage.ts` en las 3 marcas y elimina código muerto. El nombre era un leftover de la era Firebase: el módulo es 100% `@vercel/blob`, no hay dependencia `firebase` en ningún `package.json`, y el export `getFirebaseApp()` solo lanzaba y nunca se invocaba en producción.

## Por qué

El nombre mentía sobre el backend real (Vercel Blob) y arrastraba un stub muerto + sus mocks huérfanos. La deriva ya estaba a medias: el archivo de test ya se llamaba `vercel-blob-storage.test.ts` pero importaba de `../firebase-storage`.

## Commits

- `552d194` test(storage): contrato de escenarios (holdout SDD, 6 escenarios)
- `969ed28` refactor(storage): rename + drop `getFirebaseApp()` muerto (3 utils, 15 importers prod, 4 tests alquilatucarro)
- `c63feb4` docs(storage): ~19 comentarios `Firebase Storage` → `Vercel Blob` (solo comentarios)

## Verificación

- Suites storage+blog: `vitest run` → **44/44** (== baseline `origin/main`; estable en múltiples corridas)
- Sin referencias residuales: `grep firebase-storage|getFirebaseApp|firebaseStorageBucket` → vacío (excluyendo `.nuxt/` generado)
- typecheck delta: **640/640** errores, **22/22** TS2307 (sin nuevos errores atribuibles al rename; el ruido del alias `~/` ya existía en baseline)
- Escenarios: **6/6** satisfechos (`docs/specs/blob-storage-rename/scenarios/`)
- Reward hacking: limpio — los diffs de test solo cambian rutas + eliminan 2 líneas de stub muerto, cero asserts modificados

## Quality gate (4 agentes en paralelo)

- Code review: APPROVE · 0 Critical/Important
- Security: 0 High/Medium (sin secrets; `access:'public'` sin cambios; stub eliminado no era control de seguridad)
- Edge case: 0 Critical/High/Medium
- Performance: 0 introducidos (1 pre-existente informativo: `downloadFromStorage` bufferiza el stream completo — diferido, no introducido aquí)

## Fuera de scope (concerns separados, intencionalmente NO tocados)

- `firebase.json` / `.firebaserc` (config Firebase Hosting muerta — requiere confirmar que ningún pipeline los usa antes de borrar)
- Comentarios `Firebase/GCP proxy` en `blog-api-auth.ts` (infra de hosting, no storage)
- `packages/logic/` tests guardando URLs `firebasestorage.googleapis.com` (guard de migración de URLs)
- Descripciones `it()`/`describe()` en tests con la palabra "Firebase" (fast-follow opcional)
