### PR TITLE
fix(rentacar-data): tolerate missing localiza row → extras undefined (#16)

### DIFF
--- a/docs/specs/2026-05-23-issue-16-localiza-fallback/scenarios/localiza-missing-fallback.scenarios.md
+++ b/docs/specs/2026-05-23-issue-16-localiza-fallback/scenarios/localiza-missing-fallback.scenarios.md
@@ -1,0 +1,59 @@
+---
+name: localiza-missing-fallback
+created_by: scenario-driven-development
+created_at: 2026-05-23T00:00:00Z
+issues: ["#16"]
+---
+
+Holdout para Issue #16 Finding 1: el handler `/api/rentacar-data` lanza 500 (crash de
+toda la página vía SCEN-002) cuando la fila `rental_companies` con `code='localiza'`
+falta (PostgREST `PGRST116` en `.single()`), aunque `categories` y `branches` carguen
+bien. Fix: tolerar el error de `companyResult` a nivel API → `extras: undefined`,
+alineado con el contrato `ReservasApiData.extras: ExtrasData | undefined` y los
+fallbacks `?? 12000/20000/...` de `useCategory`. `categories`/`branches`/`cities`/
+`franchises`/`faqs` deben SEGUIR lanzando — esos sí rompen el booking flow.
+
+Alcance: solo Finding 1. Finding 2 (`swr` + shared storage) se consolida en issue #7.
+
+## SCEN-16-1: fila localiza ausente degrada a extras undefined (no crash)
+
+**Given**: `fetchRentacarData` resuelve con un 6-tuple donde `companyResult = { data: null, error: { code: 'PGRST116', message: 'JSON object requested, multiple (or no) rows returned' } }` y los otros 5 results (`categories`, `locations`, `cities`, `franchises`, `faqs`) tienen `data` válida y `error: null`.
+**When**: se invoca el event handler de `packages/logic/server/api/rentacar-data.get.ts`.
+**Then**: el handler NO lanza; retorna un objeto con `extras === undefined`; `categories`, `branches`, `vehicleCategories`, `cities`, `franchiseTestimonials`, `faqs` están poblados desde sus transformers respectivos; `transformExtras` NO es invocado ni una vez.
+**Evidence**: valor de retorno del handler aserteado en test unit (`expect(result.extras).toBeUndefined()`, `expect(result.categories).toBe(<sentinel categorías>)`); spy `transformExtras` con `toHaveBeenCalledTimes(0)`.
+
+## SCEN-16-2: error en categories sigue lanzando 500 (booking-breaking loud)
+
+**Given**: `fetchRentacarData` resuelve con `categoriesResult = { data: null, error: { message: 'boom' } }` (el resto válidos, incluido `companyResult` ok).
+**When**: se invoca el handler.
+**Then**: el handler lanza un error cuyo `statusCode === 500`; el assembly de `extras` nunca se evalúa (la página de disponibilidad rota NO se degrada en silencio).
+**Evidence**: `await expect(handler()).rejects.toMatchObject({ statusCode: 500 })`.
+
+## SCEN-16-3: fila localiza presente transforma extras normal (happy-path regression)
+
+**Given**: `fetchRentacarData` resuelve con `companyResult = { data: { extra_driver_day_price: 15000, baby_seat_day_price: 10000, wash_price: 20000, wash_onsite_price: 30000, wash_deep_price: 150000, wash_deep_upholstery_price: 225000 }, error: null }` (resto válidos).
+**When**: se invoca el handler.
+**Then**: `extras` NO es `undefined`; `extras` es el output de `transformExtras(companyResult.data)`; `transformExtras` es invocado exactamente una vez con la row. Garantiza que fila-con-columnas-NULL (objeto truthy, error null) NUNCA se confunde con fila-ausente (SCEN-007 preservado).
+**Evidence**: `expect(result.extras).toBe(<sentinel transformExtras>)`; spy `transformExtras` con `toHaveBeenCalledTimes(1)` y `toHaveBeenCalledWith(companyResult.data)`.
+
+## SCEN-16-4: cliente renderiza sin $0 cuando extras está ausente (e2e client contract)
+
+**Given**: cualquiera de las 3 marcas en Playwright; `/api/rentacar-data` interceptado y devuelto con un payload donde `extras` está **omitido/undefined** (forma del missing-row, distinta de `extras` con campos null que cubre SCEN-010); usuario navega a `/` y a `/bogota`.
+**When**: la página renderiza (SSR + hidratación).
+**Then**: ambas rutas retornan HTTP 200; no hay console errors que matcheen `[useFetchRentacarData]|Failed to load|Data not loaded`; el markup visible no contiene literal `$0`/`$ 0`.
+**Evidence**: `response.status() === 200`; array de console errors filtrado vacío; `body.innerText` sin match `/\$\s?0(?!\d)/`.
+
+> Cobertura honesta: el route-mock REEMPLAZA la respuesta del servidor, así que SCEN-16-4 NO ejercita el fix server-side. El gate autoritativo del fix es **SCEN-16-1 (unit)**. SCEN-16-4 documenta que el cliente tolera `extras` ausente end-to-end, complementando la cadena SCEN-003 (sentinel) + SCEN-008 (`?? 12000`).
+
+---
+
+## Matriz de no-regresión (scenarios existentes que el fix debe preservar)
+
+| Scenario existente | Preservado porque |
+|---|---|
+| SCEN-001 (build aborta si Supabase down) | `categoriesResult.error` se chequea primero y sigue lanzando 500 |
+| SCEN-002 (plugin re-throws) | sigue re-throw ante error genuino; missing-row pasa a 200 (el fix) |
+| SCEN-003 (sentinel `extras: undefined`) | el fix produce el mismo valor que el sentinel ya usa |
+| SCEN-007 (transformExtras null columns) | fila con nulls = objeto truthy + error null → va a transformExtras |
+| SCEN-008/009 (useCategory `?? default`) | no se toca useCategory ni transformExtras |
+| SCEN-010 (cotización no muestra $0) | cliente ya tolera extras null/undefined via `extras?.` |

--- a/e2e/extras-null-smoke.spec.ts
+++ b/e2e/extras-null-smoke.spec.ts
@@ -70,6 +70,13 @@ const EXTRAS_NULL_FIXTURE = {
   },
 };
 
+// SCEN-16-4 (#16, Finding 1): the rental_companies `localiza` row is ABSENT.
+// The API tolerates the PGRST116 error and returns extras: undefined (the key
+// is simply omitted on the wire — JSON has no `undefined`). This is a DIFFERENT
+// shape from EXTRAS_NULL_FIXTURE (which has `extras` present with null fields).
+// The client must render both identically via useCategory's `extras?.X ?? default`.
+const { extras: _omittedExtras, ...MISSING_EXTRAS_FIXTURE } = EXTRAS_NULL_FIXTURE;
+
 test.describe('Extras NULL smoke (SCEN-010 partial coverage)', () => {
   test.beforeEach(async ({ page }) => {
     await page.route('**/api/rentacar-data', (route) =>
@@ -122,6 +129,57 @@ test.describe('Extras NULL smoke (SCEN-010 partial coverage)', () => {
     // shows literal $0 catches accidental leakage if a future regression
     // wires a non-guarded path.
     await page.goto('/bogota');
+
+    const body = await page.locator('body').innerText();
+    expect(body, 'no leaked $0 prices on page load').not.toMatch(/\$\s?0(?!\d)/);
+  });
+});
+
+test.describe('Extras OMITTED — missing localiza row (SCEN-16-4, #16)', () => {
+  // Server-side fix (extras: undefined instead of 500) is gated by the unit
+  // test packages/logic/server/api/__tests__/rentacar-data.get.test.ts. This
+  // route-mock REPLACES the server response, so it does NOT exercise that fix;
+  // it documents that the CLIENT tolerates an absent `extras` key end-to-end.
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/rentacar-data', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MISSING_EXTRAS_FIXTURE),
+      }),
+    );
+  });
+
+  test('home page loads without console errors when extras are omitted', async ({ page }) => {
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+
+    const response = await page.goto('/');
+
+    expect(response?.status(), 'home returns 200').toBe(200);
+
+    const blocking = consoleErrors.filter(
+      (e) => /\[useFetchRentacarData\]|Failed to load|Data not loaded/.test(e),
+    );
+    expect(blocking, 'no blocking console errors from rentacar-data').toEqual([]);
+  });
+
+  test('city page (/bogota) loads and leaks no "$0" when extras are omitted', async ({ page }) => {
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+
+    const response = await page.goto('/bogota');
+
+    expect(response?.status(), 'city page returns 200').toBe(200);
+
+    const blocking = consoleErrors.filter(
+      (e) => /\[useFetchRentacarData\]|Failed to load|Data not loaded/.test(e),
+    );
+    expect(blocking, 'no blocking console errors from rentacar-data').toEqual([]);
 
     const body = await page.locator('body').innerText();
     expect(body, 'no leaked $0 prices on page load').not.toMatch(/\$\s?0(?!\d)/);

--- a/packages/logic/server/api/__tests__/rentacar-data.get.test.ts
+++ b/packages/logic/server/api/__tests__/rentacar-data.get.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Issue #16 Finding 1 — graceful fallback for a missing `localiza` row.
+//
+// SCEN-16-1: companyResult error (PGRST116, row absent) → handler returns
+//   200 with extras: undefined, other sections populated, transformExtras
+//   NOT called, no throw.
+// SCEN-16-2 (regression guard): categoriesResult error → still throws 500;
+//   booking-breaking failures stay loud. extras never evaluated.
+// SCEN-16-3 (happy-path regression): companyResult ok → transformExtras
+//   runs once on the row; extras is its output (NOT undefined). Guards that
+//   a present row with NULL columns is never confused with an absent row.
+//
+// Holdout: docs/specs/2026-05-23-issue-16-localiza-fallback/scenarios/
+//          localiza-missing-fallback.scenarios.md
+
+vi.mock('../../utils/supabase', () => ({
+  useSupabaseClient: () => ({ __dummy: true }),
+}))
+
+vi.mock('../../utils/rentacarDataFetch', () => ({
+  fetchRentacarData: vi.fn(),
+  RentacarDataTimeoutError: class RentacarDataTimeoutError extends Error {},
+}))
+
+// Transformers stubbed with identifiable sentinels — the handler contract
+// under test is the per-result branching/assembly, not transformer internals
+// (those are covered by transformers.test.ts / SCEN-007). transformExtras is
+// a spy so we can assert called/not-called.
+vi.mock('../../utils/transformers', () => ({
+  transformCategories: vi.fn(() => ['CAT']),
+  transformBranches: vi.fn(() => ['BRANCH']),
+  transformExtras: vi.fn(() => ({ extraDriverDayPrice: 999 })),
+  transformVehicleCategories: vi.fn(() => ({ B: {} })),
+  transformCities: vi.fn(() => ['CITY']),
+  transformFranchiseTestimonials: vi.fn(() => ({ localiza: [] })),
+  transformFAQs: vi.fn(() => ['FAQ']),
+}))
+
+import { fetchRentacarData } from '../../utils/rentacarDataFetch'
+import { transformExtras } from '../../utils/transformers'
+
+type Result = { data: unknown; error: unknown }
+const ok = (data: unknown): Result => ({ data, error: null })
+const errResult = (error: unknown): Result => ({ data: null, error })
+
+// Tuple order matches fetchRentacarData / handler destructuring:
+// [categories, locations, company, cities, franchises, faqs]
+function tuple(over: Partial<Record<0 | 1 | 2 | 3 | 4 | 5, Result>> = {}): Result[] {
+  const base: Result[] = [
+    ok([{ id: 'B' }]),
+    ok([{ code: 'BOG' }]),
+    ok({ extra_driver_day_price: 15000 }),
+    ok([{ slug: 'bogota' }]),
+    ok([{ code: 'localiza' }]),
+    ok([{ label: 'q' }]),
+  ]
+  for (const [i, v] of Object.entries(over)) base[Number(i)] = v as Result
+  return base
+}
+
+describe('server/api/rentacar-data.get — missing localiza fallback (#16)', () => {
+  let handler: () => Promise<Record<string, unknown>>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.stubGlobal('defineCachedEventHandler', (fn: unknown) => fn)
+    vi.stubGlobal('createError', (opts: { message?: string; statusMessage?: string }) =>
+      Object.assign(new Error(opts?.message ?? opts?.statusMessage ?? 'error'), opts),
+    )
+    handler = (await import('../rentacar-data.get')).default as unknown as typeof handler
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('SCEN-16-1: missing localiza row (PGRST116) → extras undefined, no throw, transformExtras not called', async () => {
+    vi.mocked(fetchRentacarData).mockResolvedValue(
+      tuple({ 2: errResult({ code: 'PGRST116', message: 'JSON object requested, multiple (or no) rows returned' }) }) as never,
+    )
+
+    const result = await handler()
+
+    expect(result.extras).toBeUndefined()
+    expect(result.categories).toEqual(['CAT'])
+    expect(result.branches).toEqual(['BRANCH'])
+    expect(result.vehicleCategories).toEqual({ B: {} })
+    expect(result.cities).toEqual(['CITY'])
+    expect(result.franchiseTestimonials).toEqual({ localiza: [] })
+    expect(result.faqs).toEqual(['FAQ'])
+    expect(vi.mocked(transformExtras)).not.toHaveBeenCalled()
+  })
+
+  it('SCEN-16-2: categories error → throws statusCode 500; extras never evaluated', async () => {
+    vi.mocked(fetchRentacarData).mockResolvedValue(
+      tuple({ 0: errResult({ message: 'boom' }) }) as never,
+    )
+
+    await expect(handler()).rejects.toMatchObject({ statusCode: 500 })
+    expect(vi.mocked(transformExtras)).not.toHaveBeenCalled()
+  })
+
+  // Regression lock (code-reviewer suggestion): every booking-breaking query
+  // (all results EXCEPT companyResult) must keep throwing 500. categories is
+  // covered by SCEN-16-2; this pins the remaining four so a future edit can't
+  // accidentally extend the localiza tolerance to them.
+  it.each([
+    ['locations', 1],
+    ['cities', 3],
+    ['franchises', 4],
+    ['faqs', 5],
+  ] as const)('regression: %s query error still throws 500', async (_label, idx) => {
+    vi.mocked(fetchRentacarData).mockResolvedValue(
+      tuple({ [idx]: errResult({ message: 'boom' }) }) as never,
+    )
+    await expect(handler()).rejects.toMatchObject({ statusCode: 500 })
+  })
+
+  it('SCEN-16-3: present localiza row → extras = transformExtras(row), called once', async () => {
+    const companyRow = {
+      extra_driver_day_price: 15000,
+      baby_seat_day_price: 10000,
+      wash_price: 20000,
+      wash_onsite_price: 30000,
+      wash_deep_price: 150000,
+      wash_deep_upholstery_price: 225000,
+    }
+    vi.mocked(fetchRentacarData).mockResolvedValue(tuple({ 2: ok(companyRow) }) as never)
+
+    const result = await handler()
+
+    expect(result.extras).toEqual({ extraDriverDayPrice: 999 })
+    expect(vi.mocked(transformExtras)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(transformExtras)).toHaveBeenCalledWith(companyRow)
+  })
+})

--- a/packages/logic/server/api/rentacar-data.get.ts
+++ b/packages/logic/server/api/rentacar-data.get.ts
@@ -23,9 +23,13 @@ export default defineCachedEventHandler(async () => {
   if (locationsResult.error) {
     throw createError({ statusCode: 500, message: `Locations query failed: ${locationsResult.error.message}` })
   }
-  if (companyResult.error) {
-    throw createError({ statusCode: 500, message: `Rental company query failed: ${companyResult.error.message}` })
-  }
+  // A missing `localiza` row (PGRST116 from .single()) must NOT crash the
+  // page: extras fall back client-side (useCategory `?? 12000`). PGRST116 here
+  // means zero rows or a transient failure only — never a duplicate, since
+  // rental_companies.code is UNIQUE — so tolerating companyResult.error cannot
+  // silently mask an integrity violation. Categories/branches/cities/
+  // franchises/faqs errors keep throwing — those break the booking flow.
+  // See issue #16, Finding 1.
   if (citiesResult.error) {
     throw createError({ statusCode: 500, message: `Cities query failed: ${citiesResult.error.message}` })
   }
@@ -39,7 +43,9 @@ export default defineCachedEventHandler(async () => {
   return {
     categories: transformCategories(categoriesResult.data),
     branches: transformBranches(locationsResult.data),
-    extras: transformExtras(companyResult.data),
+    extras: companyResult.error || !companyResult.data
+      ? undefined
+      : transformExtras(companyResult.data),
     vehicleCategories: transformVehicleCategories(categoriesResult.data),
     cities: transformCities(citiesResult.data),
     franchiseTestimonials: transformFranchiseTestimonials(franchisesResult.data),


### PR DESCRIPTION
## Summary
Resolves **Finding 1 of #16**. The `/api/rentacar-data` handler threw HTTP 500 when the `rental_companies` row keyed `code='localiza'` was absent (PGRST116 from `.single()`), which crashed the entire page render via the plugin re-throw — even when categories/branches loaded fine. The client already defaults extras (`useCategory` `?? 12000`) and the type is `extras: ExtrasData | undefined`, but those paths were unreachable.

- Handler now degrades `companyResult` errors to `extras: undefined` instead of throwing.
- The other five queries (categories, locations, cities, franchises, faqs) **keep throwing 500** — those break the booking flow.
- PGRST116 here can only mean zero rows or a transient failure: `rental_companies.code` is `UNIQUE` (verified against the live schema), so there is no duplicate-row case to mask.

**Finding 2** of #16 (`swr` + shared storage) is **not** included here — it overlaps the still-open #7 (same cache-strategy TODO) and should be consolidated there. The timeout sub-concern was already shipped via #7.

## Scenarios (holdout, committed before implementation)
`docs/specs/2026-05-23-issue-16-localiza-fallback/scenarios/localiza-missing-fallback.scenarios.md`
- SCEN-16-1 (unit): missing row → `extras: undefined`, no throw, `transformExtras` not called
- SCEN-16-2 (unit): categories error → still throws 500
- SCEN-16-3 (unit): present row → `transformExtras` runs (guards the NULL-columns case, SCEN-007)
- SCEN-16-4 (e2e): client renders with `extras` omitted, no `$0`, no console errors

## Test plan
- [x] `pnpm --filter @rentacar-main/logic exec vitest run server/api/__tests__/rentacar-data.get.test.ts` → 7/7 pass
- [x] TDD red→green verified (SCEN-16-1 failed pre-fix, passes post-fix)
- [x] Full logic suite → 227 pass (1 pre-existing failure: `@pinia/testing` not installed, unrelated — `useStoreAdminData.test.ts`)
- [x] `BRAND=alquilatucarro playwright test --project=chromium -g "SCEN-16-4"` → 2/2 pass
- [x] No new type errors in `rentacar-data.get.ts`
- [ ] Reviewer: confirm `@pinia/testing` install gap is tracked separately (out of scope here)

## Coverage honesty
The e2e route-mock replaces the server response, so it does **not** exercise the server-side fix — that is gated by the unit test. The e2e documents that the client tolerates an absent `extras` key end-to-end.