### PR TITLE
fix(prerender): widen retry window for build-time deploy resilience

### DIFF
--- a/docs/specs/2026-05-23-prerender-retry-resilience/scenarios/prerender-retry.scenarios.md
+++ b/docs/specs/2026-05-23-prerender-retry-resilience/scenarios/prerender-retry.scenarios.md
@@ -1,0 +1,31 @@
+---
+name: prerender-retry-resilience
+created_by: scenario-driven-development
+created_at: 2026-05-23T00:00:00Z
+issues: ["deploy-flakiness"]
+---
+
+Resiliencia ante fallos transitorios de build. Diagnóstico (2026-05-23): los deploys de
+Vercel fallan **intermitentemente** porque el prerender SERIAL de Nitro (concurrency=1)
+corre `/api/rentacar-data` por ruta; si hay un hiccup transitorio (red build↔Supabase,
+flake puntual) el fetch falla → el plugin re-lanza por diseño (fail-loud, issue #2) → ruta
+500 → tras `retry:3`/`retryDelay:500ms` (ventana ~1.5s, demasiado corta) → "Exiting due to
+prerender errors" → deploy ERROR. Supabase de prod está sana (Pro, ACTIVE_HEALTHY, sin
+errores en logs). Fix build-scoped: ampliar la ventana de reintentos del prerender para
+tolerar un blip de varios segundos. NO se toca el fetch (evitar colgar requests de runtime).
+
+## SCEN-PR-1: el prerender tolera un blip transitorio ampliando la ventana de reintentos
+
+**Given**: las 3 marcas (`ui-alquilatucarro`, `ui-alquilame`, `ui-alquicarros`) con su `nitro.prerender` en `nuxt.config.ts`.
+**When**: se inspecciona la config efectiva de prerender de cada marca.
+**Then**: cada marca declara `retry` ≥ 5 y `retryDelay` ≥ 3000 (ms) dentro de `nitro.prerender` — ampliando la ventana de recuperación de ~1.5s (default 3×500ms) a ≥15s, suficiente para un blip transitorio de varios segundos. Los valores son byte-idénticos entre las 3 marcas.
+**Evidence**: lectura fs de los 3 `nuxt.config.ts`; aserción de que `retry`/`retryDelay` están presentes con los valores acotados; diff byte-idéntico entre marcas.
+
+## SCEN-PR-2: el cambio no rompe el build
+
+**Given**: una marca con la nueva config de prerender.
+**When**: corre `nuxt build` con datos disponibles (ventana sana).
+**Then**: el build completa (exit 0), prerenderiza las rutas y no introduce errores nuevos; el comportamiento en ventana sana es idéntico (los reintentos solo actúan ante fallo).
+**Evidence**: exit code 0 de `pnpm build:<marca>`; ausencia de "Exiting due to prerender errors" en ventana sana.
+
+> Nota de satisfacción honesta: el efecto real (menos deploys fallidos) es **operacional/empírico** y no se puede forzar en un build unitario (no hay forma determinística de inyectar el blip transitorio). SCEN-PR-1 fija la intención (config acotada, anti-regresión, patrón fs como `image-cost-config.test.ts`); SCEN-PR-2 garantiza no-regresión del build sano. El fix de fondo del stampede/SWR sigue siendo issue #16-F2/#7 (fuera de alcance aquí).

--- a/packages/logic/tests/prerender-retry-config.test.ts
+++ b/packages/logic/tests/prerender-retry-config.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Deploy resilience (SCEN-PR-1): each brand's `nitro.prerender` must widen the
+ * retry window so a transient build-time blip is retried instead of hard-
+ * aborting the deploy. Default `retry:3` / `retryDelay:500ms` (~1.5s window) is
+ * too short for a multi-second Supabase/network blip during prerender; the
+ * serial prerender + fail-loud plugin (#2) turns any such hiccup into a
+ * deployment ERROR. See docs/specs/2026-05-23-prerender-retry-resilience/.
+ *
+ * fs-based + deterministic (matches nuxt-config-hygiene.test.ts pattern).
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const BRANDS = ['alquilatucarro', 'alquilame', 'alquicarros'] as const
+const MIN_RETRY = 5
+const MIN_RETRY_DELAY_MS = 3000
+
+function readBrandConfig(brand: string): string {
+  return readFileSync(join(__dirname, '..', '..', `ui-${brand}`, 'nuxt.config.ts'), 'utf-8')
+}
+
+// The prerender block sits near `prerender:`; grab a generous window after it.
+// retry/retryDelay are authored at the top of the block (before the long
+// routes[] array), well within this slice.
+function prerenderBlock(content: string): string {
+  const idx = content.indexOf('prerender:')
+  if (idx === -1) return ''
+  return content.slice(idx, idx + 1500)
+}
+
+function numIn(re: RegExp, block: string): number | null {
+  const m = block.match(re)
+  return m ? Number(m[1]) : null
+}
+
+const RETRY_RE = /\bretry:\s*(\d+)/
+const RETRY_DELAY_RE = /\bretryDelay:\s*(\d+)/
+
+describe('nitro.prerender retry resilience (SCEN-PR-1)', () => {
+  for (const brand of BRANDS) {
+    it(`${brand}: prerender.retry >= ${MIN_RETRY} and retryDelay >= ${MIN_RETRY_DELAY_MS}ms`, () => {
+      const block = prerenderBlock(readBrandConfig(brand))
+      expect(block, `${brand} has a prerender block`).not.toBe('')
+      const retry = numIn(RETRY_RE, block)
+      const retryDelay = numIn(RETRY_DELAY_RE, block)
+      expect(retry, `${brand} prerender.retry is set`).not.toBeNull()
+      expect(retryDelay, `${brand} prerender.retryDelay is set`).not.toBeNull()
+      expect(retry as number).toBeGreaterThanOrEqual(MIN_RETRY)
+      expect(retryDelay as number).toBeGreaterThanOrEqual(MIN_RETRY_DELAY_MS)
+    })
+  }
+
+  it('retry/retryDelay are byte-identical across all 3 brands', () => {
+    const vals = BRANDS.map((b) => {
+      const block = prerenderBlock(readBrandConfig(b))
+      return `${numIn(RETRY_RE, block)}|${numIn(RETRY_DELAY_RE, block)}`
+    })
+    expect(new Set(vals).size, `per-brand values: ${vals.join('  ,  ')}`).toBe(1)
+  })
+})

--- a/packages/ui-alquicarros/nuxt.config.ts
+++ b/packages/ui-alquicarros/nuxt.config.ts
@@ -574,6 +574,12 @@ export default defineNuxtConfig({
       '/soledad': { isr: 3600 },
     },
     prerender: {
+      // Deploy resilience: widen the retry window so a transient build-time
+      // blip (network build↔Supabase) is retried instead of hard-aborting the
+      // deploy. Serial prerender + fail-loud plugin (#2) otherwise turns any
+      // hiccup into a deployment ERROR. Default 3×500ms (~1.5s) → 5×3s (~15s).
+      retry: 5,
+      retryDelay: 3000,
       routes: [
         '/',
         '/armenia',

--- a/packages/ui-alquilame/nuxt.config.ts
+++ b/packages/ui-alquilame/nuxt.config.ts
@@ -573,6 +573,12 @@ export default defineNuxtConfig({
       '/soledad': { isr: 3600 },
     },
     prerender: {
+      // Deploy resilience: widen the retry window so a transient build-time
+      // blip (network build↔Supabase) is retried instead of hard-aborting the
+      // deploy. Serial prerender + fail-loud plugin (#2) otherwise turns any
+      // hiccup into a deployment ERROR. Default 3×500ms (~1.5s) → 5×3s (~15s).
+      retry: 5,
+      retryDelay: 3000,
       routes: [
         '/',
         '/armenia',

--- a/packages/ui-alquilatucarro/nuxt.config.ts
+++ b/packages/ui-alquilatucarro/nuxt.config.ts
@@ -590,6 +590,12 @@ export default defineNuxtConfig({
       '/-coche-en-espana/': { redirect: '/', statusCode: 301 },
     },
     prerender: {
+      // Deploy resilience: widen the retry window so a transient build-time
+      // blip (network build↔Supabase) is retried instead of hard-aborting the
+      // deploy. Serial prerender + fail-loud plugin (#2) otherwise turns any
+      // hiccup into a deployment ERROR. Default 3×500ms (~1.5s) → 5×3s (~15s).
+      retry: 5,
+      retryDelay: 3000,
       routes: [
         '/',
         '/armenia',


### PR DESCRIPTION
## Summary
Mitigates the **intermittent Vercel deploy failures** ("Exiting due to prerender errors").

**Root cause (diagnosed this session):** Nitro prerender is **serial** (`concurrency: 1`) and renders `/api/rentacar-data` per route. A transient build↔Supabase blip fails the fetch → the plugin re-throws by design (fail-loud, #2) → route 500 → after the default `retry: 3` / `retryDelay: 500ms` (~1.5s window) → the build aborts → deployment ERROR. The Supabase prod project (`rentacar-dashboard`) is **healthy** — Pro plan (no auto-pause), ACTIVE_HEALTHY, zero error logs — so this is a transient timing window, **not** a code/PR/env-target bug. Confirmed not caused by any specific PR: `main`'s own production deploy of #58 failed with the identical signature.

**Fix (build-scoped, no runtime impact):** set `nitro.prerender { retry: 5, retryDelay: 3000 }` in all 3 brands, widening the recovery window from ~1.5s to ~15s so a brief blip is retried instead of aborting the whole deploy. The fetch path is intentionally **not** touched (adding retries there would risk hanging runtime requests up to N×8s and overlaps #7).

This is **resilience mitigation**, not the root fix of the cold-fetch fragility — that remains issue #16 Finding 2 / #7 (request collapsing + SWR on `defineCachedEventHandler`).

## Scenarios
`docs/specs/2026-05-23-prerender-retry-resilience/scenarios/prerender-retry.scenarios.md`
- SCEN-PR-1: each brand sets `retry ≥ 5` and `retryDelay ≥ 3000ms`, byte-identical across brands.
- SCEN-PR-2: build still completes; Nitro accepts the options.

## Test plan
- [x] `pnpm --filter @rentacar-main/logic exec vitest run tests/prerender-retry-config.test.ts` → 4/4 (TDD red→green verified)
- [x] Full logic suite → 224 pass (1 pre-existing failure: `@pinia/testing` not installed — unrelated)
- [x] `nuxt build` alquilatucarro with new config → exit 0, "Build complete", 0 prerender errors, options accepted (verified against nitropack 2.12.9 `PrerenderOptions` types)

## Coverage honesty
The real effect (fewer intermittent deploy failures) is operational/empirical and can't be forced in a unit build — there is no deterministic way to inject the transient blip. The config test locks the intent (anti-regression, fs-based like `image-cost-config.test.ts`); the build proves no regression. Immediate unblock for a stuck deploy remains a **redeploy**.