### PR TITLE
feat(rentacar-data): bounded transient retry in fetchRentacarData (#7, #16)

### DIFF
--- a/docs/specs/2026-05-25-rentacar-data-transient-retry-design.md
+++ b/docs/specs/2026-05-25-rentacar-data-transient-retry-design.md
@@ -173,6 +173,29 @@ El cambio vive solo en `packages/logic/server/utils/`. Las 3 marcas lo heredan v
 | **#59 / PGRST116** (fila localiza ausente) | `code: 'PGRST116'` → NO-recuperable → 1 corrida, sin reintento ni enmascaramiento; handler/#59 lo manejan como hoy. |
 | **#7 / #53** (timeout → 504) | `RentacarDataTimeoutError` sigue propagándose tras agotar intentos → handler 504. |
 
+## Blast radius y regresiones (verificado)
+
+Superficie total de `rentacarDataFetch.ts` en todo el repo (sin `node_modules`/`.nuxt`):
+
+| Consumidor | Uso | Impacto del cambio |
+|---|---|---|
+| `server/api/rentacar-data.get.ts` (único de producción) | `fetchRentacarData(supabase)` sin 2º arg + `instanceof RentacarDataTimeoutError` | **Seguro.** La firma nueva es backward-compatible (opciones con default). El `.catch` sigue funcionando: el retry solo lanza `RentacarDataTimeoutError` (timeout agotado) o retorna la tupla (con `.error` → el handler hace 500). No introduce tipos de throw nuevos. |
+| `__tests__/rentacarDataFetch.test.ts` | 3× `fetchRentacarData(supabase, 8000)` posicional | **Rompe — esperado.** Es la migración requerida (a `{ timeoutMs: 8000, retries: 0 }`); SCEN-R6 lo blinda. |
+| e2e, otras marcas, otros paquetes | ninguna referencia | Sin impacto. |
+
+Issues que implementaron este archivo y cómo se preservan:
+
+| Issue | Qué aportó | Preservación |
+|---|---|---|
+| **#7 / #53** (`dde5f51`) | creó `fetchRentacarData` + `RentacarDataTimeoutError` + timeout 8s/AbortController | `runBatch` conserva el timeout; `RentacarDataTimeoutError` sigue propagándose → 504 (SCEN-R4). |
+| **#12** (`6dd6808`) | agregó la query `faqs` (6ª query) | Las 6 queries quedan intactas dentro de `runBatch`, mismo orden y tupla. |
+| **#2 / #3 / #4** (bundled resilience) | plugin fail-loud, sentinel, `transformExtras` | Plugin/handler/transformers no se tocan; SCEN-001/002/007 intactos. |
+
+Interacción con PRs abiertos/cerrados:
+
+- **PR #59** (#16-F1, OPEN): NO toca este archivo — modifica el handler y su test **mockea el módulo entero** (`vi.mock('../../utils/rentacarDataFetch')`). Cero overlap de archivos → cero conflicto de merge; su test no ejercita mi retry, mi cambio no rompe su test. **Sinergia:** PGRST116 (fila ausente) → mi clasificador lo marca no-recuperable → 1 corrida → el handler de #59 degrada a `extras: undefined` sin que el retry agregue latencia.
+- **PR #60** (`fix/prerender-retry-resilience`, CLOSED, no mergeado): solo tocó los 3 `nuxt.config.ts` + un test de config. No toca este archivo ni se mergeó. Sin interacción.
+
 ## Escenarios observables (puente a SDD)
 
 Todos a nivel **unit sobre la util** (`fetchRentacarData` / `isRetryableResult`); la traducción a 5xx ocurre en el handler y se asume por contrato (sin cambio). El mock de supabase cuenta cuántas veces corre el batch.

--- a/docs/specs/2026-05-25-rentacar-data-transient-retry-design.md
+++ b/docs/specs/2026-05-25-rentacar-data-transient-retry-design.md
@@ -94,31 +94,28 @@ Descartado: retry en `$fetch` del plugin (`retryStatusCodes` de ofetch). Más si
    )
    ```
 
-   Lógica (pseudocódigo):
+   Lógica (pseudocódigo) — refinada tras Quality Integration (ver §Refinamiento):
 
    ```
    lastResults = undefined
    for attempt in 0..retries:                       # retries=2 → attempts 0,1,2
-     try:
-       results = await runBatch(supabase, timeoutMs)
-       transient = results.find(isRetryableResult)
-       if not transient: return results             # éxito, o .error NO-recuperable → decide el handler
-       lastResults = results                         # .error transitorio → reintentar
-       logRetry(attempt, retries, transient.error)
-     catch err:                                      # solo path de throw real = RentacarDataTimeoutError (timeout)
-       logRetry(attempt, retries, err)
-       if attempt == retries: throw err              # agotado → propaga (handler → 504)
-       await sleep(retryDelayMs * 2**attempt); continue
-     if attempt < retries: await sleep(retryDelayMs * 2**attempt)   # backoff 300ms, 600ms
-   return lastResults                                # agotado con .error transitorio → handler lanza 500
+     results = await runBatch(supabase, timeoutMs)  # un timeout LANZA aquí, sin reintentar → 504
+     errored = results.filter(r => r.error)
+     shouldRetry = errored.length > 0 AND errored.every(isRetryableResult)
+     if not shouldRetry OR attempt == retries: return results
+     lastResults = results
+     logRetry(attempt, retries, errored[0].error)
+     await sleep(retryDelayMs * 2**attempt)         # backoff 300ms, 600ms
+   return lastResults                                # inalcanzable salvo retries<0; el `as` satisface TS
    ```
 
-   Trazas de las 5 rutas (verificadas):
+   Trazas (verificadas por SCEN-R1..R7):
    - **éxito en intento 0** → `return results`.
-   - **transitorio que recupera** (intento 0 `.error`, intento 1 ok) → reintenta, luego `return results`.
-   - **transitorio que agota** (3× `.error`) → cae a `return lastResults` (con `.error`) → handler 500. Nunca `undefined`: `lastResults` quedó asignado en cada iteración con transitorio.
-   - **timeout que agota** (3× throw) → en el último intento `throw err` → handler 504.
-   - **`.error` NO-recuperable** (PGRST116) → `transient` undefined → `return results` en 1 corrida.
+   - **transitorio que recupera** (intento 0 `.error`, intento 1 ok) → reintenta, luego `return results`. (R1)
+   - **transitorio que agota** (3× `.error`) → en el último intento `attempt == retries` → `return results` (con `.error`) → handler 500. (R2)
+   - **`.error` NO-recuperable solo** (PGRST116) → `shouldRetry` false → `return results` en 1 corrida. (R3)
+   - **timeout** → `runBatch` lanza `RentacarDataTimeoutError` → propaga inmediato, 1 corrida → handler 504. (R4)
+   - **permanente + transitorio mezclados** → `every(isRetryableResult)` false → `return results` en 1 corrida → handler 500. (R7)
 
 3. **Clasificador** `isRetryableResult(result)` (exportado para test unitario). Recibe el resultado COMPLETO (no solo `.error`), porque el `status` vive en el wrapper:
 
@@ -148,7 +145,9 @@ Descartado: retry en `$fetch` del plugin (`retryStatusCodes` de ofetch). Más si
 
 - `retries = 2` (3 intentos), backoff exponencial `300ms, 600ms`.
 - Blip que recupera en el intento 2: +~300ms al build. Despreciable.
-- Outage real: ~3 intentos (hasta 8s c/u si es por timeout) → falla fuerte. Aceptable porque de todos modos aborta.
+- Outage real:
+  - si falla rápido (`.error` de red, el caso del bug): 3 intentos + ~0.9s de backoff → falla fuerte.
+  - si es por **timeout**: NO se reintenta → falla en ~8s (1 intento), preservando el bound de #7 (ver §Refinamiento).
 - Parámetros configurables vía `FetchOptions` para tests deterministas (`retryDelayMs: 0`, `retries: 0`).
 
 ### Migración de los tests existentes (REQUERIDA, no opcional)
@@ -218,11 +217,17 @@ Todos a nivel **unit sobre la util** (`fetchRentacarData` / `isRetryableResult`)
   **Then** NO reintenta: el batch corre exactamente 1 vez; retorna inmediato con el `.error` intacto.
   **Evidence**: contador = 1; `isRetryableResult({ error: { code: 'PGRST116' }, status: 406 })` === `false`.
 
-- **SCEN-R4** (unit) — *timeout sigue → throw → 504*
-  **Given** un `supabase` cuyo batch excede `timeoutMs` (abort) en todos los intentos.
-  **When** `fetchRentacarData(supabase, { timeoutMs: 10, retries: 2, retryDelayMs: 0 })` con timers avanzados.
-  **Then** lanza `RentacarDataTimeoutError` tras agotar intentos (el handler lo mapea a 504).
-  **Evidence**: `await expect(...).rejects.toBeInstanceOf(RentacarDataTimeoutError)`.
+- **SCEN-R4** (unit) — *timeout lanza inmediato, NO reintentado → 504* (refinado tras Quality Integration)
+  **Given** un `supabase` cuyo batch excede `timeoutMs` (abort).
+  **When** `fetchRentacarData(supabase, { timeoutMs: 5, retries: 2, retryDelayMs: 0 })`.
+  **Then** lanza `RentacarDataTimeoutError` en el primer intento, sin reintentar; 1 corrida; el handler lo mapea a 504.
+  **Evidence**: `await expect(...).rejects.toBeInstanceOf(RentacarDataTimeoutError)`; contador = 1.
+
+- **SCEN-R7** (unit) — *permanente mezclado con transitorio NO se reintenta* (añadido tras Quality Integration)
+  **Given** un batch con un `.error` permanente (`code: 'PGRST205'`, `status: 404`) en una tabla y uno transitorio (`code: ''`, `status: 0`) en otra.
+  **When** `fetchRentacarData(supabase, { retries: 2, retryDelayMs: 0 })`.
+  **Then** NO reintenta (reintentar no arregla el permanente); 1 corrida; retorna con `.error` → handler 500.
+  **Evidence**: contador = 1; `results.some(r => r.error)` === true.
 
 - **SCEN-R5** (clasificador, tabla) — *fixtures con el shape real del resultado* `{ error, status }`, NO con `code`/`status` top-level (si no hay `.error`, el early-return lo daría `false` por el motivo equivocado y no ejercitaría la rama PGRST/4xx).
   **Given/When/Then** `isRetryableResult` retorna:
@@ -242,12 +247,20 @@ Todos a nivel **unit sobre la util** (`fetchRentacarData` / `isRetryableResult`)
 
 | Escenario | Layer | Archivo | Comando de evidencia |
 |---|---|---|---|
-| SCEN-R1..R6 | Vitest unit | `packages/logic/server/utils/__tests__/rentacarDataFetch.test.ts` (extender) | `pnpm --filter @rentacar-main/logic exec vitest run rentacarDataFetch` (resuelve `packages/logic/vitest.config.ts`; mismo patrón que el PR #59) |
+| SCEN-R1..R7 | Vitest unit | `packages/logic/server/utils/__tests__/rentacarDataFetch.test.ts` (extender) | `pnpm --filter @rentacar-main/logic exec vitest run rentacarDataFetch` (resuelve `packages/logic/vitest.config.ts`; mismo patrón que el PR #59) |
 | SCEN-001 (manual) | build | — | `pnpm build:alquilatucarro` con `NUXT_SUPABASE_URL` inválido → exit≠0 (sin cambio respecto a hoy) |
+
+## Refinamiento post Quality Integration
+
+Tras los agentes de calidad (code-reviewer aprobó sin Critical/Important), se adoptaron 2 mejoras MEDIUM, ambas alineadas con "retry solo transitorio":
+
+1. **Timeouts NO se reintentan.** El bug real falla rápido (`/` cayó a 1745ms, muy por debajo de los 8s), así que se manifiesta como `.error` de red, no como timeout. Reintentar un timeout no aporta y multiplicaría la cola a ~27s en runtime, erosionando el bound de 8s que añadió #7. Ahora `RentacarDataTimeoutError` propaga inmediato → 504. (amend de SCEN-R4)
+2. **Bail ante error permanente mezclado.** Solo se reintenta si TODO error en el batch es transitorio (`errored.every(isRetryableResult)`); si hay un permanente (PGRST*/4xx) junto a un transitorio, retornar de inmediato — reintentar no lo arregla y solo demora el fallo fuerte. (nuevo SCEN-R7)
+
+Además se colapsó la duplicación de `sleep`/`logRetry` en un único sitio (sugerencia del code-simplifier).
 
 ## Riesgos
 
-- **Falso positivo del clasificador** (reintentar un error persistente desconocido): cuesta ~1s de backoff y luego falla igual. No enmascara — SCEN-001 intacto.
-- **Errores PG SQLSTATE persistentes no-PGRST** (p. ej. `42501` permiso, con código pero sin status 4xx en el wrapper): se reintentan-y-fallan. Path de solo-lectura con anon key; deterministas y visibles en el primer deploy. Aceptable; documentado.
+- **Falso positivo del clasificador** (reintentar un error persistente desconocido `code:''`+`status:0`-like): cuesta ~0.9s de backoff y luego falla igual. No enmascara — SCEN-001 intacto. Acotado por el bail de error-permanente-mezclado.
 - **El `console.warn` puede ser tragado por el prerender** igual que hoy. Best-effort, no regresión.
-- **Tiempo de build en outage real**: +~hasta 24s antes de fallar. Solo en el caso ya-roto.
+- **Tiempo de build en outage real**: +~0.9s (caso `.error` de red, 3 intentos) o sin cambio (~8s, caso timeout no-reintentado). Solo en el caso ya-roto.

--- a/docs/specs/2026-05-25-rentacar-data-transient-retry-design.md
+++ b/docs/specs/2026-05-25-rentacar-data-transient-retry-design.md
@@ -1,0 +1,230 @@
+---
+name: rentacar-data-transient-retry
+created_by: brainstorming
+created_at: 2026-05-25T00:00:00Z
+issues: ["#7", "#16"]
+scope: "Finding 2 de #16 (resiliencia ante fallo transitorio en build-time) + concern de hardening de #7. NO incluye swr/shared-storage cache."
+status: draft
+---
+
+# Retry acotado de `rentacar-data` ante fallo transitorio en build-time
+
+## Causa raíz (verificada)
+
+Los deploys de preview/producción fallan de forma intermitente. El build llega al **prerender de Nitro**, que renderiza `/` + 23 rutas de ciudad listadas en `prerender.routes` de cada marca. Cada página corre el plugin `rentacar-data`, que hace `$fetch('/api/rentacar-data')` → 6 queries paralelas a Supabase.
+
+Evidencia del log de build (deploy `dpl_CsKHk…`, commit `037c189`):
+
+```
+[nitro] Prerendering 25 routes
+  ├─ / (1745ms)
+  │ └── [500] Server Error      ← única ruta con 500
+  ├─ /armenia (1495ms)          ← 200
+  ├─ /barranquilla (1484ms)     ← 200
+  ... (23 rutas más, todas 200)
+```
+
+**Solo falla `/`** — la primera ruta, que dispara la primera llamada en frío a `/api/rentacar-data`. Las otras 24, con el mismo plugin y el mismo Supabase, renderizan bien. Un blip de red aleatorio pegaría en una ruta cualquiera; pegar siempre en la primera apunta a un fallo de arranque en frío (warmup de conexión/DNS/TLS, o pool frío de Supabase).
+
+Como el plugin `rentacar-data.ts` es **fail-loud** (re-lanza ante cualquier error de fetch, por diseño de #2) y `/` es una ruta explícita de `prerender.routes`, Nitro trata ese 500 como fatal → "Exiting due to prerender errors" → deployment ERROR.
+
+Hechos que confirman que es transitorio y estructural, no un bug de un PR:
+- No-determinista: el mismo commit `c617e4b` quedó ERROR y un redeploy quedó READY.
+- Afecta a `main` en producción (`59866e1` = ERROR), no solo a ramas de feature.
+- El PR #60 amplió la ventana de retry del prerender (3→5, 500ms→3000ms) y **igual** quedó ERROR.
+
+El `error.value` subyacente no quedó capturado: el prerenderer se tragó el `console.error` del plugin. Tenemos el qué y el dónde con certeza; el porqué exacto de la primera llamada no.
+
+## Cómo se manifiesta un fallo de red (verificado en el código de la dependencia)
+
+Decisión de diseño clave, verificada contra `@supabase/postgrest-js@2.101.1` (`src/PostgrestBuilder.ts`), no contra memoria:
+
+- Nuestras queries NO usan `.throwOnError()`, así que `shouldThrowOnError === false`. En ese modo, el bloque `res.catch((fetchError) => …)` **convierte cualquier fallo de fetch (red, DNS, ECONNREFUSED) Y `AbortError`** en un resultado RESUELTO (no lanzado):
+  ```
+  { error: { message: 'FetchError: …', details, hint, code: '' }, data: null, count: null, status: 0, statusText: '' }
+  ```
+- O sea: **un blip de red vuelve como `result.error` con `code: ''` y `result.status: 0`** — NO como excepción. Un retry que solo capture throws se lo perdería. Por eso el retry vive donde ve los resultados completos.
+- `PostgrestError` expone `message`, `details`, `hint`, `code` — **no tiene `status`**. El `status` HTTP vive en el wrapper del resultado (`{ error, data, count, status, statusText }`). Cualquier clasificación por status debe leer `result.status`, no `result.error.status`.
+- Una fila ausente vía `.single()` vuelve como `{ error: { code: 'PGRST116', … }, status: 406 }`.
+- El timeout (cuando dispara nuestro `AbortController`) lo detecta el chequeo `if (signal.aborted)` y se traduce a `RentacarDataTimeoutError` lanzado — ese SÍ es el path de throw.
+
+## Objetivo
+
+Que un fallo transitorio de una sola llamada en frío durante el build **se recupere solo**, en lugar de abortar el deploy de las 3 marcas.
+
+## No-objetivos (fuera de alcance, a propósito)
+
+- **Caché swr / shared-storage** (el otro ángulo de #16 Finding 2). Reduciría el número de llamadas en frío, pero el retry recupera el blip directamente y es suficiente. Queda como follow-up.
+- **`failOnError: false` en prerender.** Violaría SCEN-001 (que exige abortar el build ante outage real).
+- Cambios en `prerender.routes`, el plugin fail-loud, o el handler.
+- Cualquier cambio de comportamiento en runtime más allá del efecto colateral benigno del retry (ver Riesgos).
+
+## Enfoque elegido
+
+**Retry acotado dentro de `fetchRentacarData`** (la util en `packages/logic`, que se propaga a las 3 marcas vía el layer).
+
+Descartado: retry en `$fetch` del plugin (`retryStatusCodes` de ofetch). Más simple pero (a) no distingue PGRST116 de un 5xx transitorio con la misma finura, (b) afecta runtime de forma menos controlada, (c) es más difícil escribir un test propio que reproduzca "falla-y-recupera" — el seam de test ya existe en `fetchRentacarData`.
+
+## Diseño
+
+### Único archivo de producción
+
+`packages/logic/server/utils/rentacarDataFetch.ts`:
+
+1. **Extraer** el cuerpo actual (`Promise.all` + `AbortController` + el chequeo `signal.aborted` → `RentacarDataTimeoutError`) a un `runBatch(supabase, timeoutMs)` interno. Contrato sin cambio: retorna la tupla de 6 resultados (cada uno `{ data, error, status, … }`) en orden fijo; lanza `RentacarDataTimeoutError` ante abort/timeout.
+
+2. **Envolver** `runBatch` en un loop de retry acotado. Firma nueva con options object:
+
+   ```ts
+   const DEFAULT_TIMEOUT_MS = 8000
+   const DEFAULT_RETRIES = 2
+   const DEFAULT_RETRY_DELAY_MS = 300
+
+   interface FetchOptions {
+     timeoutMs?: number
+     retries?: number
+     retryDelayMs?: number
+   }
+
+   export async function fetchRentacarData(
+     supabase: SupabaseClient,
+     { timeoutMs = DEFAULT_TIMEOUT_MS,
+       retries = DEFAULT_RETRIES,
+       retryDelayMs = DEFAULT_RETRY_DELAY_MS }: FetchOptions = {},
+   )
+   ```
+
+   Lógica (pseudocódigo):
+
+   ```
+   lastResults = undefined
+   for attempt in 0..retries:                       # retries=2 → attempts 0,1,2
+     try:
+       results = await runBatch(supabase, timeoutMs)
+       transient = results.find(isRetryableResult)
+       if not transient: return results             # éxito, o .error NO-recuperable → decide el handler
+       lastResults = results                         # .error transitorio → reintentar
+       logRetry(attempt, retries, transient.error)
+     catch err:                                      # solo path de throw real = RentacarDataTimeoutError (timeout)
+       logRetry(attempt, retries, err)
+       if attempt == retries: throw err              # agotado → propaga (handler → 504)
+       await sleep(retryDelayMs * 2**attempt); continue
+     if attempt < retries: await sleep(retryDelayMs * 2**attempt)   # backoff 300ms, 600ms
+   return lastResults                                # agotado con .error transitorio → handler lanza 500
+   ```
+
+   Trazas de las 5 rutas (verificadas):
+   - **éxito en intento 0** → `return results`.
+   - **transitorio que recupera** (intento 0 `.error`, intento 1 ok) → reintenta, luego `return results`.
+   - **transitorio que agota** (3× `.error`) → cae a `return lastResults` (con `.error`) → handler 500. Nunca `undefined`: `lastResults` quedó asignado en cada iteración con transitorio.
+   - **timeout que agota** (3× throw) → en el último intento `throw err` → handler 504.
+   - **`.error` NO-recuperable** (PGRST116) → `transient` undefined → `return results` en 1 corrida.
+
+3. **Clasificador** `isRetryableResult(result)` (exportado para test unitario). Recibe el resultado COMPLETO (no solo `.error`), porque el `status` vive en el wrapper:
+
+   ```ts
+   export function isRetryableResult(result: { error: unknown; status?: number }): boolean {
+     if (!result?.error) return false
+     const code = (result.error as { code?: unknown }).code
+     // NO-recuperable: errores PostgREST de datos/schema/auth (PGRST*) → reintentar no los arregla.
+     if (typeof code === 'string' && code.startsWith('PGRST')) return false
+     // NO-recuperable: HTTP 4xx (status en el wrapper, no en .error).
+     if (typeof result.status === 'number' && result.status >= 400 && result.status < 500) return false
+     // Recuperable: red (status 0, code ''), 5xx, códigos PG transitorios (53300/57P03/08006…), y lo desconocido.
+     return true
+   }
+   ```
+
+   Grounded en `@supabase/postgrest-js@2.101.1`:
+   - Red/conexión/abort → `code: ''`, `status: 0` → recuperable. ✓ (es el blip que buscamos)
+   - PGRST116 (fila ausente, lo cubre #59) y PGRST1xx/3xx (parse/schema/JWT) → `code` PGRST* → NO-recuperable. ✓
+   - 5xx de PostgREST y códigos PG de conexión (no-PGRST) → recuperable. ✓
+   - 4xx con código no-PGRST (raro en este path de solo-lectura con anon key) → `status` 4xx → NO-recuperable. ✓
+   - **Default ante lo desconocido = recuperable.** Si es persistente, igual falla al agotar (SCEN-001 se preserva, solo se retrasa); si es el blip, lo atrapa. Costo del falso positivo: ~1s de backoff en un error que de todos modos iba a fallar.
+
+4. **Helpers inline** en el mismo archivo: `sleep(ms)` (Promise + setTimeout) y `logRetry(attempt, retries, err)` → `console.warn('[rentacar-data] transient fetch failure (attempt N/M), retrying…', err)`. El `console.warn` ataca el punto ciego actual (el error subyacente se perdió en el log del prerender). Best-effort: si el prerender lo traga, no empeora nada; en runtime sí queda registro.
+
+### Cotas y presupuesto de tiempo
+
+- `retries = 2` (3 intentos), backoff exponencial `300ms, 600ms`.
+- Blip que recupera en el intento 2: +~300ms al build. Despreciable.
+- Outage real: ~3 intentos (hasta 8s c/u si es por timeout) → falla fuerte. Aceptable porque de todos modos aborta.
+- Parámetros configurables vía `FetchOptions` para tests deterministas (`retryDelayMs: 0`, `retries: 0`).
+
+### Migración de los tests existentes (REQUERIDA, no opcional)
+
+El test actual llama `fetchRentacarData(supabase, 8000)` con `timeoutMs` **posicional** en 3 sitios (SCEN-1/2/3). La firma nueva hace que el arg 2 sea un objeto; `8000` posicional ya no significa nada. Además, con `DEFAULT_RETRIES = 2`, SCEN-2 (timeout) y SCEN-3 (`.error` transitorio sin `code`) **se romperían/colgarían** bajo fake timers porque introducirían reintentos + `sleep` no avanzados.
+
+Migración explícita:
+- Reescribir los 3 sitios a `fetchRentacarData(supabase, { timeoutMs: 8000, retries: 0 })`.
+- `retries: 0` preserva la semántica original de esos tests (una sola corrida de `runBatch`): SCEN-1 happy path, SCEN-2 timeout→throw en 1 intento, SCEN-3 `.error` passthrough en 1 corrida. Quedan como tests del comportamiento de `runBatch`, sin reintento.
+- El comportamiento de retry se cubre en escenarios nuevos (SCEN-R1..R4), no tocando los viejos.
+
+### Propagación
+
+El cambio vive solo en `packages/logic/server/utils/`. Las 3 marcas lo heredan vía `extends: ['@rentacar-main/logic']`. Cero cambios por marca.
+
+## Preservación del contrato existente
+
+| Contrato | Cómo se preserva |
+|---|---|
+| **SCEN-001** (build aborta ante outage real) | Outage → los 3 intentos fallan → handler lanza 5xx (500 vía `.error`, o 504 vía timeout) → plugin re-throw → exit≠0 con `[rentacar-data] Failed to load`. Solo se retrasa ~unos segundos. |
+| **SCEN-002** (plugin re-throw + cause chain) | El plugin y el handler no se tocan. |
+| **#59 / PGRST116** (fila localiza ausente) | `code: 'PGRST116'` → NO-recuperable → 1 corrida, sin reintento ni enmascaramiento; handler/#59 lo manejan como hoy. |
+| **#7 / #53** (timeout → 504) | `RentacarDataTimeoutError` sigue propagándose tras agotar intentos → handler 504. |
+
+## Escenarios observables (puente a SDD)
+
+Todos a nivel **unit sobre la util** (`fetchRentacarData` / `isRetryableResult`); la traducción a 5xx ocurre en el handler y se asume por contrato (sin cambio). El mock de supabase cuenta cuántas veces corre el batch.
+
+- **SCEN-R1** (unit) — *reproduce el bug del deploy*
+  **Given** un `supabase` cuyo batch devuelve un `result.error` con `code: ''`, `status: 0` (forma de error de red) en el intento 1, y resultados ok en el intento 2.
+  **When** `fetchRentacarData(supabase, { retries: 2, retryDelayMs: 0 })`.
+  **Then** retorna la tupla exitosa, sin throw; el batch corrió exactamente 2 veces.
+  **Evidence**: valor de retorno; contador de invocaciones del mock = 2.
+
+- **SCEN-R2** (unit) — *fail-loud preservado, sin throw*
+  **Given** un `supabase` cuyo batch devuelve `result.error` con `code: ''`, `status: 0` en TODOS los intentos.
+  **When** `fetchRentacarData(supabase, { retries: 2, retryDelayMs: 0 })`.
+  **Then** NO lanza; retorna resultados con `.error` poblado tras exactamente 3 corridas (el handler los traducirá a 500).
+  **Evidence**: contador = 3; el retorno tiene `results[i].error` no-nulo; `await expect(...).resolves` (no rejects).
+
+- **SCEN-R3** (unit) — *no reintentar errores de datos*
+  **Given** un `supabase` cuyo batch devuelve `result.error` con `code: 'PGRST116'`, `status: 406`.
+  **When** `fetchRentacarData(supabase, { retries: 2, retryDelayMs: 0 })`.
+  **Then** NO reintenta: el batch corre exactamente 1 vez; retorna inmediato con el `.error` intacto.
+  **Evidence**: contador = 1; `isRetryableResult({ error: { code: 'PGRST116' }, status: 406 })` === `false`.
+
+- **SCEN-R4** (unit) — *timeout sigue → throw → 504*
+  **Given** un `supabase` cuyo batch excede `timeoutMs` (abort) en todos los intentos.
+  **When** `fetchRentacarData(supabase, { timeoutMs: 10, retries: 2, retryDelayMs: 0 })` con timers avanzados.
+  **Then** lanza `RentacarDataTimeoutError` tras agotar intentos (el handler lo mapea a 504).
+  **Evidence**: `await expect(...).rejects.toBeInstanceOf(RentacarDataTimeoutError)`.
+
+- **SCEN-R5** (clasificador, tabla) — *fixtures con el shape real del resultado* `{ error, status }`, NO con `code`/`status` top-level (si no hay `.error`, el early-return lo daría `false` por el motivo equivocado y no ejercitaría la rama PGRST/4xx).
+  **Given/When/Then** `isRetryableResult` retorna:
+  - `false` para: `{ error: null }`; `{ error: { code: 'PGRST116' }, status: 406 }`; `{ error: { code: 'PGRST301' }, status: 401 }`; `{ error: { message: 'forbidden' }, status: 401 }`; `{ error: { message: 'not found' }, status: 404 }`.
+  - `true` para: `{ error: { code: '' }, status: 0 }` (red); `{ error: { message: 'unavailable' }, status: 503 }`; `{ error: { code: '57P03' }, status: 503 }` (PG conexión); `{ error: { message: 'x' } }` (desconocido, sin status).
+  **Evidence**: tabla `it.each` aserteada.
+
+- **SCEN-R6** (regresión) — *tests existentes migrados siguen verdes*
+  **Given** SCEN-1/2/3 de `rentacarDataFetch.test.ts` reescritos a `{ …, retries: 0 }`.
+  **When** corre la suite.
+  **Then** verde, con la misma semántica de 1-corrida que antes.
+  **Evidence**: `pnpm --filter @rentacar-main/logic exec vitest run rentacarDataFetch` verde.
+
+**Honestidad de cobertura:** SCEN-R1 reproduce el mecanismo (transitorio→recupera) a nivel unit, no el prerender real de Vercel — mismo caveat que el e2e de #59. Es el gate autoritativo del fix. La validación end-to-end real es observar un deploy de preview que pase tras el merge.
+
+## Plan de test
+
+| Escenario | Layer | Archivo | Comando de evidencia |
+|---|---|---|---|
+| SCEN-R1..R6 | Vitest unit | `packages/logic/server/utils/__tests__/rentacarDataFetch.test.ts` (extender) | `pnpm --filter @rentacar-main/logic exec vitest run rentacarDataFetch` (resuelve `packages/logic/vitest.config.ts`; mismo patrón que el PR #59) |
+| SCEN-001 (manual) | build | — | `pnpm build:alquilatucarro` con `NUXT_SUPABASE_URL` inválido → exit≠0 (sin cambio respecto a hoy) |
+
+## Riesgos
+
+- **Falso positivo del clasificador** (reintentar un error persistente desconocido): cuesta ~1s de backoff y luego falla igual. No enmascara — SCEN-001 intacto.
+- **Errores PG SQLSTATE persistentes no-PGRST** (p. ej. `42501` permiso, con código pero sin status 4xx en el wrapper): se reintentan-y-fallan. Path de solo-lectura con anon key; deterministas y visibles en el primer deploy. Aceptable; documentado.
+- **El `console.warn` puede ser tragado por el prerender** igual que hoy. Best-effort, no regresión.
+- **Tiempo de build en outage real**: +~hasta 24s antes de fallar. Solo en el caso ya-roto.

--- a/docs/specs/2026-05-25-rentacar-data-transient-retry/implementation/plan.md
+++ b/docs/specs/2026-05-25-rentacar-data-transient-retry/implementation/plan.md
@@ -14,7 +14,7 @@ Un solo archivo de producción + su test. El fix vive en `packages/logic` y se p
 | Archivo | Acción | Responsabilidad única |
 |---|---|---|
 | `packages/logic/server/utils/rentacarDataFetch.ts` | MODIFY | Fetch resiliente de rentacar-data: el batch de 6 queries (`runBatch`, extraído del cuerpo actual), la clasificación de errores recuperables (`isRetryableResult`), y el loop de retry acotado en `fetchRentacarData`. Helpers `sleep`/`logRetry` inline. |
-| `packages/logic/server/utils/__tests__/rentacarDataFetch.test.ts` | MODIFY | Unit tests: migra los 3 call-sites de test existentes (la única llamada de producción, en el handler, no cambia) a `{ retries: 0 }`; agrega SCEN-R1..R6. |
+| `packages/logic/server/utils/__tests__/rentacarDataFetch.test.ts` | MODIFY | Unit tests: migra los 3 call-sites de test existentes (la única llamada de producción, en el handler, no cambia) a `{ retries: 0 }`; agrega SCEN-R1..R7 (incluye R7: error permanente mezclado no se reintenta). |
 
 **Decisión de decomposición**: el clasificador, el batch y el retry son una sola responsabilidad cohesiva ("traer rentacar-data de forma resiliente") y son chicos; co-locarlos en el archivo existente sigue el patrón del repo (utils chicos y enfocados) y evita fragmentar una unidad que cambia junta. `isRetryableResult` se **exporta** solo para testeo unitario directo (SCEN-R5). No se crean archivos nuevos.
 
@@ -40,25 +40,26 @@ Un solo archivo de producción + su test. El fix vive en `packages/logic` y se p
     - Sin lectura de `error.status` (status solo del wrapper); cero referencias a campos inexistentes de `PostgrestError`.
 
 - [ ] **Step 2 — Retry acotado + nueva firma + migración de tests** | Size: M | Dependencies: Step 1
-  - SDD: escribir primero SCEN-R1/R2/R3/R4 (nuevos) + migrar SCEN-1/2/3 a `{ timeoutMs: 8000, retries: 0 }` (SCEN-R6) → fallan/rompen → implementar → verde.
+  - SDD: escribir primero SCEN-R1/R2/R3/R4/R7 (nuevos) + migrar SCEN-1/2/3 a `{ timeoutMs: 8000, retries: 0 }` (SCEN-R6) → fallan/rompen → implementar → verde.
   - Refactor: extraer el cuerpo actual (`Promise.all` de 6 queries + `AbortController` + chequeo `signal.aborted` → `RentacarDataTimeoutError`) a `runBatch(supabase, timeoutMs)` interno, sin cambio de comportamiento ni de la tupla/orden de 6 resultados (preserva #12 faqs).
   - Firma nueva: `fetchRentacarData(supabase, { timeoutMs = 8000, retries = 2, retryDelayMs = 300 }: FetchOptions = {})` — backward-compatible con el handler (`fetchRentacarData(supabase)` sigue válido).
-  - Loop de retry (pseudocódigo en spec §Diseño): por intento `0..retries`, corre `runBatch`; si retorna y hay un `result.error` recuperable (`isRetryableResult`) → guarda `lastResults` y reintenta tras `sleep(retryDelayMs * 2**attempt)`; si lanza (timeout) → reintenta, y en el último intento re-lanza; si no hay error recuperable → retorna de inmediato. Al agotar con `.error` → retorna `lastResults` (handler hace 500).
+  - Loop de retry (pseudocódigo en spec §Diseño, refinado tras Quality Integration): por intento `0..retries`, corre `runBatch`; reintenta SOLO si hay error y TODO error es recuperable (`errored.every(isRetryableResult)`). Un **timeout LANZA y NO se reintenta** (propaga inmediato → 504). Un **error permanente mezclado** con uno transitorio → no reintenta. Al agotar con `.error` transitorio → retorna `lastResults` (handler hace 500).
   - Helpers inline: `sleep(ms)` y `logRetry(attempt, retries, err)` → `console.warn('[rentacar-data] transient fetch failure (attempt N/M), retrying…', err)`.
   - **Scenarios embebidos**:
     - blip que recupera en intento 2 → retorna ok, 2 corridas (SCEN-R1).
     - blip en todos los intentos → sin throw, retorna `.error`, 3 corridas → handler 500 (SCEN-R2, preserva SCEN-001).
     - PGRST116 → 1 corrida, sin reintento (SCEN-R3, preserva #59).
-    - timeout en todos → `RentacarDataTimeoutError` → 504 (SCEN-R4, preserva #7/#53). Nota de test: con `retries: 2` el loop arma un `setTimeout(timeoutMs)` por intento → avanzar fake timers **por intento** (3×); `retryDelayMs: 0` evita tener que avanzar el backoff.
+    - un timeout lanza `RentacarDataTimeoutError` inmediato, SIN reintentar → 504, 1 corrida (SCEN-R4, preserva #7/#53). Nota de test: real timers + `timeoutMs` pequeño (5ms).
+    - permanente (`PGRST205`/4xx) mezclado con transitorio → 1 corrida, sin reintento → handler 500 (SCEN-R7).
     - tests existentes migrados verdes, sin cuelgue (SCEN-R6).
   - **Acceptance**:
-    - Los 3 call-sites existentes usan `{ timeoutMs: 8000, retries: 0 }`; toda la suite `rentacarDataFetch` verde (SCEN-1/2/3 migrados + R1..R6), 0 skipped, 2 corridas estables.
+    - Los 3 call-sites existentes usan `{ timeoutMs: 8000, retries: 0 }`; toda la suite `rentacarDataFetch` verde (SCEN-1/2/3 migrados + R1..R7), 0 skipped, 2 corridas estables.
     - El handler `rentacar-data.get.ts` NO se modifica; `pnpm --filter ui-* typecheck` sin nuevos errores que referencien `rentacarDataFetch` (delta-vs-baseline; baseline rojo conocido).
     - Diff de producción acotado a `rentacarDataFetch.ts`.
 
 ## Testing Strategy
 
-- **Unit** (autoritativo): `rentacarDataFetch.test.ts` cubre SCEN-R1..R6 con un mock de supabase que cuenta corridas del batch y simula `.error` de red (`code:''`, `status:0`), PGRST116, y abort/timeout (fake timers). Comando: `pnpm --filter @rentacar-main/logic exec vitest run rentacarDataFetch`.
+- **Unit** (autoritativo): `rentacarDataFetch.test.ts` cubre SCEN-R1..R7 con un mock de supabase que cuenta corridas del batch y simula `.error` de red (`code:''`, `status:0`), PGRST116, y abort/timeout (fake timers). Comando: `pnpm --filter @rentacar-main/logic exec vitest run rentacarDataFetch`.
 - **Regresión de suite logic**: `pnpm --filter @rentacar-main/logic exec vitest run` — confirmar que nada más se rompe (el plugin test y transformers no dependen de la firma).
 - **SCEN-001 (manual, no automatizable aquí)**: `pnpm build:alquilatucarro` con `NUXT_SUPABASE_URL` inválido → exit≠0 con `[rentacar-data] Failed to load` (comportamiento sin cambio respecto a hoy; solo se retrasa ~unos segundos por los reintentos).
 - **Cobertura honesta**: ningún unit ejercita el prerender real de Vercel; el gate end-to-end es observar un deploy de preview verde tras el merge.

--- a/docs/specs/2026-05-25-rentacar-data-transient-retry/implementation/plan.md
+++ b/docs/specs/2026-05-25-rentacar-data-transient-retry/implementation/plan.md
@@ -1,0 +1,71 @@
+# Implementation Plan: rentacar-data transient retry (#7, #16-F2)
+
+**Date**: 2026-05-25
+**Spec (detailed design)**: `docs/specs/2026-05-25-rentacar-data-transient-retry-design.md` (aprobado + revisado por subagente, 2 iteraciones)
+**Scenarios (holdout)**: `docs/specs/2026-05-25-rentacar-data-transient-retry/scenarios/rentacar-data-transient-retry.scenarios.md`
+**Branch / worktree**: `fix/rentacar-data-transient-retry` (off `origin/main`)
+
+> Nota de proceso: las fases de clarificación/research/detailed-design de sop-planning se completaron en `/brainstorming` (el spec aprobado es el detailed-design). Este plan cubre Step 6.5 (file structure) + Step 7 (steps) + Step 7.5 (review loop).
+
+## File Structure
+
+Un solo archivo de producción + su test. El fix vive en `packages/logic` y se propaga a las 3 marcas vía el layer (`extends: ['@rentacar-main/logic']`). Cero cambios por marca, cero cambios en el handler/plugin.
+
+| Archivo | Acción | Responsabilidad única |
+|---|---|---|
+| `packages/logic/server/utils/rentacarDataFetch.ts` | MODIFY | Fetch resiliente de rentacar-data: el batch de 6 queries (`runBatch`, extraído del cuerpo actual), la clasificación de errores recuperables (`isRetryableResult`), y el loop de retry acotado en `fetchRentacarData`. Helpers `sleep`/`logRetry` inline. |
+| `packages/logic/server/utils/__tests__/rentacarDataFetch.test.ts` | MODIFY | Unit tests: migra los 3 call-sites de test existentes (la única llamada de producción, en el handler, no cambia) a `{ retries: 0 }`; agrega SCEN-R1..R6. |
+
+**Decisión de decomposición**: el clasificador, el batch y el retry son una sola responsabilidad cohesiva ("traer rentacar-data de forma resiliente") y son chicos; co-locarlos en el archivo existente sigue el patrón del repo (utils chicos y enfocados) y evita fragmentar una unidad que cambia junta. `isRetryableResult` se **exporta** solo para testeo unitario directo (SCEN-R5). No se crean archivos nuevos.
+
+**No se tocan** (fuera de alcance, confirmado en blast-radius del spec): `rentacar-data.get.ts` (handler), `plugins/rentacar-data.ts`, `nuxt.config.ts` (prerender/failOnError), caché swr/shared-storage.
+
+## Prerequisites
+
+- Ninguna dependencia nueva. `@supabase/supabase-js@^2.100.1` (postgrest-js 2.101.1) ya instalado.
+- Trabajar dentro del worktree `fix/rentacar-data-transient-retry`.
+- Vitest ya configurado (`packages/logic/vitest.config.ts`, `environment: node`).
+
+## Steps
+
+### Chunk 1: retry resiliente en fetchRentacarData
+
+- [ ] **Step 1 — Clasificador `isRetryableResult(result)`** | Size: S | Dependencies: none
+  - SDD: escribir primero SCEN-R5 (tabla `it.each`) en `rentacarDataFetch.test.ts` con los fixtures de shape real `{ error, status }` → falla (la función no existe) → implementar `isRetryableResult` exportada en `rentacarDataFetch.ts` → verde.
+  - Reglas: `false` si `!result.error`, si `error.code` empieza con `'PGRST'`, o si `result.status` es 4xx; `true` en cualquier otro caso (red `code:''`/`status:0`, 5xx, códigos PG de conexión, desconocido).
+  - **Scenario**: dado un resultado PostgREST, cuando se clasifica, entonces devuelve recuperable solo para errores no-PostgREST/no-4xx (SCEN-R5).
+  - **Acceptance**:
+    - `isRetryableResult` exportada; SCEN-R5 verde (9 casos: 5 `false`, 4 `true`).
+    - `pnpm --filter @rentacar-main/logic exec vitest run rentacarDataFetch` pasa SCEN-R5.
+    - Sin lectura de `error.status` (status solo del wrapper); cero referencias a campos inexistentes de `PostgrestError`.
+
+- [ ] **Step 2 — Retry acotado + nueva firma + migración de tests** | Size: M | Dependencies: Step 1
+  - SDD: escribir primero SCEN-R1/R2/R3/R4 (nuevos) + migrar SCEN-1/2/3 a `{ timeoutMs: 8000, retries: 0 }` (SCEN-R6) → fallan/rompen → implementar → verde.
+  - Refactor: extraer el cuerpo actual (`Promise.all` de 6 queries + `AbortController` + chequeo `signal.aborted` → `RentacarDataTimeoutError`) a `runBatch(supabase, timeoutMs)` interno, sin cambio de comportamiento ni de la tupla/orden de 6 resultados (preserva #12 faqs).
+  - Firma nueva: `fetchRentacarData(supabase, { timeoutMs = 8000, retries = 2, retryDelayMs = 300 }: FetchOptions = {})` — backward-compatible con el handler (`fetchRentacarData(supabase)` sigue válido).
+  - Loop de retry (pseudocódigo en spec §Diseño): por intento `0..retries`, corre `runBatch`; si retorna y hay un `result.error` recuperable (`isRetryableResult`) → guarda `lastResults` y reintenta tras `sleep(retryDelayMs * 2**attempt)`; si lanza (timeout) → reintenta, y en el último intento re-lanza; si no hay error recuperable → retorna de inmediato. Al agotar con `.error` → retorna `lastResults` (handler hace 500).
+  - Helpers inline: `sleep(ms)` y `logRetry(attempt, retries, err)` → `console.warn('[rentacar-data] transient fetch failure (attempt N/M), retrying…', err)`.
+  - **Scenarios embebidos**:
+    - blip que recupera en intento 2 → retorna ok, 2 corridas (SCEN-R1).
+    - blip en todos los intentos → sin throw, retorna `.error`, 3 corridas → handler 500 (SCEN-R2, preserva SCEN-001).
+    - PGRST116 → 1 corrida, sin reintento (SCEN-R3, preserva #59).
+    - timeout en todos → `RentacarDataTimeoutError` → 504 (SCEN-R4, preserva #7/#53). Nota de test: con `retries: 2` el loop arma un `setTimeout(timeoutMs)` por intento → avanzar fake timers **por intento** (3×); `retryDelayMs: 0` evita tener que avanzar el backoff.
+    - tests existentes migrados verdes, sin cuelgue (SCEN-R6).
+  - **Acceptance**:
+    - Los 3 call-sites existentes usan `{ timeoutMs: 8000, retries: 0 }`; toda la suite `rentacarDataFetch` verde (SCEN-1/2/3 migrados + R1..R6), 0 skipped, 2 corridas estables.
+    - El handler `rentacar-data.get.ts` NO se modifica; `pnpm --filter ui-* typecheck` sin nuevos errores que referencien `rentacarDataFetch` (delta-vs-baseline; baseline rojo conocido).
+    - Diff de producción acotado a `rentacarDataFetch.ts`.
+
+## Testing Strategy
+
+- **Unit** (autoritativo): `rentacarDataFetch.test.ts` cubre SCEN-R1..R6 con un mock de supabase que cuenta corridas del batch y simula `.error` de red (`code:''`, `status:0`), PGRST116, y abort/timeout (fake timers). Comando: `pnpm --filter @rentacar-main/logic exec vitest run rentacarDataFetch`.
+- **Regresión de suite logic**: `pnpm --filter @rentacar-main/logic exec vitest run` — confirmar que nada más se rompe (el plugin test y transformers no dependen de la firma).
+- **SCEN-001 (manual, no automatizable aquí)**: `pnpm build:alquilatucarro` con `NUXT_SUPABASE_URL` inválido → exit≠0 con `[rentacar-data] Failed to load` (comportamiento sin cambio respecto a hoy; solo se retrasa ~unos segundos por los reintentos).
+- **Cobertura honesta**: ningún unit ejercita el prerender real de Vercel; el gate end-to-end es observar un deploy de preview verde tras el merge.
+
+## Rollout Plan
+
+- **Deploy**: push de la rama `fix/rentacar-data-transient-retry` → PR nuevo (#7/#16-F2). El deploy de preview de Vercel es en sí la validación end-to-end del fix (debe pasar de forma estable; idealmente confirmar con 2+ deploys o redeploys dado que el fallo era intermitente).
+- **Monitoreo**: buscar `[rentacar-data] transient fetch failure` en los logs de build/runtime — si aparece seguido, indica un problema de conexión más persistente que merece el follow-up de caché (swr/shared-storage, #16-F2).
+- **Rollback**: el cambio es un solo archivo en `logic`; revert del commit restaura el comportamiento anterior. Sin migraciones ni cambios de infra. Riesgo bajo.
+- **Gate pre-PR**: `/verification-before-completion` con evidencia fresca (suite verde + typecheck delta) antes de cualquier claim de "done".

--- a/docs/specs/2026-05-25-rentacar-data-transient-retry/scenarios/rentacar-data-transient-retry.scenarios.md
+++ b/docs/specs/2026-05-25-rentacar-data-transient-retry/scenarios/rentacar-data-transient-retry.scenarios.md
@@ -1,0 +1,69 @@
+---
+name: rentacar-data-transient-retry
+created_by: brainstorming + sop-planning
+created_at: 2026-05-25T00:00:00Z
+spec: docs/specs/2026-05-25-rentacar-data-transient-retry-design.md
+plan: docs/specs/2026-05-25-rentacar-data-transient-retry/implementation/plan.md
+issues: ["#7", "#16"]
+---
+
+Holdout para el retry acotado de `fetchRentacarData` ante fallo transitorio en build-time (causa raíz verificada: la primera llamada en frío a `/api/rentacar-data` durante el prerender de `/` falla, y el plugin fail-loud aborta el deploy). Todos los scenarios son unit sobre la util `fetchRentacarData` / `isRetryableResult`; el mock de supabase cuenta cuántas veces corre el batch. Behavior groundeado en `@supabase/postgrest-js@2.101.1` (red/abort → resultado resuelto `{ error: { code: '' }, status: 0 }`, no throw; `status` en el wrapper, no en `.error`).
+
+## SCEN-R1: blip transitorio en el intento 1 se recupera en el intento 2 (reproduce el bug del deploy)
+
+**Given**: un `supabase` cuyo batch devuelve un `result.error` con `code: ''`, `status: 0` (forma de error de red) en el intento 1, y resultados válidos (`error: null`) en el intento 2.
+**When**: se invoca `fetchRentacarData(supabase, { retries: 2, retryDelayMs: 0 })`.
+**Then**: retorna la tupla de 6 resultados exitosa; NO lanza; el batch (consulta a supabase) corrió exactamente 2 veces.
+**Evidence**: valor de retorno aserteado sin `.error`; contador de invocaciones del mock `from()` por tabla → 2 corridas del batch.
+
+## SCEN-R2: blip transitorio en TODOS los intentos → fail-loud preservado, sin throw
+
+**Given**: un `supabase` cuyo batch devuelve `result.error` con `code: ''`, `status: 0` en cada intento.
+**When**: se invoca `fetchRentacarData(supabase, { retries: 2, retryDelayMs: 0 })`.
+**Then**: NO lanza; retorna la tupla con `.error` poblado tras exactamente 3 corridas (`retries + 1`); el handler la traducirá a 500 (preserva SCEN-001).
+**Evidence**: `await expect(...).resolves` (no `rejects`); `results.some(r => r.error)` === true; contador de corridas = 3.
+
+## SCEN-R3: error de datos (PGRST116) NO se reintenta
+
+**Given**: un `supabase` cuyo batch devuelve un `result.error` con `code: 'PGRST116'`, `status: 406` (fila ausente, el caso de #59).
+**When**: se invoca `fetchRentacarData(supabase, { retries: 2, retryDelayMs: 0 })`.
+**Then**: NO reintenta — el batch corre exactamente 1 vez; retorna inmediato con el `.error` intacto.
+**Evidence**: contador de corridas = 1; `isRetryableResult({ error: { code: 'PGRST116' }, status: 406 })` === `false`.
+
+## SCEN-R4: timeout en todos los intentos sigue lanzando → 504
+
+**Given**: un `supabase` cuyo batch excede `timeoutMs` (abort vía AbortController) en todos los intentos.
+**When**: se invoca `fetchRentacarData(supabase, { timeoutMs: 10, retries: 2, retryDelayMs: 0 })` con timers avanzados.
+**Then**: lanza `RentacarDataTimeoutError` tras agotar intentos; el handler lo mapea a 504 (preserva #7/#53).
+**Evidence**: `await expect(...).rejects.toBeInstanceOf(RentacarDataTimeoutError)`.
+
+## SCEN-R5: `isRetryableResult` clasifica correctamente (tabla)
+
+**Given/When/Then**: con fixtures que llevan el shape real `{ error, status }` (NO `code`/`status` top-level), `isRetryableResult` retorna:
+- `false` para: `{ error: null }`; `{ error: { code: 'PGRST116' }, status: 406 }`; `{ error: { code: 'PGRST301' }, status: 401 }`; `{ error: { message: 'forbidden' }, status: 401 }`; `{ error: { message: 'not found' }, status: 404 }`.
+- `true` para: `{ error: { code: '' }, status: 0 }` (red); `{ error: { message: 'unavailable' }, status: 503 }`; `{ error: { code: '57P03' }, status: 503 }` (PG conexión); `{ error: { message: 'x' } }` (desconocido, sin status).
+**Evidence**: tabla `it.each` aserteada campo por campo.
+
+## SCEN-R6: tests existentes migrados siguen verdes (regresión)
+
+**Given**: los tests SCEN-1/2/3 de `rentacarDataFetch.test.ts` reescritos a `fetchRentacarData(supabase, { timeoutMs: 8000, retries: 0 })`.
+**When**: corre la suite.
+**Then**: verde, con la misma semántica de 1-corrida que antes (happy path, timeout→throw, `.error` passthrough); ningún cuelgue bajo fake timers.
+**Evidence**: `pnpm --filter @rentacar-main/logic exec vitest run rentacarDataFetch` → todos pasan.
+
+---
+
+## Matriz de no-regresión (contratos existentes que el fix debe preservar)
+
+| Contrato | Preservado porque |
+|---|---|
+| SCEN-001 (build aborta ante outage real) | outage → agota 3 intentos → handler 500/504 → plugin re-throw → exit≠0 (solo se retrasa ~unos segundos) |
+| SCEN-002 (plugin re-throw + cause chain) | el plugin y el handler no se tocan |
+| SCEN-007 (transformExtras null sin coercion) | `transformExtras` y el handler no se tocan |
+| #7/#53 (timeout → 504) | `RentacarDataTimeoutError` sigue propagándose tras agotar (SCEN-R4) |
+| #12 (query faqs, 6ª) | las 6 queries quedan intactas dentro de `runBatch`, misma tupla |
+| #16-F1 / #59 (PGRST116 → degrade) | PGRST116 clasificado no-recuperable → 1 corrida, sin latencia extra (SCEN-R3) |
+
+## Cobertura honesta
+
+SCEN-R1 reproduce el mecanismo (transitorio→recupera) a nivel unit, NO el prerender real de Vercel — mismo caveat que el e2e de #59. Es el gate autoritativo del fix. La validación end-to-end real es observar un deploy de preview que pase tras el merge (verificación manual post-merge, no automatizable aquí).

--- a/docs/specs/2026-05-25-rentacar-data-transient-retry/scenarios/rentacar-data-transient-retry.scenarios.md
+++ b/docs/specs/2026-05-25-rentacar-data-transient-retry/scenarios/rentacar-data-transient-retry.scenarios.md
@@ -30,12 +30,12 @@ Holdout para el retry acotado de `fetchRentacarData` ante fallo transitorio en b
 **Then**: NO reintenta — el batch corre exactamente 1 vez; retorna inmediato con el `.error` intacto.
 **Evidence**: contador de corridas = 1; `isRetryableResult({ error: { code: 'PGRST116' }, status: 406 })` === `false`.
 
-## SCEN-R4: timeout en todos los intentos sigue lanzando → 504
+## SCEN-R4: un timeout lanza inmediato (no reintentado) → 504
 
-**Given**: un `supabase` cuyo batch excede `timeoutMs` (abort vía AbortController) en todos los intentos.
-**When**: se invoca `fetchRentacarData(supabase, { timeoutMs: 10, retries: 2, retryDelayMs: 0 })` con timers avanzados.
-**Then**: lanza `RentacarDataTimeoutError` tras agotar intentos; el handler lo mapea a 504 (preserva #7/#53).
-**Evidence**: `await expect(...).rejects.toBeInstanceOf(RentacarDataTimeoutError)`.
+**Given**: un `supabase` cuyo batch excede `timeoutMs` (abort vía AbortController).
+**When**: se invoca `fetchRentacarData(supabase, { timeoutMs: 5, retries: 2, retryDelayMs: 0 })`.
+**Then**: lanza `RentacarDataTimeoutError` en el primer intento, SIN reintentar — un upstream lento no se recupera dentro del deadline y reintentar multiplicaría la cola de latencia (erosionando el bound de 8s de #7); el handler lo mapea a 504 (preserva #7/#53). El batch corre exactamente 1 vez.
+**Evidence**: `await expect(...).rejects.toBeInstanceOf(RentacarDataTimeoutError)`; contador de corridas = 1.
 
 ## SCEN-R5: `isRetryableResult` clasifica correctamente (tabla)
 
@@ -50,6 +50,13 @@ Holdout para el retry acotado de `fetchRentacarData` ante fallo transitorio en b
 **When**: corre la suite.
 **Then**: verde, con la misma semántica de 1-corrida que antes (happy path, timeout→throw, `.error` passthrough); ningún cuelgue bajo fake timers.
 **Evidence**: `pnpm --filter @rentacar-main/logic exec vitest run rentacarDataFetch` → todos pasan.
+
+## SCEN-R7: error permanente mezclado con uno transitorio NO se reintenta → 1 corrida
+
+**Given**: un `supabase` cuyo batch devuelve, en la misma corrida, un `result.error` permanente (`code: 'PGRST205'`, `status: 404`) en una tabla y uno transitorio (`code: ''`, `status: 0`) en otra.
+**When**: se invoca `fetchRentacarData(supabase, { retries: 2, retryDelayMs: 0 })`.
+**Then**: NO reintenta (reintentar no puede arreglar el error permanente) — el batch corre exactamente 1 vez; retorna los resultados con `.error` poblado → el handler hace 500 (fail-loud, sin demora). Solo se reintenta cuando TODO error en el batch es transitorio.
+**Evidence**: contador de corridas = 1; `results.some(r => r.error)` === true.
 
 ---
 

--- a/docs/specs/2026-05-25-rentacar-data-transient-retry/summary.md
+++ b/docs/specs/2026-05-25-rentacar-data-transient-retry/summary.md
@@ -1,0 +1,33 @@
+# Planning Summary: rentacar-data transient retry (#7, #16-F2)
+
+**Date**: 2026-05-25
+**Goal**: Que un fallo transitorio de la primera llamada en frío a `/api/rentacar-data` durante el prerender no aborte el deploy de las 3 marcas, sin romper el fail-loud ante un outage real.
+
+## Artifacts Created
+- `2026-05-25-rentacar-data-transient-retry-design.md` — diseño detallado (vía `/brainstorming`; aprobado + revisado por subagente, 2 iteraciones; incluye blast-radius verificado).
+- `scenarios/rentacar-data-transient-retry.scenarios.md` — holdout SDD (SCEN-R1..R6 + matriz de no-regresión).
+- `implementation/plan.md` — file structure + plan de 2 steps (revisado por subagente, aprobado).
+- `summary.md` — este documento.
+
+> Las fases de clarificación/research de sop-planning se completaron en `/brainstorming`; no se re-derivaron (el diseño estaba locked y revisado).
+
+## Key Decisions
+1. **Retry dentro de `fetchRentacarData`** (no en `$fetch` del plugin): ve tanto el `.error` transitorio como el throw de timeout, y es testeable de forma determinista con el seam existente.
+2. **Clasificación solo-transitorios** (`isRetryableResult`): reintenta red/5xx/PG-conexión/desconocido; NO reintenta `PGRST*` (incl. PGRST116 de #59) ni 4xx. Groundeado en `@supabase/postgrest-js@2.101.1` (red/abort → `{ error:{code:''}, status:0 }`, no throw; `status` en el wrapper).
+3. **Fail-loud preservado**: outage real agota 3 intentos → handler 500/504 → exit≠0 (SCEN-001 intacto, solo se retrasa).
+4. **Alcance mínimo**: un solo archivo de producción + su test; sin tocar handler/plugin/nuxt.config. Caché swr/shared-storage queda como follow-up (#16-F2).
+5. **PR nuevo aparte** de #59 (que sigue su curso); comparten error path pero son fixes distintos y complementarios.
+
+## Complexity Estimate
+- **Overall**: S–M (un archivo de producción + su test).
+- **Duration**: ~2 h de implementación.
+- **Risk Level**: Bajo (cambio aislado en `logic`, revert de un commit; sin migraciones ni infra).
+
+## Recommended Next Steps
+1. Implementar con SDD: Step 1 (clasificador + SCEN-R5) → Step 2 (retry + firma + migración de tests + SCEN-R1..R6).
+2. `/verification-before-completion` con evidencia fresca antes de cualquier claim de done.
+3. `/pull-request` (review + security + edge-case + performance) → PR nuevo (#7/#16-F2).
+4. Validación end-to-end: observar deploy de preview verde (idealmente 2+ corridas, dado que el fallo era intermitente).
+
+## Open Questions
+- El trigger exacto de la primera llamada en frío (TLS/DNS/pool) quedó sin capturar (el prerender se tragó el error subyacente). El `console.warn` de diagnóstico que agrega este fix hará diagnosticable la próxima ocurrencia. Si reaparece seguido tras el merge → escalar al follow-up de caché swr/shared-storage (#16-F2).

--- a/docs/specs/2026-05-25-rentacar-data-transient-retry/summary.md
+++ b/docs/specs/2026-05-25-rentacar-data-transient-retry/summary.md
@@ -5,7 +5,7 @@
 
 ## Artifacts Created
 - `2026-05-25-rentacar-data-transient-retry-design.md` — diseño detallado (vía `/brainstorming`; aprobado + revisado por subagente, 2 iteraciones; incluye blast-radius verificado).
-- `scenarios/rentacar-data-transient-retry.scenarios.md` — holdout SDD (SCEN-R1..R6 + matriz de no-regresión).
+- `scenarios/rentacar-data-transient-retry.scenarios.md` — holdout SDD (SCEN-R1..R7 + matriz de no-regresión).
 - `implementation/plan.md` — file structure + plan de 2 steps (revisado por subagente, aprobado).
 - `summary.md` — este documento.
 
@@ -24,7 +24,7 @@
 - **Risk Level**: Bajo (cambio aislado en `logic`, revert de un commit; sin migraciones ni infra).
 
 ## Recommended Next Steps
-1. Implementar con SDD: Step 1 (clasificador + SCEN-R5) → Step 2 (retry + firma + migración de tests + SCEN-R1..R6).
+1. Implementar con SDD: Step 1 (clasificador + SCEN-R5) → Step 2 (retry + firma + migración de tests + SCEN-R1..R7).
 2. `/verification-before-completion` con evidencia fresca antes de cualquier claim de done.
 3. `/pull-request` (review + security + edge-case + performance) → PR nuevo (#7/#16-F2).
 4. Validación end-to-end: observar deploy de preview verde (idealmente 2+ corridas, dado que el fallo era intermitente).

--- a/packages/logic/server/utils/__tests__/rentacarDataFetch.test.ts
+++ b/packages/logic/server/utils/__tests__/rentacarDataFetch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { fetchRentacarData, RentacarDataTimeoutError } from '../rentacarDataFetch'
+import { fetchRentacarData, RentacarDataTimeoutError, isRetryableResult } from '../rentacarDataFetch'
 
 const TABLES = ['vehicle_categories', 'locations', 'rental_companies', 'cities', 'franchises', 'faqs'] as const
 
@@ -46,6 +46,32 @@ function makeSupabase(perTable: Partial<Record<(typeof TABLES)[number], { data: 
 
 const OK = { data: [], error: null }
 
+type Result = { data: unknown; error: unknown; status?: number }
+
+/**
+ * Supabase mock that returns a different per-table result on each batch run,
+ * so retry behavior can be exercised. A "batch run" is counted when the first
+ * table (`vehicle_categories`) is requested — all 6 `from()` calls of one batch
+ * happen synchronously before any await. `perAttempt(n)` (1-indexed) returns
+ * per-table overrides; tables not overridden default to OK. `'stall'` makes a
+ * query hang until its AbortSignal fires (mirrors a timeout).
+ */
+function makeRetrySupabase(
+  perAttempt: (attempt: number) => Partial<Record<(typeof TABLES)[number], Result | 'stall'>>,
+) {
+  let runs = 0
+  const supabase = {
+    from: (table: string) => {
+      if (table === 'vehicle_categories') runs++
+      const spec = perAttempt(runs)[table as (typeof TABLES)[number]]
+      return makeQuery(spec === 'stall' ? undefined : (spec ?? OK))
+    },
+  } as never
+  return { supabase, runs: () => runs }
+}
+
+const NET_ERR: Result = { data: null, error: { code: '' }, status: 0 } // network blip (postgrest-js shape)
+
 afterEach(() => {
   vi.useRealTimers()
 })
@@ -62,7 +88,7 @@ describe('fetchRentacarData', () => {
       faqs: OK,
     })
 
-    const results = await fetchRentacarData(supabase, 8000)
+    const results = await fetchRentacarData(supabase, { timeoutMs: 8000, retries: 0 })
 
     expect(results).toHaveLength(6)
     expect(vi.getTimerCount()).toBe(0) // timer cleared, no dangling handle
@@ -72,7 +98,7 @@ describe('fetchRentacarData', () => {
     vi.useFakeTimers()
     const { supabase, builders } = makeSupabase({}) // all stall until abort
 
-    const promise = fetchRentacarData(supabase, 8000)
+    const promise = fetchRentacarData(supabase, { timeoutMs: 8000, retries: 0 })
     const assertion = expect(promise).rejects.toBeInstanceOf(RentacarDataTimeoutError)
 
     await vi.advanceTimersByTimeAsync(8000)
@@ -96,9 +122,89 @@ describe('fetchRentacarData', () => {
       faqs: OK,
     })
 
-    const results = await fetchRentacarData(supabase, 8000)
+    const results = await fetchRentacarData(supabase, { timeoutMs: 8000, retries: 0 })
 
     expect(results[0]).toEqual(dbError)
     expect(vi.getTimerCount()).toBe(0)
+  })
+})
+
+describe('isRetryableResult (SCEN-R5)', () => {
+  it.each([
+    // NON-retryable: data/schema/auth errors (PGRST*) and HTTP 4xx — retrying won't help.
+    [{ error: null }, false],
+    [{ error: { code: 'PGRST116' }, status: 406 }, false],
+    [{ error: { code: 'PGRST301' }, status: 401 }, false],
+    [{ error: { message: 'forbidden' }, status: 401 }, false],
+    [{ error: { message: 'not found' }, status: 404 }, false],
+    // RETRYABLE: network (code:'' / status:0), 5xx, PG connection codes, and unknown.
+    [{ error: { code: '' }, status: 0 }, true],
+    [{ error: { message: 'unavailable' }, status: 503 }, true],
+    [{ error: { code: '57P03' }, status: 503 }, true],
+    [{ error: { message: 'x' } }, true],
+  ])('classifies %o as retryable=%s', (result, expected) => {
+    expect(isRetryableResult(result as { error: unknown; status?: number })).toBe(expected)
+  })
+})
+
+describe('fetchRentacarData retry (SCEN-R1..R4)', () => {
+  it('SCEN-R1: transient .error on attempt 1, success on attempt 2 → returns ok, 2 batch runs', async () => {
+    const { supabase, runs } = makeRetrySupabase((attempt) =>
+      attempt === 1 ? { vehicle_categories: NET_ERR } : {},
+    )
+
+    const results = await fetchRentacarData(supabase, { retries: 2, retryDelayMs: 0 })
+
+    expect(runs()).toBe(2)
+    expect(results.every((r) => r.error === null)).toBe(true)
+  })
+
+  it('SCEN-R2: transient .error on every attempt → no throw, returns .error after 3 runs', async () => {
+    const { supabase, runs } = makeRetrySupabase(() => ({ vehicle_categories: NET_ERR }))
+
+    const results = await fetchRentacarData(supabase, { retries: 2, retryDelayMs: 0 })
+
+    expect(runs()).toBe(3) // retries + 1
+    expect(results.some((r) => r.error)).toBe(true) // handler will map this to 500 (fail-loud preserved)
+  })
+
+  it('SCEN-R3: PGRST116 (missing row) is not retried → 1 batch run', async () => {
+    const pgrst116: Result = { data: null, error: { code: 'PGRST116' }, status: 406 }
+    const { supabase, runs } = makeRetrySupabase(() => ({ rental_companies: pgrst116 }))
+
+    const results = await fetchRentacarData(supabase, { retries: 2, retryDelayMs: 0 })
+
+    expect(runs()).toBe(1)
+    expect(results[2].error).toEqual({ code: 'PGRST116' })
+  })
+
+  it('SCEN-R4: a timeout throws RentacarDataTimeoutError immediately (not retried)', async () => {
+    // A timeout is NOT retried: it propagates on the first attempt → 504. Real
+    // timers + tiny timeout; the stalled queries reject on abort.
+    const { supabase, runs } = makeRetrySupabase(() =>
+      Object.fromEntries(TABLES.map((t) => [t, 'stall' as const])),
+    )
+
+    await expect(
+      fetchRentacarData(supabase, { timeoutMs: 5, retries: 2, retryDelayMs: 0 }),
+    ).rejects.toBeInstanceOf(RentacarDataTimeoutError)
+
+    expect(runs()).toBe(1) // timeouts are not retried
+  })
+
+  it('SCEN-R7: a permanent error mixed with a transient one is not retried → 1 run', async () => {
+    // PGRST205 (schema cache miss, permanent) on one table + a network blip on
+    // another. Retry cannot fix the permanent error, so bail immediately and
+    // let the handler surface it (fail-loud, just not delayed).
+    const permanent: Result = { data: null, error: { code: 'PGRST205' }, status: 404 }
+    const { supabase, runs } = makeRetrySupabase(() => ({
+      vehicle_categories: permanent,
+      cities: NET_ERR,
+    }))
+
+    const results = await fetchRentacarData(supabase, { retries: 2, retryDelayMs: 0 })
+
+    expect(runs()).toBe(1)
+    expect(results.some((r) => r.error)).toBe(true)
   })
 })

--- a/packages/logic/server/utils/rentacarDataFetch.ts
+++ b/packages/logic/server/utils/rentacarDataFetch.ts
@@ -152,18 +152,18 @@ export async function fetchRentacarData(
     retryDelayMs = DEFAULT_RETRY_DELAY_MS,
   }: FetchOptions = {},
 ) {
-  let lastResults: Awaited<ReturnType<typeof runBatch>> | undefined
-  for (let attempt = 0; attempt <= retries; attempt++) {
+  const lastAttempt = Math.max(0, retries) // clamp: retries < 0 still runs once
+  for (let attempt = 0; attempt <= lastAttempt; attempt++) {
     // runBatch throws RentacarDataTimeoutError on timeout — it propagates here
     // unretried (see docstring), surfacing as a 504 in the handler.
     const results = await runBatch(supabase, timeoutMs)
     const errored = results.filter((r) => r.error)
     // Retry only when something errored AND every errored query is transient.
     const shouldRetry = errored.length > 0 && errored.every(isRetryableResult)
-    if (!shouldRetry || attempt === retries) return results
-    lastResults = results
-    logRetry(attempt, retries, errored[0].error)
+    if (!shouldRetry || attempt === lastAttempt) return results
+    logRetry(attempt, lastAttempt, errored[0].error)
     await sleep(retryDelayMs * 2 ** attempt)
   }
-  return lastResults as Awaited<ReturnType<typeof runBatch>>
+  // Unreachable: the final iteration (attempt === lastAttempt) always returns.
+  throw new Error('fetchRentacarData: retry loop exited without returning')
 }

--- a/packages/logic/server/utils/rentacarDataFetch.ts
+++ b/packages/logic/server/utils/rentacarDataFetch.ts
@@ -1,6 +1,17 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 
 const DEFAULT_TIMEOUT_MS = 8000
+const DEFAULT_RETRIES = 2
+const DEFAULT_RETRY_DELAY_MS = 300
+
+interface FetchOptions {
+  /** Per-attempt deadline for the parallel batch. */
+  timeoutMs?: number
+  /** Extra attempts after the first (total attempts = retries + 1). */
+  retries?: number
+  /** Base backoff; attempt N waits `retryDelayMs * 2 ** N` ms. */
+  retryDelayMs?: number
+}
 
 /**
  * Thrown when the parallel Supabase fetch does not complete within the
@@ -16,13 +27,46 @@ export class RentacarDataTimeoutError extends Error {
 }
 
 /**
+ * Classifies a PostgREST result as worth retrying after a transient failure.
+ *
+ * In @supabase/postgrest-js (with `.throwOnError()` off, as here) a network /
+ * DNS / connection failure does NOT throw — it resolves to a result with
+ * `error.code: ''` and `status: 0`. The HTTP status lives on the result
+ * wrapper, never on `error` (PostgrestError has no `status` field).
+ *
+ * - Retryable: network (`code: ''`, `status: 0`), 5xx, PG connection codes
+ *   (e.g. 57P03/53300), and anything unrecognized — a cold-start blip we want
+ *   to recover from. If it's actually persistent, the bounded retry exhausts
+ *   and the caller still fails loud.
+ * - NOT retryable: PostgREST data/schema/auth errors (`PGRST*`, incl. the
+ *   missing-row PGRST116 handled upstream by #16) and HTTP 4xx — retrying
+ *   cannot change the outcome.
+ */
+export function isRetryableResult(result: { error: unknown; status?: number }): boolean {
+  if (!result?.error) return false
+  const code = (result.error as { code?: unknown }).code
+  if (typeof code === 'string' && code.startsWith('PGRST')) return false
+  if (typeof result.status === 'number' && result.status >= 400 && result.status < 500) return false
+  return true
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+function logRetry(attempt: number, retries: number, error: unknown): void {
+  console.warn(
+    `[rentacar-data] transient fetch failure (attempt ${attempt + 1}/${retries + 1}), retrying:`,
+    error,
+  )
+}
+
+/**
  * Runs the 6 rentacar-data Supabase queries in parallel with a hard deadline.
  * A shared AbortController cancels the underlying fetches on timeout so they
  * stop consuming the connection pool — Promise.race alone would leave them
  * running. Returns the raw PostgREST results in fixed order; per-result
  * `.error` interpretation stays in the caller (no behavior change there).
  */
-export async function fetchRentacarData(supabase: SupabaseClient, timeoutMs: number = DEFAULT_TIMEOUT_MS) {
+async function runBatch(supabase: SupabaseClient, timeoutMs: number) {
   const controller = new AbortController()
   const signal = controller.signal
   const timer = setTimeout(() => controller.abort(), timeoutMs)
@@ -80,4 +124,46 @@ export async function fetchRentacarData(supabase: SupabaseClient, timeoutMs: num
   } finally {
     clearTimeout(timer)
   }
+}
+
+/**
+ * Fetches rentacar-data with bounded retry on transient failures.
+ *
+ * A cold first call during build-time prerender can fail transiently (network
+ * warmup, a brief 5xx); the rentacar-data plugin is fail-loud, so one such blip
+ * on the `/` route aborts the whole deploy (#7, #16). This retries with
+ * exponential backoff ONLY when every errored query is transient (see
+ * `isRetryableResult`). Two failures are deliberately NOT retried:
+ *   - a timeout (`RentacarDataTimeoutError`) — a slow upstream won't recover
+ *     within the deadline, and retrying would multiply the tail latency
+ *     (eroding the 8s bound from #7); the cold-start blip we recover from
+ *     surfaces as a fast `.error`, not a timeout;
+ *   - a batch containing any permanent error (PGRST code or HTTP 4xx) — retry
+ *     can't fix it, so retrying only delays the loud failure.
+ * Both still surface (a thrown timeout → 504, an `.error` result → 500), so the
+ * build fails loud — just without the wasted attempts. Backward-compatible with
+ * `fetchRentacarData(supabase)`.
+ */
+export async function fetchRentacarData(
+  supabase: SupabaseClient,
+  {
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    retries = DEFAULT_RETRIES,
+    retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+  }: FetchOptions = {},
+) {
+  let lastResults: Awaited<ReturnType<typeof runBatch>> | undefined
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    // runBatch throws RentacarDataTimeoutError on timeout — it propagates here
+    // unretried (see docstring), surfacing as a 504 in the handler.
+    const results = await runBatch(supabase, timeoutMs)
+    const errored = results.filter((r) => r.error)
+    // Retry only when something errored AND every errored query is transient.
+    const shouldRetry = errored.length > 0 && errored.every(isRetryableResult)
+    if (!shouldRetry || attempt === retries) return results
+    lastResults = results
+    logRetry(attempt, retries, errored[0].error)
+    await sleep(retryDelayMs * 2 ** attempt)
+  }
+  return lastResults as Awaited<ReturnType<typeof runBatch>>
 }


### PR DESCRIPTION
## Summary

Preview/production deploys fail **intermittently** at the Nitro prerender stage. Root cause (verified from the build log of `dpl_CsKHk…`, commit `037c189`): only the home route `/` returns `[500]` — it's the first route prerendered, so it makes the **first, cold** call to `/api/rentacar-data`. That cold call fails transiently (the other 24 routes, same plugin and same Supabase, render `200`). Because the `rentacar-data` plugin is fail-loud and `/` is an explicit `prerender.routes` entry, that one 500 aborts the whole deploy of all three brands.

Evidence it's transient and not PR-specific: the same commit `c617e4b` went ERROR then READY on a plain redeploy; `main` in production (`59866e1`) also errored; and PR #60's prerender-retry-widening attempt still errored.

**Fix:** `fetchRentacarData` now retries the cold blip with bounded exponential backoff (2 retries, 300/600ms) **only when every errored query is transient**, so a genuine outage still fails loud.

## What changed

One production file — `packages/logic/server/utils/rentacarDataFetch.ts` (propagates to all 3 brands via the `@rentacar-main/logic` layer):

- Extracted the existing 6-query parallel batch into `runBatch`.
- Added `isRetryableResult(result)` — keyed on `error.code` (`PGRST*` → no) and `result.status` (4xx → no); network (`code:''`/`status:0`), 5xx and PG connection codes retry. Grounded in `@supabase/postgrest-js@2.101.1` source (a network/abort failure resolves to `{ error: { code: '' }, status: 0 }`, it does **not** throw; `status` lives on the wrapper, not on `PostgrestError`).
- Bounded retry loop. **Two failures are deliberately not retried:** a timeout (`RentacarDataTimeoutError` propagates → 504 — preserves the 8s bound from #7), and a batch containing any permanent error (retry can't fix it).
- Signature is now `(supabase, { timeoutMs, retries, retryDelayMs })`, backward-compatible with the sole caller `server/api/rentacar-data.get.ts`.

**Not touched (out of scope):** the handler, the fail-loud plugin, `prerender.routes`/`failOnError`, and the `swr`/shared-storage cache (that's the remaining #16-F2 follow-up).

## Scenarios (holdout, committed before implementation)

`docs/specs/2026-05-25-rentacar-data-transient-retry/scenarios/rentacar-data-transient-retry.scenarios.md`

- **SCEN-R1** transient on attempt 1, recovers on attempt 2 → returns ok, 2 batch runs *(reproduces the deploy bug)*
- **SCEN-R2** transient on every attempt → no throw, returns `.error` after 3 runs → handler 500 (fail-loud preserved)
- **SCEN-R3** PGRST116 (missing row, #59's case) → not retried, 1 run
- **SCEN-R4** timeout → throws `RentacarDataTimeoutError` immediately, not retried → 504
- **SCEN-R5** `isRetryableResult` classification table (9 cases)
- **SCEN-R6** existing tests migrated to `{ retries: 0 }`, still green
- **SCEN-R7** permanent error mixed with a transient one → not retried, 1 run

Non-regression matrix preserves SCEN-001/002/007, #7/#53 (timeout→504), #12 (faqs query), #16-F1/#59 (PGRST116).

## Test plan

- [x] `pnpm --filter @rentacar-main/logic exec vitest run rentacarDataFetch` → **17 passed** (SCEN-1/2/3 migrated + SCEN-R1..R7), stable across 3 runs
- [x] Red→green observed for both steps (classifier undefined → green; run-count mismatch → green)
- [x] `tsc --strict` on the touched file → clean
- [x] Full logic suite delta = **0 regressions** from this change. (8 intermittent failures appear in `useStoreSearchData.*` store tests — timeout-bound ~5s, do **not** import this file, pass in isolation, present on `main` under load. Pre-existing flakiness, unrelated.)
- [ ] **End-to-end (post-merge):** confirm a green preview deploy. Because the failure was intermittent, ideally confirm with 2+ deploys/redeploys. Watch build logs for `[rentacar-data] transient fetch failure` — if it recurs often, escalate to the #16-F2 cache follow-up rather than bumping `retries`.

## Quality gate

code-reviewer **APPROVED** (0 Critical/Important) · security **clean** (0 High/Medium — `console.warn` logs the error object, which carries no key/PII) · edge-case + performance: the two MEDIUMs were addressed — the `retries < 0` footgun is fixed (clamp + loud throw), and the timeout-tail/`swr` concern is the deferred #16-F2 cache work, not this PR.

## Coverage honesty

The unit suite is the authoritative **mechanism** gate (transient → recovers; outage → fails loud). No unit exercises the real Vercel prerender — the end-to-end gate is the green preview deploy above.

## Relationship to other issues

Refs #7 — adds the transient-resilience hardening; field-narrowing and cache-invalidation remain open.
Refs #16 — addresses the build-time resilience overlap of Finding 2; the `swr`/shared-storage cache strategy is **not** included and stays open. Finding 1 (missing localiza row) is PR #59, which this complements (PGRST116 is classified non-retryable, so #59's degrade path fires with no added latency).

Neither issue is fully closed by this PR.
