### PR TITLE
fix(rentacar-data): scope cache key to app.buildId — stop deploy ERRORs since #58

### DIFF
--- a/docs/specs/2026-05-26-rentacar-data-cache-deploy-scope-design.md
+++ b/docs/specs/2026-05-26-rentacar-data-cache-deploy-scope-design.md
@@ -20,7 +20,7 @@ Cannot read properties of undefined (reading 'map')
 
 `/api/rentacar-data` is a `defineCachedEventHandler({ name: 'rentacar-data', maxAge: 3600 })` (SWR on by default). Its cache persists to `packages/ui-*/.nuxt/cache/nitro/handlers/`, which lives under `node_modules/.cache/nuxt/`.
 
-Vercel **restores the build cache from the previous deployment** — the build log states it verbatim: `Restored build cache from previous deployment (CWPEgb2…)`, which is deploy #57, *before* faqs existed. So the restored cached response is frozen at the pre-faqs shape — it has **no `faqs` key**.
+Vercel **restores the build cache from the previous deployment**. The build log says so verbatim: `Restored build cache from previous deployment (CWPEgb2…)`, which is deploy #57, *before* faqs existed. So the restored cached response is frozen at the pre-faqs shape, with **no `faqs` key**.
 
 The chain:
 1. Prerender renders `/` first. Its plugin calls `$fetch('/api/rentacar-data')`.
@@ -53,7 +53,7 @@ Scope the handler's cache key to a single deployment so a restored cross-build e
 - **Within a deploy:** one stable key → prerender writes the entry, runtime reuses it. The caching benefit is preserved.
 - **Across deploys:** the restored entry sits under the previous build's `buildId`; the new build reads under its own `buildId` → cache miss → fresh Supabase fetch → the response always carries the current schema → `/` renders → deploy green.
 
-A stale-shaped response can never be served to a build that did not produce it. The fix is auto-busting — no manual version to bump on future schema changes — and the only cost is one fresh ~1.5s fetch per deploy during prerender, which is the correct behavior on a new deploy anyway.
+A stale-shaped response can never be served to a build that did not produce it. The fix is auto-busting (no manual version to bump when the schema changes again), and its only cost is one fresh ~1.5s fetch per deploy during prerender — which is the right behavior on a new deploy anyway.
 
 ### Alternatives considered
 
@@ -81,7 +81,7 @@ Fail-loud is preserved unchanged. No throw path is touched: a genuine Supabase f
 
 ## Observable scenarios (holdout for SDD)
 
-- **SCEN-C1** (unit): Given `useRuntimeConfig().app.buildId = X`, when `getKey(event)` runs, then it returns `X`; the same buildId yields the same key, and two distinct buildIds-as-used-here (UUIDs) yield distinct stored keys after Nitro's `escapeKey` (which is lossy in general — `replace(/\W/g, "")` — but injective for UUIDs given their entropy).
+- **SCEN-C1** (unit): Given `useRuntimeConfig().app.buildId = X`, when `getKey(event)` runs, then it returns `X`; the same buildId yields the same key, and two distinct buildIds as used here (UUIDs) yield distinct stored keys after Nitro's `escapeKey` (lossy in general via `replace(/\W/g, "")`, but injective for UUIDs given their entropy).
 - **SCEN-C2** (integration): Given a cache entry stored under `escapeKey(buildIdA)` whose body lacks `faqs`, when the handler is invoked under `buildIdB` (B≠A), then that entry is not served — a fresh fetch runs and the response carries the current schema. (The end-to-end reproduce→fix is SCEN-C6.)
 - **SCEN-C3** (build): Given a clean build, when prerendering all routes, then `/` is `200` and the build exits 0.
 - **SCEN-C4** (build, fail-loud lock): Given a genuine Supabase fetch failure, when building, then the build aborts loud with `[rentacar-data] fetch failed:` and non-zero exit — unchanged from SCEN-003.

--- a/docs/specs/2026-05-26-rentacar-data-cache-deploy-scope-design.md
+++ b/docs/specs/2026-05-26-rentacar-data-cache-deploy-scope-design.md
@@ -72,22 +72,25 @@ Fail-loud is preserved unchanged. No throw path is touched: a genuine Supabase f
 
 ## Testing & verification
 
-1. **Unit (vitest, logic):** the key incorporates `buildId`; distinct builds yield distinct keys, identical within a build.
+1. **Unit (vitest, logic):** `getKey` returns the build's `app.buildId`, so Nitro stores the entry under a per-build key. Two notes for the implementer: Nitro escapes the stored key via `escapeKey` (`String(key).replace(/\W/g, "")`, so a UUID's hyphens are dropped) — a literal-key assertion must apply the same escaping; and because `buildId` is constant under Vitest (`"test"`), the test drives the key logic with explicit `buildId` inputs (mocked `useRuntimeConfig`), not the ambient runtime value.
 2. **Local prod build:** `pnpm build:alquilatucarro` → `/` prerenders `200`, exit 0, no "Exiting due to prerender errors".
-3. **Stale-cache regression:** seed an old-`buildId` entry with the pre-faqs (no-`faqs`) body, build, confirm `/` is still `200` — the incident reproduced, then proven fixed.
-4. **Vercel preview deploy GREEN** — the real end-to-end gate, red since #58. This is the definition of done; the unit test is a regression lock, not the proof.
+3. **Stale-cross-build invariant (integration):** an entry stored under `escapeKey(buildIdA)` with a no-`faqs` body is *not* served to a request running under `buildIdB` (B≠A) — the handler runs a fresh fetch instead. This is the invariant that prevents the incident, and it is observable with the fix in place (no pre-fix code needed).
+4. **Vercel preview deploy GREEN — the real reproduce→fix.** The branch base (main, pre-fix) deploys RED today because it restores #57's stale cache; the fix branch deploys GREEN against that *same* restored cache. This is the definition of done; the unit/integration tests are regression locks, not the proof.
+
+**Toolchain note:** verification runs against the installed `nuxt@4.2.2` / `nitropack@2.12.9` / `@nuxt/schema@4.2.2` (stack.md still cites 4.1.3). The `getKey` option and `app.buildId` semantics are identical across these versions — confirmed against the installed source.
 
 ## Observable scenarios (holdout for SDD)
 
-- **SCEN-C1** (unit): Given two builds with different `buildId`, when `getKey` runs, then the keys differ; given the same `buildId`, the key is identical.
-- **SCEN-C2** (build): Given a restored cache entry under a different `buildId` whose body lacks `faqs`, when `/` is prerendered, then it returns `200` with faqs rendered — not `500`.
+- **SCEN-C1** (unit): Given `useRuntimeConfig().app.buildId = X`, when `getKey(event)` runs, then it returns `X`; two distinct buildIds yield distinct stored keys (after Nitro's `escapeKey`), the same buildId yields the same key.
+- **SCEN-C2** (integration): Given a cache entry stored under `escapeKey(buildIdA)` whose body lacks `faqs`, when the handler is invoked under `buildIdB` (B≠A), then that entry is not served — a fresh fetch runs and the response carries the current schema. (The end-to-end reproduce→fix is SCEN-C6.)
 - **SCEN-C3** (build): Given a clean build, when prerendering all routes, then `/` is `200` and the build exits 0.
 - **SCEN-C4** (build, fail-loud lock): Given a genuine Supabase fetch failure, when building, then the build aborts loud with `[rentacar-data] fetch failed:` and non-zero exit — unchanged from SCEN-003.
-- **SCEN-C5** (cross-brand): the three brands' `rentacar-data.get.ts` stays byte-identical (the change is in the shared logic layer).
+- **SCEN-C5** (single source): no per-brand `rentacar-data.get.ts` override exists; the handler lives only in the shared logic layer, so all 3 brands inherit the change via `extends`.
+- **SCEN-C6** (deploy, end-to-end): Given the branch base deploys RED against #57's restored stale cache, when the fix branch is deployed, then its Vercel preview goes GREEN against that same restored cache.
 
 ## Known limitations
 
-- In **dev**, `buildId` is the constant `"dev"`, so the local `.nuxt` cache still persists across dev restarts. This is a dev-only convenience issue, out of scope here; clearing `.nuxt/cache` or waiting out the 1h `maxAge` resolves it.
+- `app.buildId` is constant in non-prod modes (`"dev"` in dev, `"test"` under Vitest) and a fresh `randomUUID()` per production build. So in **dev** the local `.nuxt` cache still persists across restarts (a dev-only convenience issue — clear `.nuxt/cache` or wait out the 1h `maxAge`), and **unit tests** must exercise the key logic with explicit `buildId` inputs rather than the ambient constant. The busting guarantee applies to production builds, which is exactly where the incident occurs.
 
 ## Follow-ups (not in this change)
 

--- a/docs/specs/2026-05-26-rentacar-data-cache-deploy-scope-design.md
+++ b/docs/specs/2026-05-26-rentacar-data-cache-deploy-scope-design.md
@@ -81,12 +81,12 @@ Fail-loud is preserved unchanged. No throw path is touched: a genuine Supabase f
 
 ## Observable scenarios (holdout for SDD)
 
-- **SCEN-C1** (unit): Given `useRuntimeConfig().app.buildId = X`, when `getKey(event)` runs, then it returns `X`; two distinct buildIds yield distinct stored keys (after Nitro's `escapeKey`), the same buildId yields the same key.
+- **SCEN-C1** (unit): Given `useRuntimeConfig().app.buildId = X`, when `getKey(event)` runs, then it returns `X`; the same buildId yields the same key, and two distinct buildIds-as-used-here (UUIDs) yield distinct stored keys after Nitro's `escapeKey` (which is lossy in general — `replace(/\W/g, "")` — but injective for UUIDs given their entropy).
 - **SCEN-C2** (integration): Given a cache entry stored under `escapeKey(buildIdA)` whose body lacks `faqs`, when the handler is invoked under `buildIdB` (B≠A), then that entry is not served — a fresh fetch runs and the response carries the current schema. (The end-to-end reproduce→fix is SCEN-C6.)
 - **SCEN-C3** (build): Given a clean build, when prerendering all routes, then `/` is `200` and the build exits 0.
 - **SCEN-C4** (build, fail-loud lock): Given a genuine Supabase fetch failure, when building, then the build aborts loud with `[rentacar-data] fetch failed:` and non-zero exit — unchanged from SCEN-003.
 - **SCEN-C5** (single source): no per-brand `rentacar-data.get.ts` override exists; the handler lives only in the shared logic layer, so all 3 brands inherit the change via `extends`.
-- **SCEN-C6** (deploy, end-to-end): Given the branch base deploys RED against #57's restored stale cache, when the fix branch is deployed, then its Vercel preview goes GREEN against that same restored cache.
+- **SCEN-C6** (deploy, end-to-end): Given the branch base deploys RED against #57's restored stale cache, when the fix branch is deployed, then its Vercel preview goes GREEN against that same restored cache. Verification captures *both* artifacts in the same window — the main/branch-base preview observed RED and the fix-branch preview observed GREEN — so the reproduce→fix is evidenced against an identical restored-cache baseline, not just the GREEN half.
 
 ## Known limitations
 

--- a/docs/specs/2026-05-26-rentacar-data-cache-deploy-scope-design.md
+++ b/docs/specs/2026-05-26-rentacar-data-cache-deploy-scope-design.md
@@ -1,0 +1,95 @@
+# Deployment-scoped cache key for `/api/rentacar-data`
+
+**Date:** 2026-05-26
+**Status:** Approved — pending implementation
+**Scope:** `packages/logic/server/api/rentacar-data.get.ts` (shared layer → all 3 brands)
+**Related:** issue #2 / SCEN-003 (fail-loud), faqs→Supabase migration (#58/#12), cache TODOs in #7 and #16-F2. Supersedes the wrong-root-cause attempts PR #60 and PR #61 (both closed).
+
+## Problem
+
+Every Vercel deploy since the faqs→Supabase migration merged (#58, ~2026-05-21) fails, including production. Production is frozen on the last green deploy, #57 (`93bb14a`), so the faqs migration never reached users and nothing new can ship.
+
+The failure is **deterministic**, not a transient blip. During Nitro prerender the `/` route returns `[500] Server Error` while all 24 city routes return 200, which aborts the build ("Exiting due to prerender errors"). The exact thrown error, reproduced locally:
+
+```
+Cannot read properties of undefined (reading 'map')
+  at setup (packages/ui-{brand}/app/pages/index.vue)   // faqs.map(...) in the useSchemaOrg FAQPage block
+```
+
+### Root cause (proven)
+
+`/api/rentacar-data` is a `defineCachedEventHandler({ name: 'rentacar-data', maxAge: 3600 })` (SWR on by default). Its cache persists to `packages/ui-*/.nuxt/cache/nitro/handlers/`, which lives under `node_modules/.cache/nuxt/`.
+
+Vercel **restores the build cache from the previous deployment** — the build log states it verbatim: `Restored build cache from previous deployment (CWPEgb2…)`, which is deploy #57, *before* faqs existed. So the restored cached response is frozen at the pre-faqs shape — it has **no `faqs` key**.
+
+The chain:
+1. Prerender renders `/` first. Its plugin calls `$fetch('/api/rentacar-data')`.
+2. SWR returns the restored stale entry (no `faqs`) immediately.
+3. `useData().faqs` is `undefined`; the homepage `useSchemaOrg` block runs `faqs.map(...)` → throws → `[500]` → build aborts.
+4. City pages render FAQs from hardcoded `useCityFAQs`, never touching `useData().faqs`, so they pass — which is why only `/` fails.
+
+It is not a fetch failure: there is **no `[rentacar-data] fetch failed:`** log (the SCEN-003 fail-loud signature is absent) and a direct call to `/api/rentacar-data` returns 200 with the faqs present. The fetch succeeds; the cache simply hands back a response shaped for an older schema.
+
+The failure is self-perpetuating: failed deploys do not update the cache baseline, so every new deploy keeps restoring #57's stale entry.
+
+### Why the earlier fixes missed
+
+PR #60 (`nitro.prerender { retry: 5, retryDelay: 3000 }`) and PR #61 (bounded retry inside `fetchRentacarData`) both assumed a transient fetch blip. Retrying re-renders `/` against the same stale cache, so neither could ever go green. Both are closed.
+
+## The fix
+
+Scope the handler's cache key to a single deployment so a restored cross-build entry can never match:
+
+```ts
+}, {
+  maxAge: 3600,
+  name: 'rentacar-data',
+  getKey: (event) => useRuntimeConfig(event).app.buildId,
+})
+```
+
+`app.buildId` is unique per production build (Nuxt default; not pinned in this repo) and constant within a build, available at both build and runtime.
+
+- **Within a deploy:** one stable key → prerender writes the entry, runtime reuses it. The caching benefit is preserved.
+- **Across deploys:** the restored entry sits under the previous build's `buildId`; the new build reads under its own `buildId` → cache miss → fresh Supabase fetch → the response always carries the current schema → `/` renders → deploy green.
+
+A stale-shaped response can never be served to a build that did not produce it. The fix is auto-busting — no manual version to bump on future schema changes — and the only cost is one fresh ~1.5s fetch per deploy during prerender, which is the correct behavior on a new deploy anyway.
+
+### Alternatives considered
+
+- **Static schema version in the key** (e.g. `'rentacar-data:v2'`, bumped by hand). Fixes the immediate incident but recurrence depends on a human remembering to bump on every schema change — and this incident *is* a schema change nobody bumped for. Rejected as fragile.
+- **Disable cross-build cache persistence** (force a non-restored storage for the handler). More invasive, fights Vercel's build cache, and risks losing runtime caching. Rejected as disproportionate.
+
+## Error handling
+
+Fail-loud is preserved unchanged. No throw path is touched: a genuine Supabase fetch failure still logs `[rentacar-data] fetch failed:` and aborts the build, exactly as SCEN-003 (issue #2) requires. The consumer (`useFetchRentacarData`, homepage) is not modified — no shape-masking, no silent degradation. The fix changes *which* cache entry is read, never whether failures surface.
+
+## Blast radius
+
+- **Changed:** `packages/logic/server/api/rentacar-data.get.ts` — add `getKey`; refresh the stale cache-strategy TODO comment.
+- **Consumers (behavior unchanged):** `packages/logic/plugins/rentacar-data.ts` → `useFetchRentacarData` → homepage `/`, city pages, reservation flow, across all 3 brands.
+- **New:** one unit test locking the key mechanism; design doc + scenarios.
+
+## Testing & verification
+
+1. **Unit (vitest, logic):** the key incorporates `buildId`; distinct builds yield distinct keys, identical within a build.
+2. **Local prod build:** `pnpm build:alquilatucarro` → `/` prerenders `200`, exit 0, no "Exiting due to prerender errors".
+3. **Stale-cache regression:** seed an old-`buildId` entry with the pre-faqs (no-`faqs`) body, build, confirm `/` is still `200` — the incident reproduced, then proven fixed.
+4. **Vercel preview deploy GREEN** — the real end-to-end gate, red since #58. This is the definition of done; the unit test is a regression lock, not the proof.
+
+## Observable scenarios (holdout for SDD)
+
+- **SCEN-C1** (unit): Given two builds with different `buildId`, when `getKey` runs, then the keys differ; given the same `buildId`, the key is identical.
+- **SCEN-C2** (build): Given a restored cache entry under a different `buildId` whose body lacks `faqs`, when `/` is prerendered, then it returns `200` with faqs rendered — not `500`.
+- **SCEN-C3** (build): Given a clean build, when prerendering all routes, then `/` is `200` and the build exits 0.
+- **SCEN-C4** (build, fail-loud lock): Given a genuine Supabase fetch failure, when building, then the build aborts loud with `[rentacar-data] fetch failed:` and non-zero exit — unchanged from SCEN-003.
+- **SCEN-C5** (cross-brand): the three brands' `rentacar-data.get.ts` stays byte-identical (the change is in the shared logic layer).
+
+## Known limitations
+
+- In **dev**, `buildId` is the constant `"dev"`, so the local `.nuxt` cache still persists across dev restarts. This is a dev-only convenience issue, out of scope here; clearing `.nuxt/cache` or waiting out the 1h `maxAge` resolves it.
+
+## Follow-ups (not in this change)
+
+- The broader cache strategy (shorter `maxAge`, tag-based invalidation from the admin write path) remains open in #7 and #16-F2; this fix does not address pricing-edit propagation latency.
+- An immediate operational alternative — redeploy main with the build cache cleared — would also unblock production, but the code fix is self-unblocking on the next deploy and prevents recurrence, so a manual cache clear is unnecessary.

--- a/docs/specs/2026-05-26-rentacar-data-cache-deploy-scope/implementation/plan.md
+++ b/docs/specs/2026-05-26-rentacar-data-cache-deploy-scope/implementation/plan.md
@@ -1,0 +1,81 @@
+# Implementation Plan — deployment-scoped cache key for `/api/rentacar-data`
+
+**Date:** 2026-05-26
+**Design:** `docs/specs/2026-05-26-rentacar-data-cache-deploy-scope-design.md` (approved; spec-reviewer approved iter2)
+**Branch:** `fix/rentacar-data-cache-schema-drift` (worktree, from `origin/main` @ 59866e1)
+**Scenarios (holdout):** SCEN-C1…C6 from the design doc.
+
+## File structure
+
+Files that change together live together. The change is one cache option plus the seam that makes it testable.
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `packages/logic/server/utils/rentacarDataCacheKey.ts` | **NEW** | Single source of the cache-key derivation: `buildId → key`. Guards the invariant that the key must be deploy-unique (throws on empty `buildId` rather than silently producing a shared key). Pure, no Nitro auto-imports → unit-testable in the node vitest env. |
+| `packages/logic/server/utils/__tests__/rentacarDataCacheKey.test.ts` | **NEW** | Unit lock for SCEN-C1: returns the buildId; distinct buildIds → distinct keys; empty buildId throws. |
+| `packages/logic/server/api/rentacar-data.get.ts` | **MODIFY** | Add `getKey: (event) => rentacarDataCacheKey(useRuntimeConfig(event).app.buildId)` to the cached-handler options; refresh the stale cache-strategy TODO comment to record the deploy-scoping. No change to any fetch/throw path. |
+
+The helper lives in `server/utils/` beside `rentacarDataFetch.ts`, matching the existing pattern of extracting handler logic into testable utils (`fetchRentacarData` was extracted for the same reason in #7). The handler stays the only consumer. All three brands inherit the change through the shared `logic` layer — no per-brand file exists (SCEN-C5).
+
+## Prerequisites
+
+- **`pnpm install` in the worktree first** — a fresh git worktree has no `node_modules`. Needed before unit tests, build, or confirming Nitro's `escapeKey` against installed source.
+- Local prod-build verification uses the existing `.env.local` (Supabase creds): `nuxt build --dotenv ../../.env.local` from `packages/ui-alquilatucarro`.
+- Worktree already created; baseline is `origin/main` (carries the bug).
+
+## Implementation steps
+
+### Step 1 — Deploy-scoped cache key (the fix) · Size: S · Deps: none
+
+Introduce `rentacarDataCacheKey(buildId)` and wire it into the cached handler so the entry is stored under the per-build `app.buildId`; update the TODO comment. A restored cross-build entry then sits under a different key and is never served.
+
+**Scenarios:** SCEN-C1 (key derivation), SCEN-C3 (clean build → `/` 200), SCEN-C5 (single source).
+
+**Acceptance criteria:**
+- `rentacarDataCacheKey('a') === 'a'`; `rentacarDataCacheKey('a') !== rentacarDataCacheKey('b')`; `rentacarDataCacheKey('')` throws. Unit test green (`pnpm --filter @rentacar-main/logic test`).
+- `rentacar-data.get.ts` passes `getKey` reading `useRuntimeConfig(event).app.buildId` via the helper; no fetch/throw path edited (diff shows only the option + comment + import).
+- Local prod build of alquilatucarro: `/` prerenders **200**, exit 0, no "Exiting due to prerender errors"; the written cache entry is at `packages/ui-alquilatucarro/.nuxt/cache/nitro/handlers/rentacar-data/<escaped-buildId>.json`, **not** the old request-hash filename — proving the key is buildId-scoped. Read this together with the design's SCEN-C1 note: `escapeKey` strips `\W`, so the filename is the UUID with hyphens removed; assert on the escaped form, not the raw `buildId`.
+- `find packages -path '*/server/api/rentacar-data.get.ts'` returns exactly one path (the logic layer).
+- The empty-`buildId` guard fires only on misconfiguration: per the design, `app.buildId` is a `randomUUID()` on a prod build and the literal `"dev"`/`"test"` otherwise — always non-empty — so a normal build never trips the throw.
+
+### Step 2 — Adversarial regression: stale entry ignored, fail-loud intact · Size: S · Deps: Step 1
+
+Prove the actual incident cannot recur and that fail-loud is untouched.
+
+**Scenarios:** SCEN-C2 (cross-build stale entry not served), SCEN-C4 (fail-loud preserved).
+
+**Acceptance criteria:**
+- With Step 1 built, seed a cache entry under a *different* buildId filename whose body lacks `faqs`, then run the build / request `/`: the seeded entry is **not** served (fresh fetch runs; `/` is 200 with faqs). This reproduces the incident's fixture against the fixed code and shows it no longer crashes.
+- Fail-loud unchanged: `git diff origin/main -- packages/logic/server/api/rentacar-data.get.ts` shows only the `getKey` option, the comment refresh, and the helper import — no change to any `createError`/`throw`/`console.error` line. The plugin's `console.error('[rentacar-data] fetch failed:', …)` + `throw` are untouched. A genuine fetch failure still aborts the build loud — SCEN-003 invariant intact.
+
+### Step 3 — Deploy gate (definition of done) · Size: S · Deps: Steps 1–2
+
+Push the branch and observe the Vercel preview, capturing the reproduce→fix evidence.
+
+**Scenario:** SCEN-C6 (preview GREEN against the same restored cache).
+
+**Acceptance criteria:**
+- The fix branch's Vercel preview deploy reaches **READY** (all 3 brands), with `/` served — the first green deploy since #58.
+- Evidence captured for both halves of reproduce→fix: the current main/branch-base preview observed RED (restores #57's stale cache) and the fix-branch preview observed GREEN against that same restored baseline.
+- Push only after explicit user authorization (CLAUDE.md: no `git push` without it).
+
+## Testing strategy
+
+- **Unit (vitest, logic):** `rentacarDataCacheKey` — SCEN-C1. Runs in the existing node env, no Nitro globals (the reason the logic lives in a pure helper). Delta-vs-baseline acceptance per the repo's red typecheck/lint baseline.
+- **Build-artifact (scripted, local):** prod build → `/` 200 + cache filename = escaped buildId — SCEN-C3, and the key half of SCEN-C1's wiring. Stale-seed build → `/` 200 — SCEN-C2.
+- **Diff inspection:** fetch/throw paths unchanged — SCEN-C4; single handler file — SCEN-C5.
+- **Deploy:** Vercel preview GREEN — SCEN-C6, the real definition of done.
+
+The unit test is a fast in-suite regression lock; the build and deploy observations are the faithful proof that the incident is fixed. No scenario is satisfied by weakening it to match output.
+
+## Rollout plan
+
+1. Open PR `fix/rentacar-data-cache-schema-drift` → `main` (after user authorizes push). PR body: root cause, the one-line fix, the reproduce→fix evidence (RED base / GREEN fix), and that it supersedes the closed #60/#61. `Refs #2` (fail-loud context); does not fully close #7/#16-F2 (broader cache strategy remains).
+2. Merge unblocks the deploy pipeline: the next `main` deploy restores the (now key-mismatched) stale cache, misses, fetches fresh, and goes green — production catches up to the faqs migration.
+3. **Monitoring:** confirm the post-merge production deploy is READY; spot-check `/` renders FAQs on all 3 brands.
+4. **Rollback:** revert the single commit. The cache-key change is self-contained and side-effect-free; reverting returns to the prior (broken) keying. Production stays on the last green deploy regardless, so a bad change cannot take the live site down — only the deploy would error, as today.
+
+## Out of scope / follow-ups
+
+- Broader cache strategy (shorter `maxAge`, tag-based invalidation from the admin write path) — #7 / #16-F2.
+- Dev-mode cache persistence (`buildId === "dev"`) — dev convenience only; clear `.nuxt/cache` if needed.

--- a/docs/specs/2026-05-26-rentacar-data-cache-deploy-scope/scenarios/rentacar-data-cache-deploy-scope.scenarios.md
+++ b/docs/specs/2026-05-26-rentacar-data-cache-deploy-scope/scenarios/rentacar-data-cache-deploy-scope.scenarios.md
@@ -1,0 +1,45 @@
+---
+name: rentacar-data-cache-deploy-scope
+created_by: claude-sdd
+created_at: 2026-05-26T00:00:00Z
+---
+
+# Scenarios — deployment-scoped cache key for `/api/rentacar-data`
+
+Holdout for the fix in `../implementation/plan.md`. Root cause + design: `../../2026-05-26-rentacar-data-cache-deploy-scope-design.md`.
+
+## SCEN-C1: cache key is derived from buildId, and refuses an empty buildId
+**Given**: the pure helper `rentacarDataCacheKey(buildId)`
+**When**: it is called with `"build-A"`, then `"build-B"`, then `""`
+**Then**: it returns `"build-A"`; `rentacarDataCacheKey("build-A") !== rentacarDataCacheKey("build-B")` (distinct builds never collide); and `rentacarDataCacheKey("")` throws (an empty buildId would silently collapse to one shared key, re-creating the cross-build leak — so it must fail loud)
+**Evidence**: vitest assertions in `packages/logic/server/utils/__tests__/rentacarDataCacheKey.test.ts`, run output green
+
+## SCEN-C2: a stale cross-build cache entry is never served
+**Given**: a Nitro cache entry stored under `escapeKey(buildIdA)` in `handlers/rentacar-data/` whose body lacks the `faqs` key (the pre-faqs shape that crashes `/`)
+**When**: the cached handler is invoked under a different `buildIdB` (B≠A) — i.e. a new deploy/build
+**Then**: the seeded entry is not served; the handler runs a fresh fetch and the response carries the current schema (with `faqs`); `/` renders 200, not 500
+**Evidence**: the cache entry written by the build is `handlers/rentacar-data/<escapeKey(buildIdB)>.json` (distinct filename from the seeded `escapeKey(buildIdA)`), and `/` prerenders 200 in the build log
+
+## SCEN-C3: a clean build prerenders `/` successfully
+**Given**: a production build with no restored stale cache
+**When**: `nuxt build` (alquilatucarro) prerenders all routes
+**Then**: `/` is `200`, the build exits 0, and the log contains no "Exiting due to prerender errors"
+**Evidence**: build log line `├─ / (…ms)` with no `[500]`, and process exit code 0
+
+## SCEN-C4: fail-loud on a genuine fetch failure is preserved (SCEN-003 unchanged)
+**Given**: the cache-key change applied
+**When**: comparing the handler/plugin error paths against `origin/main`
+**Then**: the plugin's `console.error('[rentacar-data] fetch failed:', …)` + `throw`, and the handler's per-result `createError(500)` / `504` paths, are byte-identical to `origin/main` — a genuine Supabase fetch failure still aborts the build loud, exactly as issue #2 / SCEN-003 requires
+**Evidence**: `git diff origin/main -- packages/logic/server/api/rentacar-data.get.ts` shows only the `getKey` option, the helper import, and the comment refresh — no change to any `throw` / `createError` / `console.error` line; the plugin file is unchanged
+
+## SCEN-C5: the handler is a single shared source, not a per-brand copy
+**Given**: the repository
+**When**: `find packages -path '*/server/api/rentacar-data.get.ts'`
+**Then**: exactly one path is returned, in the shared logic layer; no per-brand override exists, so all 3 brands inherit the change via `extends`
+**Evidence**: `find` output is a single line `packages/logic/server/api/rentacar-data.get.ts`
+
+## SCEN-C6: the fix-branch preview deploy is GREEN against the same restored cache (definition of done)
+**Given**: the branch base (`main`, pre-fix) deploys RED today because Vercel restores #57's stale cache
+**When**: the fix branch is deployed to a Vercel preview (restoring that same cache)
+**Then**: the preview reaches READY for all 3 brands with `/` served — the first green deploy since #58 — while the base stays RED, evidencing reproduce→fix against an identical restored-cache baseline
+**Evidence**: Vercel deployment `readyState: READY` for the fix-branch preview (vs `ERROR` for the base), and its build log shows `├─ / (…ms)` with no `[500]` / no "Exiting due to prerender errors"

--- a/docs/specs/2026-05-26-rentacar-data-cache-deploy-scope/summary.md
+++ b/docs/specs/2026-05-26-rentacar-data-cache-deploy-scope/summary.md
@@ -1,0 +1,31 @@
+# Planning Summary: deployment-scoped cache key for `/api/rentacar-data`
+
+**Date:** 2026-05-26
+**Goal:** Stop every Vercel deploy from failing since #58 by scoping the `rentacar-data` cache to a single deployment, so a restored cross-build response with an outdated schema can never crash the `/` prerender.
+
+## Artifacts
+- `../2026-05-26-rentacar-data-cache-deploy-scope-design.md` — approved design (root cause, fix, alternatives, scenarios C1–C6). Spec-reviewer approved (iter2).
+- `implementation/plan.md` — file structure + 3-step plan with scenario-embedded acceptance criteria. Plan-reviewer approved.
+- `summary.md` — this file.
+
+(No `rough-idea`/`idea-honing`/`research`/`detailed-design` — the design came from `/brainstorming`; sop-planning consumed it and produced the file structure + implementation plan, per the brainstorming→planning handoff.)
+
+## Key decisions
+1. **Per-deploy cache key via `app.buildId`** (Approach A) over a manually-bumped static version (B, fragile) or disabling persistence (C, invasive). Auto-busting, no recurrence, keeps within-deploy caching.
+2. **Fail-loud preserved** — no consumer-side shape-masking; SCEN-003 (issue #2) stays intact. The fix changes which cache entry is read, never whether failures surface.
+3. **Pure `rentacarDataCacheKey(buildId)` helper** extracted for a node-env unit test (matches the `fetchRentacarData` extract-for-testability pattern) and to guard the deploy-unique invariant (throws on empty `buildId`).
+4. **Definition of done = Vercel preview GREEN**, capturing both the RED base and GREEN fix against the same restored cache — not the unit test.
+
+## Complexity
+- **Overall:** S (one option + one tiny helper + one unit test + comment).
+- **Duration:** ~1–2h including local build + deploy verification.
+- **Risk:** Low. Self-contained, side-effect-free; a bad change only errors the deploy (live site stays on the last green deploy), and revert is a one-commit rollback.
+
+## Recommended next steps
+1. Proceed to `/scenario-driven-development` with SCEN-C1–C6 as the holdout.
+2. Implement Step 1 (helper + handler), then Step 2 (adversarial regression), red→green.
+3. `/verification-before-completion` before the PR.
+4. Open PR after user authorizes push; the deploy gate (SCEN-C6) is the final proof.
+
+## Open questions
+- None blocking. Broader cache strategy (tag-based invalidation, `maxAge`) stays deferred to #7 / #16-F2.

--- a/packages/logic/server/api/rentacar-data.get.ts
+++ b/packages/logic/server/api/rentacar-data.get.ts
@@ -1,5 +1,6 @@
 import { useSupabaseClient } from '../utils/supabase'
 import { fetchRentacarData, RentacarDataTimeoutError } from '../utils/rentacarDataFetch'
+import { rentacarDataCacheKey } from '../utils/rentacarDataCacheKey'
 import { transformCategories, transformBranches, transformExtras, transformVehicleCategories, transformCities, transformFranchiseTestimonials, transformFAQs } from '../utils/transformers'
 
 export default defineCachedEventHandler(async () => {
@@ -46,10 +47,17 @@ export default defineCachedEventHandler(async () => {
     faqs: transformFAQs(faqsResult.data),
   }
 }, {
-  // TODO(perf+seo): revisit cache strategy before launch. 1h is fine while in
-  // alpha but pricing edits in admin take up to 1h to surface. Options:
-  // shorter maxAge, swr revalidation, or tag-based invalidation triggered
-  // from the admin write path.
   maxAge: 3600,
   name: 'rentacar-data',
+  // Scope the cache to a single deployment. Vercel restores Nitro's persisted
+  // handler cache across builds, so without a per-build key a new deploy can be
+  // served the previous deploy's response — whose schema may predate the current
+  // code (e.g. a body without `faqs`), which crashes the `/` prerender. Keying on
+  // app.buildId (unique per prod build, stable within a build) makes a restored
+  // entry sit under the old key and be ignored, while the cache is still reused
+  // within a deploy. See docs/specs/2026-05-26-rentacar-data-cache-deploy-scope-design.md.
+  getKey: (event) => rentacarDataCacheKey(useRuntimeConfig(event).app.buildId),
+  // TODO(perf+seo): broader cache strategy still open (#7 / #16-F2) — pricing
+  // edits in admin take up to 1h (maxAge) to surface; options are a shorter
+  // maxAge, swr, or tag-based invalidation from the admin write path.
 })

--- a/packages/logic/server/utils/__tests__/rentacarDataCacheKey.test.ts
+++ b/packages/logic/server/utils/__tests__/rentacarDataCacheKey.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { rentacarDataCacheKey } from '../rentacarDataCacheKey'
+
+// SCEN-C1: the rentacar-data cache key is derived from the build's app.buildId,
+// so a restored cross-build entry (different buildId) can never collide with the
+// current build's key. An empty buildId must fail loud rather than silently
+// collapse every build onto one shared key (which would re-create the leak).
+describe('rentacarDataCacheKey (SCEN-C1)', () => {
+  it('returns the buildId as the cache key', () => {
+    expect(rentacarDataCacheKey('build-A')).toBe('build-A')
+  })
+
+  it('yields distinct keys for distinct buildIds (no cross-build collision)', () => {
+    expect(rentacarDataCacheKey('build-A')).not.toBe(rentacarDataCacheKey('build-B'))
+  })
+
+  it('is stable for the same buildId (within-deploy cache reuse)', () => {
+    expect(rentacarDataCacheKey('build-A')).toBe(rentacarDataCacheKey('build-A'))
+  })
+
+  it('throws on an empty buildId (refuses a shared key)', () => {
+    expect(() => rentacarDataCacheKey('')).toThrow()
+  })
+
+  it('throws on a non-string buildId (defensive against a missing runtimeConfig)', () => {
+    // @ts-expect-error — exercising the runtime guard for an absent buildId
+    expect(() => rentacarDataCacheKey(undefined)).toThrow()
+  })
+})

--- a/packages/logic/server/utils/rentacarDataCacheKey.ts
+++ b/packages/logic/server/utils/rentacarDataCacheKey.ts
@@ -1,0 +1,26 @@
+/**
+ * Cache key for the `/api/rentacar-data` cached handler, scoped to a single
+ * deployment via Nuxt's per-build `app.buildId`.
+ *
+ * Why: Vercel restores Nitro's persisted handler cache across builds. Keyed by
+ * the request alone, a new build inherits the previous deploy's cached response
+ * — whose schema may predate the current code (e.g. a body without `faqs`),
+ * which crashes the `/` prerender. Scoping the key to `buildId` puts a restored
+ * entry under the previous build's key, so it is never served to a new build;
+ * within a single deploy the key is stable, so prerender + runtime still share
+ * one cache entry.
+ *
+ * An empty or missing `buildId` would collapse every build onto one shared key
+ * and re-create the leak, so we fail loud rather than degrade silently. A throw
+ * here rejects the handler's `$fetch`, surfacing through the plugin as the
+ * `[rentacar-data] fetch failed:` fail-loud path (SCEN-003) — never a silent
+ * fallback to Nitro's request-derived key.
+ */
+export function rentacarDataCacheKey(buildId: string): string {
+  if (typeof buildId !== 'string' || buildId.length === 0) {
+    throw new Error(
+      'rentacar-data cache: app.buildId is empty (check runtimeConfig.app / a NITRO_APP_BUILD_ID override); refusing a deploy-shared cache key that would leak stale responses across deploys',
+    )
+  }
+  return buildId
+}


### PR DESCRIPTION
## Summary

Every Vercel deploy since the faqs→Supabase migration merged (#58) has failed — **including production**, which is frozen on the last green deploy #57 (`93bb14a`). This `fix` scopes the `/api/rentacar-data` cached-handler key to the deployment so a restored cross-build response can never crash the `/` prerender again. One file in the shared `logic/` layer + a tiny helper + unit test (Δ67 LOC code, complexity **S**); all 3 brands inherit it via `extends`.

**Supersedes the wrong-root-cause attempts #60 (prerender retry) and #61 (fetch retry), both closed.**

## Root cause (proven)

`/api/rentacar-data` is a `defineCachedEventHandler({ name: 'rentacar-data', maxAge: 3600 })` (SWR). Its cache persists under `node_modules/.cache/nuxt/.nuxt/cache/nitro/handlers/`, and **Vercel restores the build cache from the previous deployment** (build log: `Restored build cache from previous deployment (CWPEgb2…)` = deploy #57, *before* faqs existed). So the restored response is frozen at the pre-faqs shape — **no `faqs` key**.

During prerender, `/` is rendered first; its plugin `$fetch('/api/rentacar-data')` gets the stale SWR cache hit, `useData().faqs` is `undefined`, and the homepage's `useSchemaOrg` block runs `faqs.map(...)` → `Cannot read properties of undefined (reading 'map')` → `[500]` → "Exiting due to prerender errors" → deploy ERROR.

It is **deterministic**: only `/` renders Supabase faqs, so only `/` failed while the 24 city routes (hardcoded `useCityFAQs`) passed. It is **not** a fetch failure — there is no `[rentacar-data] fetch failed:` log, and a direct call returns 200 with faqs. The earlier retry-based PRs (#60/#61) couldn't help because retrying re-renders `/` against the same stale cache.

## The fix

```ts
}, {
  maxAge: 3600,
  name: 'rentacar-data',
  getKey: (event) => rentacarDataCacheKey(useRuntimeConfig(event).app.buildId),
})
```

`app.buildId` is unique per production build (Nuxt default) and stable within a build. A restored entry sits under the previous build's key and is ignored → fresh fetch carries the current schema → `/` renders → deploy green. Within a deploy the key is stable, so prerender + runtime caching are preserved. Auto-busting: no manual version to bump on future schema changes. The helper throws on an empty `buildId` (which would collapse every build onto one shared key and re-create the leak) — fail-loud, consistent with SCEN-003.

## Changes (7 commits)

- `b9807fc` fix(rentacar-data): scope cache key to app.buildId
- `a66b98e` test(spec): SCEN-C1..C6 holdout
- `ae12592` docs(plan): implementation plan + summary
- `59ad5fe`…`6fd8728` docs(spec): design + spec-review iterations + humanizer pass

## Pre-PR quality gate

- **Code review:** APPROVE for merge — 0 Critical/Important.
- **Security:** clean — 0 High/Medium/Low. Cache key is build-time `buildId`, never request-derived → no cache poisoning/injection; same public data for all users → no cross-user exposure; no secrets.
- **Edge cases:** 0 Critical/High. 1 MEDIUM (latent): a deliberate runtime `NITRO_APP_BUILD_ID=""` override would make `getKey` throw on every request — operator-controlled, not attacker-reachable, and fails loud immediately at the deploy smoke-test. Not a blocker.
- **Performance:** neutral — cache still hits within a deploy; the only added cost is one fresh ~1.5s fetch per deploy (correct on a new deploy).

All four agents verified the mechanics against the installed `nitropack@2.12.9` / `@nuxt/schema@4.2.2` source and the built `.output`.

### Observations
| Check | Status |
|-------|--------|
| Tests | ✅ unit added (`rentacarDataCacheKey.test.ts`) |
| API Changes | ⚠️ expected — the fix is in `server/api/rentacar-data.get.ts` |
| Breaking Changes | ✅ none |
| Complexity | ✅ S (Δ67 LOC code) |

## Scenarios & verification (SCEN-C1…C6)

- **C1** unit: `vitest run rentacarDataCacheKey.test.ts` → **5 passed** (incl. empty-buildId throw), stable across runs.
- **C2** (observed): two local prod builds wrote **distinct** entries `escapeKey(buildId)` (`1671…`, `6e79…`); the 2nd build ignored the 1st's entry and fetched fresh.
- **C3**: clean `nuxt build` → `/` prerenders **200**, exit 0, no "Exiting due to prerender errors".
- **C4** fail-loud preserved: `git diff origin/main` shows `throw`/`createError`/`console.error` paths byte-identical; plugin unchanged. (A no-creds build empirically confirmed the fail-loud signature.)
- **C5**: single shared handler — no per-brand override.
- **C6** (deploy gate, **this PR's preview**): the definition of done — the preview should go **GREEN** against the same restored cache that keeps `main` RED. Capturing both artifacts is the reproduce→fix evidence.

No regressions: `pnpm --filter @rentacar-main/logic test` → **232 passed, 0 failed** (clean run).

## Test plan
- [x] Bug reproduced before fix (local: stale cache → `/` 500 `faqs.map undefined`; refresh → 200)
- [x] Regression test added (SCEN-C1 unit; C2/C3 build-artifact)
- [ ] Verified on preview deploy (SCEN-C6 — the merge gate)

## Notes
- Refs #2 (fail-loud contract), #7 (cache invalidation), #16 (cache strategy: swr + shared storage). This is a targeted slice; the broader cache strategy (shorter `maxAge`, tag-based invalidation) stays open in #7 / #16.
- Design + scenarios: `docs/specs/2026-05-26-rentacar-data-cache-deploy-scope-design.md` and `.../scenarios/`.
