### PR TITLE
perf(images): route category-model images through the Vercel optimizer (#48)

### DIFF
--- a/docs/specs/2026-05-27-model-image-optimization/scenarios/model-image-optimization.scenarios.md
+++ b/docs/specs/2026-05-27-model-image-optimization/scenarios/model-image-optimization.scenarios.md
@@ -1,0 +1,55 @@
+---
+name: model-image-optimization
+created_by: claude
+created_at: 2026-05-27T00:00:00Z
+issue: 48
+---
+
+# Model image optimization (#48)
+
+Holdout for the post-search category-model images. Root cause (runtime-verified):
+the model `<img>` (`Carrusel.vue`, `:src="item.image"`) points at an absolute
+external Vercel Blob URL, and `@nuxt/image` has no `image.domains` entry for that
+host, so the images bypass `/_vercel/image` and are served as raw ~412 KB JPEGs.
+The optimizer itself works (same host is already in the `remotePatterns` allowlist):
+`/_vercel/image?...&w=640&q=80` → `200 image/webp` ~45 KB.
+
+The authoritative scenarios are runtime (preview deploy). SCEN-004 is a fast local
+proxy. Blob host observed in prod: `9grznib0czdjtk77.public.blob.vercel-storage.com`
+(shared across the 3 brands — `vehicle_categories` query is not franchise-scoped).
+
+## SCEN-001: model image is served through the optimizer, not raw
+**Given**: a user lands on a real results page (post availability search) on any brand preview (alquilatucarro / alquilame / alquicarros)
+**When**: a category-model `<img>` (the `Carrusel` slide) renders
+**Then**: its resolved `currentSrc` is a `/_vercel/image?url=…&w=…&q=80` URL — and is NOT a raw `https://<store>.public.blob.vercel-storage.com/….jpeg`
+**Evidence**: agent-browser `currentSrc` of model `img` elements on a preview results URL; zero `currentSrc` matching the raw `*.blob.vercel-storage.com/*.jpeg` pattern
+
+## SCEN-002: optimized variant is WebP
+**Given**: the optimized model-image URL resolved in SCEN-001
+**When**: fetched with header `Accept: image/avif,image/webp,*/*`
+**Then**: HTTP `200` with `content-type: image/webp` and `cache-control` `max-age` ≥ 2678400
+**Evidence**: `curl -sI` response headers of the rendered `currentSrc`
+
+## SCEN-003: variant is right-sized and light
+**Given**: a model card rendered at ~360–400 px width (lg grid, `grid-cols-3`) on a 2× DPR viewport
+**When**: the browser selects the `srcset` candidate for the model image
+**Then**: the served variant has width `≤ 768` and transferred size `≤ ~80 KB` (versus the ~412 KB raw JPEG baseline) — a ≥5× reduction
+**Evidence**: `content-length` of the served `currentSrc` + its `w` query param
+
+## SCEN-004: Blob host whitelisted in each brand's resolved Nuxt config
+**Given**: each brand package (`ui-alquilatucarro`, `ui-alquilame`, `ui-alquicarros`)
+**When**: the brand's Nuxt `image` config is resolved
+**Then**: `image.domains` contains `9grznib0czdjtk77.public.blob.vercel-storage.com`
+**Evidence**: brand config-hygiene unit test (pattern of `packages/ui-*/tests/*.test.ts`) asserting `image.domains` includes the host; fails before the fix, passes after
+
+## SCEN-005: first card loads eagerly (LCP), the rest lazily
+**Given**: a results page with ≥ 2 available category cards
+**When**: inspecting the model `<img>` loading attributes across cards
+**Then**: the FIRST card's first/visible model image has `loading="eager"` and `fetchpriority="high"`; every other model image has `loading="lazy"`
+**Evidence**: agent-browser attribute capture (`loading`, `fetchpriority`) across the first card vs subsequent cards
+
+## SCEN-006: local images keep working (no regression)
+**Given**: the same preview results page
+**When**: auditing every `<img>` `currentSrc` on the page
+**Then**: local images (e.g. `/images/ciudades/chica.webp`) still resolve through `/_vercel/image` as webp (count ≥ the 7 observed pre-fix), AND the count of raw `*.blob.vercel-storage.com/*.jpeg` `currentSrc` is `0`
+**Evidence**: agent-browser audit of `document.images` — `viaOptimizer` count for local images unchanged or higher, `rawBlob` count == 0

--- a/packages/ui-alquicarros/app/components/Carrusel.vue
+++ b/packages/ui-alquicarros/app/components/Carrusel.vue
@@ -1,6 +1,6 @@
 <template>
     <UCarousel
-      v-slot="{ item }"
+      v-slot="{ item, index }"
       :items="vehicleModels"
       dots
       prev-icon="lucide:chevron-left"
@@ -21,7 +21,9 @@
           :alt="item.nombre"
           width="800"
           height="480"
-          loading="lazy"
+          sizes="100vw md:50vw lg:33vw"
+          :loading="(priority && index === 0) ? 'eager' : 'lazy'"
+          :fetchpriority="(priority && index === 0) ? 'high' : 'auto'"
           decoding="async"
           class="w-full"
         />
@@ -35,7 +37,11 @@ interface CarruselProps {
   category: CategoryType;
   models?: CategoryModelData[];
   vehicleModels?: VehicleCategoryModel[]
+  // LCP: solo la primera card pasa priority=true → su primer slide carga eager.
+  priority?: boolean;
 }
 
-defineProps<CarruselProps>();
+withDefaults(defineProps<CarruselProps>(), {
+  priority: false,
+});
 </script>

--- a/packages/ui-alquicarros/app/components/CategoryCard.vue
+++ b/packages/ui-alquicarros/app/components/CategoryCard.vue
@@ -6,6 +6,7 @@
           :models="categoryModels"
           :vehicleModels="modelos"
           :category="categoryCode"
+          :priority="priority"
         />
       </div>
 
@@ -609,8 +610,11 @@ const Carrusel = defineAsyncComponent(() => import('./Carrusel.vue'))
 import type { CategoryProps } from '@rentacar-main/logic/utils';
 
 /** props */
-const props = withDefaults(defineProps<CategoryProps>(), {
+// `priority` es local a la card (LCP): NO se agrega al tipo compartido CategoryProps,
+// se extiende por intersección. Solo la primera card lo recibe en true.
+const props = withDefaults(defineProps<CategoryProps & { priority?: boolean }>(), {
   showButton: true,
+  priority: false,
 });
 
 /** emits */

--- a/packages/ui-alquicarros/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquicarros/app/components/CategorySelectionSection.vue
@@ -40,7 +40,7 @@
       </div>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-      <template v-for="category in filteredCategories" :key="`cat-${category.categoryCode}`">
+      <template v-for="(category, index) in filteredCategories" :key="`cat-${category.categoryCode}`">
         <placeholders-unable-category-card
           v-if="
             category.estimatedTotalAmount == 999999999 &&
@@ -53,6 +53,7 @@
           v-else-if="vehicleCategories[category.categoryCode]"
           :category
           :vehicle-category="vehicleCategories[category.categoryCode]"
+          :priority="index === 0"
           @selected-category="setSelectedCategory"
         />
       </template>

--- a/packages/ui-alquicarros/app/components/__tests__/model-image-optimization.test.ts
+++ b/packages/ui-alquicarros/app/components/__tests__/model-image-optimization.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Issue #48 — model-image-optimization holdout (source-string idiom).
+ * Scenarios: docs/specs/2026-05-27-model-image-optimization/scenarios/model-image-optimization.scenarios.md
+ *
+ * Post-search, CategoryCard → Carrusel.vue renders model images from an absolute
+ * external Vercel Blob URL. @nuxt/image only optimizes external hosts listed in
+ * image.domains; without the entry the raw ~412KB JPEG is served. These tests
+ * lock the two static guarantees behind that fix.
+ */
+
+const BLOB_HOST = '9grznib0czdjtk77.public.blob.vercel-storage.com'
+
+const nuxtConfig = readFileSync(
+  fileURLToPath(new URL('../../../nuxt.config.ts', import.meta.url)),
+  'utf8',
+)
+const carrusel = readFileSync(
+  fileURLToPath(new URL('../Carrusel.vue', import.meta.url)),
+  'utf8',
+)
+
+describe('model-image-optimization — nuxt.config image.domains (SCEN-004)', () => {
+  it('declares an image.domains array', () => {
+    expect(nuxtConfig).toMatch(/image:\s*\{[\s\S]*?domains:\s*\[/)
+  })
+
+  it('whitelists the shared Blob host so external model images route through the optimizer', () => {
+    // domains entry, not just the comment / remotePatterns hook
+    expect(nuxtConfig).toMatch(
+      new RegExp(`domains:\\s*\\[[^\\]]*['"]${BLOB_HOST.replace(/\./g, '\\.')}['"]`),
+    )
+  })
+})
+
+describe('model-image-optimization — Carrusel.vue model image (SCEN-002/003 + SCEN-005)', () => {
+  it('declares responsive sizes in @nuxt/image breakpoint shorthand, not CSS media queries', () => {
+    const match = carrusel.match(/sizes="([^"]*)"/)
+    expect(match?.[1]).toBeTruthy()
+    const sizes = match?.[1] ?? ''
+    // @nuxt/image parses its own `screenKey:value` shorthand. CSS media-query
+    // syntax (`(min-width: …)`) or calc() mis-parses → srcset collapses to a
+    // single 320px variant and the LCP image upscales/blurs. Lock the shorthand.
+    expect(sizes).not.toMatch(/\(min-width|\(max-width|calc\(/)
+    expect(sizes).toMatch(/\bmd:\d+vw\b/)
+    expect(sizes).toMatch(/\blg:\d+vw\b/)
+  })
+
+  it('keeps intrinsic width/height to avoid CLS', () => {
+    expect(carrusel).toMatch(/width="800"/)
+    expect(carrusel).toMatch(/height="480"/)
+  })
+
+  it('eager-loads only the priority first slide, lazy otherwise (LCP)', () => {
+    // the slide index must be exposed so only the first slide can be eager
+    expect(carrusel).toMatch(/v-slot="\{\s*item\s*,\s*index\s*\}"/)
+    // conditional loading/fetchpriority gated on the priority prop AND first slide
+    expect(carrusel).toMatch(
+      /:loading="\(?\s*priority\s*&&\s*index\s*===\s*0\s*\)?\s*\?\s*'eager'\s*:\s*'lazy'"/,
+    )
+    expect(carrusel).toMatch(
+      /:fetchpriority="\(?\s*priority\s*&&\s*index\s*===\s*0\s*\)?\s*\?\s*'high'\s*:\s*'auto'"/,
+    )
+  })
+})

--- a/packages/ui-alquicarros/nuxt.config.ts
+++ b/packages/ui-alquicarros/nuxt.config.ts
@@ -420,6 +420,10 @@ export default defineNuxtConfig({
   image: {
     provider: 'vercel',
     quality: 80,
+    // Whitelist del host Blob compartido (modelos de vehículos en Supabase, las 3 marcas).
+    // Sin esto, @nuxt/image NO optimiza URLs externas y las imágenes salen como JPEG ~412KB crudo
+    // en vez de enrutarse por el optimizador Vercel (/_vercel/image → webp ~45KB).
+    domains: ['9grznib0czdjtk77.public.blob.vercel-storage.com'],
     screens: {
       xs: 320,
       sm: 640,

--- a/packages/ui-alquilame/app/components/Carrusel.vue
+++ b/packages/ui-alquilame/app/components/Carrusel.vue
@@ -1,6 +1,6 @@
 <template>
     <UCarousel
-      v-slot="{ item }"
+      v-slot="{ item, index }"
       :items="vehicleModels"
       dots
       prev-icon="lucide:chevron-left"
@@ -21,7 +21,9 @@
           :alt="item.nombre"
           width="800"
           height="480"
-          loading="lazy"
+          sizes="100vw md:50vw lg:33vw"
+          :loading="(priority && index === 0) ? 'eager' : 'lazy'"
+          :fetchpriority="(priority && index === 0) ? 'high' : 'auto'"
           decoding="async"
           class="w-full"
         />
@@ -35,7 +37,11 @@ interface CarruselProps {
   category: CategoryType;
   models?: CategoryModelData[];
   vehicleModels?: VehicleCategoryModel[]
+  // LCP: solo la primera card pasa priority=true → su primer slide carga eager.
+  priority?: boolean;
 }
 
-defineProps<CarruselProps>();
+withDefaults(defineProps<CarruselProps>(), {
+  priority: false,
+});
 </script>

--- a/packages/ui-alquilame/app/components/CategoryCard.vue
+++ b/packages/ui-alquilame/app/components/CategoryCard.vue
@@ -6,6 +6,7 @@
           :models="categoryModels"
           :vehicleModels="modelos"
           :category="categoryCode"
+          :priority="priority"
         />
       </div>
 
@@ -609,8 +610,11 @@ const Carrusel = defineAsyncComponent(() => import('./Carrusel.vue'))
 import type { CategoryProps } from '@rentacar-main/logic/utils';
 
 /** props */
-const props = withDefaults(defineProps<CategoryProps>(), {
+// `priority` es local a la card (LCP): NO se agrega al tipo compartido CategoryProps,
+// se extiende por intersección. Solo la primera card lo recibe en true.
+const props = withDefaults(defineProps<CategoryProps & { priority?: boolean }>(), {
   showButton: true,
+  priority: false,
 });
 
 /** emits */

--- a/packages/ui-alquilame/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquilame/app/components/CategorySelectionSection.vue
@@ -40,7 +40,7 @@
       </div>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-      <template v-for="category in filteredCategories" :key="`cat-${category.categoryCode}`">
+      <template v-for="(category, index) in filteredCategories" :key="`cat-${category.categoryCode}`">
         <placeholders-unable-category-card
           v-if="
             category.estimatedTotalAmount == 999999999 &&
@@ -53,6 +53,7 @@
           v-else-if="vehicleCategories[category.categoryCode]"
           :category
           :vehicle-category="vehicleCategories[category.categoryCode]"
+          :priority="index === 0"
           @selected-category="setSelectedCategory"
         />
       </template>

--- a/packages/ui-alquilame/app/components/__tests__/model-image-optimization.test.ts
+++ b/packages/ui-alquilame/app/components/__tests__/model-image-optimization.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Issue #48 — model-image-optimization holdout (source-string idiom).
+ * Scenarios: docs/specs/2026-05-27-model-image-optimization/scenarios/model-image-optimization.scenarios.md
+ *
+ * Post-search, CategoryCard → Carrusel.vue renders model images from an absolute
+ * external Vercel Blob URL. @nuxt/image only optimizes external hosts listed in
+ * image.domains; without the entry the raw ~412KB JPEG is served. These tests
+ * lock the two static guarantees behind that fix.
+ */
+
+const BLOB_HOST = '9grznib0czdjtk77.public.blob.vercel-storage.com'
+
+const nuxtConfig = readFileSync(
+  fileURLToPath(new URL('../../../nuxt.config.ts', import.meta.url)),
+  'utf8',
+)
+const carrusel = readFileSync(
+  fileURLToPath(new URL('../Carrusel.vue', import.meta.url)),
+  'utf8',
+)
+
+describe('model-image-optimization — nuxt.config image.domains (SCEN-004)', () => {
+  it('declares an image.domains array', () => {
+    expect(nuxtConfig).toMatch(/image:\s*\{[\s\S]*?domains:\s*\[/)
+  })
+
+  it('whitelists the shared Blob host so external model images route through the optimizer', () => {
+    // domains entry, not just the comment / remotePatterns hook
+    expect(nuxtConfig).toMatch(
+      new RegExp(`domains:\\s*\\[[^\\]]*['"]${BLOB_HOST.replace(/\./g, '\\.')}['"]`),
+    )
+  })
+})
+
+describe('model-image-optimization — Carrusel.vue model image (SCEN-002/003 + SCEN-005)', () => {
+  it('declares responsive sizes in @nuxt/image breakpoint shorthand, not CSS media queries', () => {
+    const match = carrusel.match(/sizes="([^"]*)"/)
+    expect(match?.[1]).toBeTruthy()
+    const sizes = match?.[1] ?? ''
+    // @nuxt/image parses its own `screenKey:value` shorthand. CSS media-query
+    // syntax (`(min-width: …)`) or calc() mis-parses → srcset collapses to a
+    // single 320px variant and the LCP image upscales/blurs. Lock the shorthand.
+    expect(sizes).not.toMatch(/\(min-width|\(max-width|calc\(/)
+    expect(sizes).toMatch(/\bmd:\d+vw\b/)
+    expect(sizes).toMatch(/\blg:\d+vw\b/)
+  })
+
+  it('keeps intrinsic width/height to avoid CLS', () => {
+    expect(carrusel).toMatch(/width="800"/)
+    expect(carrusel).toMatch(/height="480"/)
+  })
+
+  it('eager-loads only the priority first slide, lazy otherwise (LCP)', () => {
+    // the slide index must be exposed so only the first slide can be eager
+    expect(carrusel).toMatch(/v-slot="\{\s*item\s*,\s*index\s*\}"/)
+    // conditional loading/fetchpriority gated on the priority prop AND first slide
+    expect(carrusel).toMatch(
+      /:loading="\(?\s*priority\s*&&\s*index\s*===\s*0\s*\)?\s*\?\s*'eager'\s*:\s*'lazy'"/,
+    )
+    expect(carrusel).toMatch(
+      /:fetchpriority="\(?\s*priority\s*&&\s*index\s*===\s*0\s*\)?\s*\?\s*'high'\s*:\s*'auto'"/,
+    )
+  })
+})

--- a/packages/ui-alquilame/nuxt.config.ts
+++ b/packages/ui-alquilame/nuxt.config.ts
@@ -420,6 +420,10 @@ export default defineNuxtConfig({
   image: {
     provider: 'vercel',
     quality: 80,
+    // Whitelist del host Blob compartido (modelos de vehículos en Supabase, las 3 marcas).
+    // Sin esto, @nuxt/image NO optimiza URLs externas y las imágenes salen como JPEG ~412KB crudo
+    // en vez de enrutarse por el optimizador Vercel (/_vercel/image → webp ~45KB).
+    domains: ['9grznib0czdjtk77.public.blob.vercel-storage.com'],
     screens: {
       xs: 320,
       sm: 640,

--- a/packages/ui-alquilatucarro/app/components/Carrusel.vue
+++ b/packages/ui-alquilatucarro/app/components/Carrusel.vue
@@ -1,6 +1,6 @@
 <template>
     <UCarousel
-      v-slot="{ item }"
+      v-slot="{ item, index }"
       :items="vehicleModels"
       dots
       prev-icon="lucide:chevron-left"
@@ -21,7 +21,9 @@
           :alt="item.nombre"
           width="800"
           height="480"
-          loading="lazy"
+          sizes="100vw md:50vw lg:33vw"
+          :loading="(priority && index === 0) ? 'eager' : 'lazy'"
+          :fetchpriority="(priority && index === 0) ? 'high' : 'auto'"
           decoding="async"
           class="w-full"
         />
@@ -35,7 +37,11 @@ interface CarruselProps {
   category: CategoryType;
   models?: CategoryModelData[];
   vehicleModels?: VehicleCategoryModel[]
+  // LCP: solo la primera card pasa priority=true → su primer slide carga eager.
+  priority?: boolean;
 }
 
-defineProps<CarruselProps>();
+withDefaults(defineProps<CarruselProps>(), {
+  priority: false,
+});
 </script>

--- a/packages/ui-alquilatucarro/app/components/CategoryCard.vue
+++ b/packages/ui-alquilatucarro/app/components/CategoryCard.vue
@@ -6,6 +6,7 @@
           :models="categoryModels"
           :vehicleModels="modelos"
           :category="categoryCode"
+          :priority="priority"
         />
       </div>
 
@@ -609,8 +610,11 @@ const Carrusel = defineAsyncComponent(() => import('./Carrusel.vue'))
 import type { CategoryProps } from '@rentacar-main/logic/utils';
 
 /** props */
-const props = withDefaults(defineProps<CategoryProps>(), {
+// `priority` es local a la card (LCP): NO se agrega al tipo compartido CategoryProps,
+// se extiende por intersección. Solo la primera card lo recibe en true.
+const props = withDefaults(defineProps<CategoryProps & { priority?: boolean }>(), {
   showButton: true,
+  priority: false,
 });
 
 /** emits */

--- a/packages/ui-alquilatucarro/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquilatucarro/app/components/CategorySelectionSection.vue
@@ -40,7 +40,7 @@
       </div>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-      <template v-for="category in filteredCategories" :key="`cat-${category.categoryCode}`">
+      <template v-for="(category, index) in filteredCategories" :key="`cat-${category.categoryCode}`">
         <placeholders-unable-category-card
           v-if="
             category.estimatedTotalAmount == 999999999 &&
@@ -53,6 +53,7 @@
           v-else-if="vehicleCategories[category.categoryCode]"
           :category
           :vehicle-category="vehicleCategories[category.categoryCode]"
+          :priority="index === 0"
           @selected-category="setSelectedCategory"
         />
       </template>

--- a/packages/ui-alquilatucarro/app/components/__tests__/model-image-optimization.test.ts
+++ b/packages/ui-alquilatucarro/app/components/__tests__/model-image-optimization.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Issue #48 — model-image-optimization holdout (source-string idiom).
+ * Scenarios: docs/specs/2026-05-27-model-image-optimization/scenarios/model-image-optimization.scenarios.md
+ *
+ * Post-search, CategoryCard → Carrusel.vue renders model images from an absolute
+ * external Vercel Blob URL. @nuxt/image only optimizes external hosts listed in
+ * image.domains; without the entry the raw ~412KB JPEG is served. These tests
+ * lock the two static guarantees behind that fix.
+ */
+
+const BLOB_HOST = '9grznib0czdjtk77.public.blob.vercel-storage.com'
+
+const nuxtConfig = readFileSync(
+  fileURLToPath(new URL('../../../nuxt.config.ts', import.meta.url)),
+  'utf8',
+)
+const carrusel = readFileSync(
+  fileURLToPath(new URL('../Carrusel.vue', import.meta.url)),
+  'utf8',
+)
+
+describe('model-image-optimization — nuxt.config image.domains (SCEN-004)', () => {
+  it('declares an image.domains array', () => {
+    expect(nuxtConfig).toMatch(/image:\s*\{[\s\S]*?domains:\s*\[/)
+  })
+
+  it('whitelists the shared Blob host so external model images route through the optimizer', () => {
+    // domains entry, not just the comment / remotePatterns hook
+    expect(nuxtConfig).toMatch(
+      new RegExp(`domains:\\s*\\[[^\\]]*['"]${BLOB_HOST.replace(/\./g, '\\.')}['"]`),
+    )
+  })
+})
+
+describe('model-image-optimization — Carrusel.vue model image (SCEN-002/003 + SCEN-005)', () => {
+  it('declares responsive sizes in @nuxt/image breakpoint shorthand, not CSS media queries', () => {
+    const match = carrusel.match(/sizes="([^"]*)"/)
+    expect(match?.[1]).toBeTruthy()
+    const sizes = match?.[1] ?? ''
+    // @nuxt/image parses its own `screenKey:value` shorthand. CSS media-query
+    // syntax (`(min-width: …)`) or calc() mis-parses → srcset collapses to a
+    // single 320px variant and the LCP image upscales/blurs. Lock the shorthand.
+    expect(sizes).not.toMatch(/\(min-width|\(max-width|calc\(/)
+    expect(sizes).toMatch(/\bmd:\d+vw\b/)
+    expect(sizes).toMatch(/\blg:\d+vw\b/)
+  })
+
+  it('keeps intrinsic width/height to avoid CLS', () => {
+    expect(carrusel).toMatch(/width="800"/)
+    expect(carrusel).toMatch(/height="480"/)
+  })
+
+  it('eager-loads only the priority first slide, lazy otherwise (LCP)', () => {
+    // the slide index must be exposed so only the first slide can be eager
+    expect(carrusel).toMatch(/v-slot="\{\s*item\s*,\s*index\s*\}"/)
+    // conditional loading/fetchpriority gated on the priority prop AND first slide
+    expect(carrusel).toMatch(
+      /:loading="\(?\s*priority\s*&&\s*index\s*===\s*0\s*\)?\s*\?\s*'eager'\s*:\s*'lazy'"/,
+    )
+    expect(carrusel).toMatch(
+      /:fetchpriority="\(?\s*priority\s*&&\s*index\s*===\s*0\s*\)?\s*\?\s*'high'\s*:\s*'auto'"/,
+    )
+  })
+})

--- a/packages/ui-alquilatucarro/nuxt.config.ts
+++ b/packages/ui-alquilatucarro/nuxt.config.ts
@@ -429,6 +429,10 @@ export default defineNuxtConfig({
   image: {
     provider: 'vercel',
     quality: 80,
+    // Whitelist del host Blob compartido (modelos de vehículos en Supabase, las 3 marcas).
+    // Sin esto, @nuxt/image NO optimiza URLs externas y las imágenes salen como JPEG ~412KB crudo
+    // en vez de enrutarse por el optimizador Vercel (/_vercel/image → webp ~45KB).
+    domains: ['9grznib0czdjtk77.public.blob.vercel-storage.com'],
     screens: {
       xs: 320,
       sm: 640,


### PR DESCRIPTION
## What this fixes

After the availability search, the model carousel in each result card loaded its images straight from their Vercel Blob URLs — raw, full-size, unoptimized. A sampled model image was a 412 KB JPEG, and 84 of the 102 model images in the data are JPEGs. That's the slow, intermittent loading operators reported in #48.

The reason: `@nuxt/image` only optimizes external hosts you list in `image.domains`, and that key wasn't set, so the model images skipped `/_vercel/image` entirely. PR #56 wired the optimizer up for the *blog* images, not this path — easy to conflate, but they're separate pipelines. The optimizer was already willing to serve this host; it's in the `remotePatterns` allowlist from #56's `nitro:config` hook.

## The change (same across the 3 brands)

- `nuxt.config.ts`: add the shared Blob host to `image.domains`. This is the switch that makes `@nuxt/image` route external model images through the Vercel optimizer — webp, resized, 31-day TTL.
- `Carrusel.vue`: add a `sizes` value in `@nuxt/image`'s own shorthand (`100vw md:50vw lg:33vw`) so the optimizer picks a variant matched to the card width instead of shipping one giant image. Worth flagging for reviewers: `@nuxt/image` does *not* parse CSS media-query `sizes` — that silently collapses the srcset to a single 320px variant. The shorthand is mandatory (the holdout test now rejects the CSS form).
- LCP: the first available card's first slide loads `eager` + `fetchpriority="high"`; everything else stays `lazy`. `priority` is passed down `CategorySelectionSection → CategoryCard → Carrusel` without touching the shared `CategoryProps` type.

## Evidence

Optimizer probe on a real model image (same Blob host):

| request | result |
|---|---|
| raw Blob | 412 KB JPEG |
| `w=320` | 13.7 KB webp |
| `w=640` | 45 KB webp |
| `w=768` | 62 KB webp |

All optimized variants return `200` with `cache-control: max-age=2678400`.

- Holdout `model-image-optimization.test.ts`: 5/5 per brand. Full brand suites: 198 / 42 / 42 (delta vs the repo's known-red typecheck/lint baseline).
- SEO: `useProductSchema` still emits the absolute raw image URL, so JSON-LD is unaffected (relevant to #49 / #69).
- Runtime (SCEN-1/2/3/5/6): verified on the preview — results posted as a comment below.

## Notes

- The Blob host in `image.domains` is hardcoded. It's shared and stable across the brands and mirrors the hardcoded regex already in the `nitro:config` hook. If the store ever rotates, `NUXT_IMAGE_DOMAINS` is the env override.
- `:priority="index === 0"` rides on `filteredCategories`, which is sorted cheapest-first with unavailable cards pushed to the end, so it lands on the first *available* card. When everything is unavailable (LLNRAG009) nothing gets priority, which is fine — there's no product image to rush.

Scenarios: `docs/specs/2026-05-27-model-image-optimization/`.

Closes #48
