### PR TITLE
fix(alquilame): point site URL fields to alquilame.co canonical domain

### DIFF
--- a/packages/ui-alquilame/app/app.config.ts
+++ b/packages/ui-alquilame/app/app.config.ts
@@ -27,14 +27,14 @@ export default defineAppConfig({
 
   // Brand-specific reservation configuration
   reservation: {
-    website: "https://alquilame.com",
+    website: "https://alquilame.co",
   },
 
   // Brand-specific franchise information
   franchise: {
     name: "alquilame.com",
     shortname: "alquilame",
-    website: "https://alquilame.com",
+    website: "https://alquilame.co",
     title: "Alquiler de Carros en Colombia desde $32/día",
     description:
       "Alquila carros en Bogotá, Medellín, Cali y 16 ciudades más. Hasta 60% descuento por reserva anticipada. Sin pago previo. Flota renovada cada 2 años.",

--- a/packages/ui-alquilame/nuxt.config.ts
+++ b/packages/ui-alquilame/nuxt.config.ts
@@ -444,7 +444,7 @@ export default defineNuxtConfig({
 
   // Configuración SEO
   site: {
-    url: 'https://alquilame.com',
+    url: 'https://alquilame.co',
     name: 'Alquilame',
     description: 'Alquila carros en Bogotá, Medellín, Cali y 14 ciudades más.',
     defaultLocale: 'es',
@@ -677,7 +677,7 @@ export default defineNuxtConfig({
   },
 
   llms: {
-    domain: 'https://alquilame.com',
+    domain: 'https://alquilame.co',
     title: 'Alquilame',
     description: 'Los mejores precios en alquiler de carros y alquiler de camionetas en varias zonas del país. Reserva Ahora! Tenemos variedad de carros nuevos renovando nuestra flota cada 2 años. Alquiler de carros en Bogotá, Medellín, Barranquilla, Cali, Cartagena, Bucaramanga, Ibagué, Manizales, Cúcuta, Santa Marta, Pereira, Montería y Villavicencio.',
     sections: [


### PR DESCRIPTION
## What

Point alquilame's site-URL config fields at the real canonical domain **`alquilame.co`** (they were on the stale `alquilame.com`).

The canonical is already enforced at runtime by `packages/ui-alquilame/server/middleware/canonical-redirect.ts` (consolidates `www.alquilame.co` → `alquilame.co`), so the `.com` values were inconsistent SEO signals.

Changed (4 fields):
- `nuxt.config.ts` → `site.url`, `llms.domain`
- `app.config.ts` → `reservation.website`, `franchise.website`

Left on purpose:
- `franchise.name: "alquilame.com"` — a brand label, not a URL.
- `instagram.com/alquilame.com` — the IG username (literally `alquilame.com`), not the site domain.
- Docs references — out of scope (and already stale, e.g. mention Firebase Hosting).

## Impact

No production effect today: `alquilame.co` currently serves the legacy site (new design pending). This bakes the correct host so SEO output (canonical, og:url, sitemap, robots, llms.txt, schema website) is right when the alquilame redesign launches.

## Verification

`pnpm --filter ui-alquilame exec vitest run` → 42 passed (10 files), 0 failed. No test asserts the domain (grep-confirmed), so no regression.
