### PR TITLE
test(e2e): SCEN-010 holdout → smoke + unit-chain (Option B, #17)

### DIFF
--- a/docs/specs/2026-04-29-bundled-rentacar-data-resilience/scenarios/rentacar-data-resilience.scenarios.md
+++ b/docs/specs/2026-04-29-bundled-rentacar-data-resilience/scenarios/rentacar-data-resilience.scenarios.md
@@ -72,12 +72,14 @@ Holdout scenarios para el bundled fix de #2 (ISR cachea outage Supabase como HTM
 **Then**: los precios reflejan los valores Supabase. Para `numberDays=2`, conductor adicional total = `30000` (= 15000 × 2), silla bebé total = `20000` (= 10000 × 2). El fallback `?? 12000` no dispara cuando hay valor real.
 **Evidence**: outputs de la composable `useCategory()` aserteados contra valores derivados del extras Supabase, NO de los defaults del código.
 
-## SCEN-010: Cotización user-facing no muestra $0 silencioso
+## SCEN-010: Cotización user-facing no muestra $0 silencioso (smoke + cadena unit)
 
-**Given**: una cualquiera de las 3 marcas (alquilatucarro, alquilame, alquicarros) corriendo en Playwright; Supabase mockeado para `/api/rentacar-data` retorna payload con todos los campos de `extras` en `null` (per `EXTRAS_NULL_FIXTURE`); usuario navega a `/bogota`, selecciona sucursal Bogotá, fechas válidas, opta por agregar conductor adicional + silla bebé, llega a la pantalla de resumen.
-**When**: el componente `ReservationResume.vue` renderiza las líneas user-facing.
-**Then**: el elemento `[data-testid="extra-driver-line"]` está visible y contiene el texto `12.000` (no `$0`); el elemento `[data-testid="baby-seat-line"]` contiene `12.000`; ningún elemento de líneas de extras contiene la string `$0` o `$ 0`.
-**Evidence**: DOM snapshot capturado por Playwright en cada marca; `expect(page.getByTestId('extra-driver-line')).toContainText('12.000')`; `expect(...).not.toContainText('$0')`.
+**Given**: cualquiera de las 3 marcas corriendo en Playwright; el usuario navega a `/` y `/bogota`.
+**When**: la página carga (SSR + hidratación) y renderiza el markup user-facing.
+**Then**: respuesta 200; ningún error de consola `[useFetchRentacarData]` / `Failed to load`; ningún elemento del markup contiene `$0` ni `$ 0`. El default `?? 12000` (que produce `12.000`, no `$0`, cuando los extras de Supabase son `null`) queda probado end-to-end de forma COMPUESTA por la cadena unit SCEN-007 + SCEN-008/009 + SCEN-003 + SCEN-005.
+**Evidence**: `e2e/extras-null-smoke.spec.ts` (status 200 + sin console errors + `body.not.toMatch(/\$\s?0/)`); más los unit de SCEN-007/008/009/003/005 que asertan el valor `12000` y la no-coerción a `0`.
+
+> **Nota de cobertura (issue #17, amend 2026-05-28)**: el walk-through completo de Playwright (pickup → categoría → toggles → slideover asertando `[data-testid="extra-driver-line"]` = `12.000`) NO es automatizable. `rentacar-data` (incl. `extras`) se obtiene server-side en SSR (`useAsyncData` en `plugins/rentacar-data.ts`), se serializa al payload Nuxt y el cliente lo restaura desde `useState` sin re-fetch — por lo que `page.route('/api/rentacar-data')` es inerte y no puede forzar la precondición extras-null; además el universo admin de categorías/branches queda en los datos reales de Supabase (un stub de availability solo-`B` produce tarjetas "No disponible"). Forzar extras-null end-to-end exigiría un seam de fixture server-side, fuera de alcance de #17. Verificado empíricamente 2026-05-28. La cadena unit es la evidencia satisfactoria de la implicación; los testids `extra-driver-line`/`baby-seat-line` siguen presentes en `ReservationResume.vue` para verificación manual.
 
 ---
 
@@ -102,4 +104,4 @@ V6.1 evalúa el comportamiento de Vercel ISR ante revalidación 5xx. NO es un sc
 | SCEN-007 | Step 3 | Vitest unit `transformers.test.ts` (extender existente) |
 | SCEN-008 | Step 3 | Vitest unit `useCategory.test.ts` |
 | SCEN-009 | Step 3 | Vitest unit `useCategory.test.ts` |
-| SCEN-010 | Step 6 | Playwright e2e `extras-fallback.spec.ts` × 3 marcas |
+| SCEN-010 | Step 6 | Smoke e2e `extras-null-smoke.spec.ts` (walk-through infeasible — SSR payload, ver nota) + cadena unit SCEN-007/008/009/003/005 |

--- a/e2e/extras-null-smoke.spec.ts
+++ b/e2e/extras-null-smoke.spec.ts
@@ -1,18 +1,28 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * SCEN-010 (smoke coverage): when /api/rentacar-data returns extras with
- * all fields null, SSR/CSR must not propagate $0 to user-visible pages
- * and must not emit console errors.
+ * SCEN-010 — when /api/rentacar-data returns extras with all fields null,
+ * the user-facing cotización must show the `?? 12000` default (12.000), never $0.
  *
- * Full coverage (walk through cotización + assert testids on resume) is
- * deferred to a follow-up issue. The unit chain
- *   SCEN-007 (transformer null) +
- *   SCEN-008/009 (useCategory ?? 12000 fallback) +
- *   SCEN-003 (useFetchRentacarData sentinel) +
- *   SCEN-005 (consumers don't throw)
- * implies SCEN-010 holds end-to-end; this smoke exercises the SSR data
- * path that the units validate piecewise.
+ * Coverage here is SMOKE-level by necessity: `/` and `/bogota` load with no
+ * rentacar-data console errors and no literal `$0` leaking into the markup.
+ *
+ * Why no full browser walk-through (pickup → category → resume slideover):
+ *   `rentacar-data` (including `extras`) is fetched SERVER-SIDE during SSR via
+ *   useAsyncData in plugins/rentacar-data.ts, serialized into the Nuxt payload,
+ *   and restored on the client from useState — the browser never re-fetches it.
+ *   So `page.route('**\/api/rentacar-data', …)` is INERT: it cannot force the
+ *   extras-null precondition, and the admin category/branch universe stays the
+ *   real Supabase set (a single-`B` availability stub yields all-"No disponible"
+ *   cards, with no card to walk through). Forcing null extras end-to-end would
+ *   require a server-side fixture seam, out of scope for issue #17 (Option B).
+ *   Empirically confirmed 2026-05-28; see issue #17 and the holdout amend note.
+ *
+ * The null-extras → 12.000 behavior is instead proven by the unit chain:
+ *   SCEN-007 (transformer keeps null) + SCEN-008/009 (useCategory `?? 12000`
+ *   fallback) + SCEN-003 (useFetchRentacarData sentinel) + SCEN-005 (consumers
+ *   don't throw). These validate end-to-end piecewise what SSR prevents the
+ *   browser from exercising.
  */
 
 const EXTRAS_NULL_FIXTURE = {
@@ -77,7 +87,7 @@ const EXTRAS_NULL_FIXTURE = {
 // The client must render both identically via useCategory's `extras?.X ?? default`.
 const { extras: _omittedExtras, ...MISSING_EXTRAS_FIXTURE } = EXTRAS_NULL_FIXTURE;
 
-test.describe('Extras NULL smoke (SCEN-010 partial coverage)', () => {
+test.describe('Extras NULL smoke (SCEN-010 SSR data path)', () => {
   test.beforeEach(async ({ page }) => {
     await page.route('**/api/rentacar-data', (route) =>
       route.fulfill({


### PR DESCRIPTION
## Qué

Cierra issue #17 por **Opción B**: alinea el holdout SCEN-010 con la cobertura realmente verificable y deja el spec e2e honesto.

## Por qué A no era viable (probado, no teórico)

El holdout exigía un walk-through completo de Playwright que asertara `12.000` en el slideover de cotización con `extras` NULL. Es **arquitectónicamente imposible** vía `page.route`:

- `rentacar-data` (incl. `extras`) se obtiene **server-side en SSR** (`useAsyncData` en `plugins/rentacar-data.ts`), se serializa al payload Nuxt y el cliente lo restaura desde `useState` **sin re-fetch**. `page.route('**/api/rentacar-data')` intercepta solo requests del browser → es **inerte**, no puede forzar la precondición extras-null.
- El universo admin de categorías/branches queda en los **datos reales de Supabase**; un stub de availability solo-`B` produce tarjetas "No disponible" (sin tarjeta que recorrer). Confirmado empíricamente 2026-05-28 (la corrida dio "¡Oops!" / all-unable).

Forzar extras-null end-to-end exigiría un seam de fixture server-side, fuera de alcance de #17.

## Cambios

- **`rentacar-data-resilience.scenarios.md`** — SCEN-010 reescrito a su cobertura observable real (smoke: 200 + sin console errors + sin `$0`) + la cadena unit **SCEN-007 + SCEN-008/009 + SCEN-003 + SCEN-005** que prueba el default `?? 12000` end-to-end de forma compuesta. Nota de cobertura documentando la barrera SSR. Fila de mapping actualizada. Amend aplicado con autorización explícita del owner (gate human-final del protocolo SDD).
- **`e2e/extras-null-smoke.spec.ts`** — removido el walk-through inviable; header reescrito documentando por qué; conservados los 5 smoke tests.

## Verificación

- Smoke e2e: `BRAND=alquilatucarro playwright test extras-null-smoke.spec.ts --project=chromium` → **5 passed (33.4s)**
- Cadena unit: `vitest run transformers useCategory useFetchRentacarData useLocalBusiness useCityProductSchema` → **65 passed**, estable en 2 corridas
- Los testids `extra-driver-line` / `baby-seat-line` siguen en `ReservationResume.vue` para verificación manual.

Closes #17