### PR TITLE
fix(logic): skip close timer when useDelayedClose already closed (#35)

### DIFF
--- a/packages/logic/src/composables/__tests__/useDelayedClose.test.ts
+++ b/packages/logic/src/composables/__tests__/useDelayedClose.test.ts
@@ -17,6 +17,9 @@ import useDelayedClose from '../useDelayedClose'
 //       pending close timer is cancelled and `open` stays true.
 //   S4  When the owning effect scope is disposed with a pending close timer,
 //       the timer is cleared (no leak, no late mutation).
+//   S5  When the opener requests open=false while already closed, no close
+//       timer is scheduled (idempotent) — `open` stays false with no pending
+//       work.
 
 describe('useDelayedClose', () => {
   beforeEach(() => {
@@ -86,5 +89,22 @@ describe('useDelayedClose', () => {
     scope.stop()
     vi.advanceTimersByTime(10000)
     expect(openRef!.value).toBe(true)
+  })
+
+  it('S5 — requesting close while already closed schedules no timer', () => {
+    const scope = effectScope()
+    scope.run(() => {
+      const { open, onOpenChange } = useDelayedClose(3000)
+      expect(open.value).toBe(false)
+
+      // Redundant close on an already-closed tooltip is a no-op: no timer
+      // is armed, so advancing past the delay changes nothing.
+      onOpenChange(false)
+      expect(vi.getTimerCount()).toBe(0)
+
+      vi.advanceTimersByTime(5000)
+      expect(open.value).toBe(false)
+    })
+    scope.stop()
   })
 })

--- a/packages/logic/src/composables/useDelayedClose.ts
+++ b/packages/logic/src/composables/useDelayedClose.ts
@@ -17,6 +17,10 @@ export default function useDelayedClose(closeDelayMs: number) {
       open.value = true
       return
     }
+    // Idempotency: already closed (so no timer can be pending — `open` stays
+    // true until the timer fires). Scheduling here would be a redundant
+    // close timer with nothing to close.
+    if (!open.value) return
     closeTimer = setTimeout(() => {
       open.value = false
       closeTimer = null


### PR DESCRIPTION
## Problema

`useDelayedClose.onOpenChange(false)` sobre un tooltip **ya cerrado** armaba un `setTimeout` redundante que no tenía nada que cerrar.

## Fix

Early-return cuando `open.value` es `false` antes de agendar el timer. No puede haber timer pendiente en ese estado (`open` queda `true` hasta que el timer dispara), así que agendar es trabajo redundante.

## Scenario (observable)

`S5` — pedir cierre estando ya cerrado no agenda timer (`vi.getTimerCount() === 0`) y `open` permanece `false` tras avanzar más allá del delay.

## Verificación

- `pnpm --filter @rentacar-main/logic test useDelayedClose.test.ts` → **5 passed** (S1–S5)
- Suite logic completa → **240 passed**, sin regresión (baseline 239 + S5)
- Red-green: S5 **falla** sin el fix (1 failed), **pasa** con el fix

Closes #35