### PR TITLE
fix(reservations): close price tooltip immediately on Escape/outside-click (#34)

### DIFF
--- a/packages/logic/src/composables/__tests__/useDelayedClose.test.ts
+++ b/packages/logic/src/composables/__tests__/useDelayedClose.test.ts
@@ -20,6 +20,9 @@ import useDelayedClose from '../useDelayedClose'
 //   S5  When the opener requests open=false while already closed, no close
 //       timer is scheduled (idempotent) — `open` stays false with no pending
 //       work.
+//   S6  forceClose() closes immediately (no delay) and cancels any pending
+//       close timer — this is the dismiss path (Escape / outside-click /
+//       sibling tooltip), distinct from a hover-leave which keeps the delay.
 
 describe('useDelayedClose', () => {
   beforeEach(() => {
@@ -102,6 +105,27 @@ describe('useDelayedClose', () => {
       onOpenChange(false)
       expect(vi.getTimerCount()).toBe(0)
 
+      vi.advanceTimersByTime(5000)
+      expect(open.value).toBe(false)
+    })
+    scope.stop()
+  })
+
+  it('S6 — forceClose() closes immediately and cancels a pending timer', () => {
+    const scope = effectScope()
+    scope.run(() => {
+      const { open, onOpenChange, forceClose } = useDelayedClose(3000)
+      onOpenChange(true)
+      onOpenChange(false) // hover-leave: arms the delayed-close timer
+      expect(open.value).toBe(true)
+      expect(vi.getTimerCount()).toBe(1)
+
+      // Dismiss (Escape / outside-click): close now, drop the pending timer.
+      forceClose()
+      expect(open.value).toBe(false)
+      expect(vi.getTimerCount()).toBe(0)
+
+      // The delayed timer must not fire late and mutate state again.
       vi.advanceTimersByTime(5000)
       expect(open.value).toBe(false)
     })

--- a/packages/logic/src/composables/useDelayedClose.ts
+++ b/packages/logic/src/composables/useDelayedClose.ts
@@ -27,7 +27,16 @@ export default function useDelayedClose(closeDelayMs: number) {
     }, closeDelayMs)
   }
 
+  // Dismiss path: Escape, outside-click or a sibling tooltip opening must
+  // close now, not after closeDelayMs (the delay only serves hover-leave, so
+  // the operator can move into the tooltip to read/select it). Cancels any
+  // pending hover-leave timer so it can't fire late.
+  function forceClose() {
+    clearCloseTimer()
+    open.value = false
+  }
+
   onScopeDispose(clearCloseTimer)
 
-  return { open, onOpenChange }
+  return { open, onOpenChange, forceClose }
 }

--- a/packages/ui-alquicarros/app/components/CategoryCard.vue
+++ b/packages/ui-alquicarros/app/components/CategoryCard.vue
@@ -81,7 +81,7 @@
             Total {{ haveMonthlyReservation ? "30 días" : getFormattedDays }}
           </p>
 
-          <UTooltip :open="totalPriceTooltipOpen" :delay-duration="3000" :ui="{content: 'h-full select-text bg-white text-gray-900 shadow-lg border border-gray-200'}" @update:open="onTotalPriceTooltipOpenChange">
+          <UTooltip :open="totalPriceTooltipOpen" :delay-duration="3000" :content="{ onEscapeKeyDown: forceTotalPriceTooltipClose, onPointerDownOutside: forceTotalPriceTooltipClose }" :ui="{content: 'h-full select-text bg-white text-gray-900 shadow-lg border border-gray-200'}" @update:open="onTotalPriceTooltipOpenChange">
             <template #content>
               Día: $ {{ dayPriceTooltip }} <br />
               Seguro día: $ {{ coverageDayPriceTooltip }} <br />
@@ -677,6 +677,7 @@ const { modelos, grupo } = props.vehicleCategory;
 const {
   open: totalPriceTooltipOpen,
   onOpenChange: onTotalPriceTooltipOpenChange,
+  forceClose: forceTotalPriceTooltipClose,
 } = useDelayedClose(3000);
 
 /** Product Schema for SEO */

--- a/packages/ui-alquilame/app/components/CategoryCard.vue
+++ b/packages/ui-alquilame/app/components/CategoryCard.vue
@@ -81,7 +81,7 @@
             Total {{ haveMonthlyReservation ? "30 días" : getFormattedDays }}
           </p>
 
-          <UTooltip :open="totalPriceTooltipOpen" :delay-duration="3000" :ui="{content: 'h-full select-text bg-white text-gray-900 shadow-lg border border-gray-200'}" @update:open="onTotalPriceTooltipOpenChange">
+          <UTooltip :open="totalPriceTooltipOpen" :delay-duration="3000" :content="{ onEscapeKeyDown: forceTotalPriceTooltipClose, onPointerDownOutside: forceTotalPriceTooltipClose }" :ui="{content: 'h-full select-text bg-white text-gray-900 shadow-lg border border-gray-200'}" @update:open="onTotalPriceTooltipOpenChange">
             <template #content>
               Día: $ {{ dayPriceTooltip }} <br />
               Seguro día: $ {{ coverageDayPriceTooltip }} <br />
@@ -677,6 +677,7 @@ const { modelos, grupo } = props.vehicleCategory;
 const {
   open: totalPriceTooltipOpen,
   onOpenChange: onTotalPriceTooltipOpenChange,
+  forceClose: forceTotalPriceTooltipClose,
 } = useDelayedClose(3000);
 
 /** Product Schema for SEO */

--- a/packages/ui-alquilatucarro/app/components/CategoryCard.vue
+++ b/packages/ui-alquilatucarro/app/components/CategoryCard.vue
@@ -81,7 +81,7 @@
             Total {{ haveMonthlyReservation ? "30 días" : getFormattedDays }}
           </p>
 
-          <UTooltip :open="totalPriceTooltipOpen" :delay-duration="3000" :ui="{content: 'h-full select-text bg-white text-gray-900 shadow-lg border border-gray-200'}" @update:open="onTotalPriceTooltipOpenChange">
+          <UTooltip :open="totalPriceTooltipOpen" :delay-duration="3000" :content="{ onEscapeKeyDown: forceTotalPriceTooltipClose, onPointerDownOutside: forceTotalPriceTooltipClose }" :ui="{content: 'h-full select-text bg-white text-gray-900 shadow-lg border border-gray-200'}" @update:open="onTotalPriceTooltipOpenChange">
             <template #content>
               Día: $ {{ dayPriceTooltip }} <br />
               Seguro día: $ {{ coverageDayPriceTooltip }} <br />
@@ -677,6 +677,7 @@ const { modelos, grupo } = props.vehicleCategory;
 const {
   open: totalPriceTooltipOpen,
   onOpenChange: onTotalPriceTooltipOpenChange,
+  forceClose: forceTotalPriceTooltipClose,
 } = useDelayedClose(3000);
 
 /** Product Schema for SEO */


### PR DESCRIPTION
> Apilado sobre #78 (#35). Base: `fix/issue-35-delayed-idempotency`. GitHub re-apunta a `main` al mergear #78.

## Problema

`useDelayedClose` solo recibía un booleano desde `update:open` de `UTooltip`, así que **todo** cierre (Escape, click-fuera, sibling tooltip) heredaba el delay de hover-leave de 3s. Un operador que presiona Escape espera 3s a que el tooltip de precios desaparezca.

## Fix

Nuxt UI `UTooltip` reenvía `:content` a Reka `TooltipContent`, que emite `escapeKeyDown`/`pointerDownOutside` (verificado en `node_modules`: `TooltipContentImpl.emits = ["escapeKeyDown","pointerDownOutside"]`). Se cablean a un nuevo `forceClose()` que cancela el timer pendiente y cierra de inmediato. El hover-leave sigue por `onOpenChange` y conserva el delay.

`forceClose` compone con la idempotencia de #35: el `update:open(false)` que Reka dispara tras un dismiss es no-op una vez que `open` ya es `false`.

## Scenario (observable)

`S6` — `forceClose()` cierra inmediato (`open=false`) y cancela el timer pendiente (`getTimerCount()===0`); avanzar 5s no muta de nuevo.

## Verificación

- `pnpm --filter @rentacar-main/logic test useDelayedClose.test.ts` → **6 passed** (S1–S6)
- Suite logic → **241 passed**, sin regresión
- Red-green: S6 **falla** sin el fix (`TypeError: forceClose is not a function`), **pasa** con el fix
- `pnpm --filter ui-alquilatucarro typecheck` → 640 errores = baseline pre-existente (#18, auto-imports del layer); **0 nuevos** (sin error en la línea del `:content` ni en los identificadores añadidos)

Validación runtime en navegador (Escape/click-fuera cierran ya) → cubierta por el e2e de **#37**.

Closes #34