### PR TITLE
refactor(logic): document useDelayedClose, name default delay, clamp input (#36)

### DIFF
--- a/packages/logic/src/composables/__tests__/useDelayedClose.test.ts
+++ b/packages/logic/src/composables/__tests__/useDelayedClose.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { effectScope, nextTick } from 'vue'
 
-import useDelayedClose from '../useDelayedClose'
+import useDelayedClose, { DEFAULT_CLOSE_DELAY_MS } from '../useDelayedClose'
 
 // Scenarios captured: an operator-facing tooltip on category-card total price
 // must remain visible for closeDelayMs after the trigger loses hover/focus,
@@ -23,6 +23,8 @@ import useDelayedClose from '../useDelayedClose'
 //   S6  forceClose() closes immediately (no delay) and cancels any pending
 //       close timer — this is the dismiss path (Escape / outside-click /
 //       sibling tooltip), distinct from a hover-leave which keeps the delay.
+//   S7  Called with no argument, the close delay defaults to
+//       DEFAULT_CLOSE_DELAY_MS (3000ms).
 
 describe('useDelayedClose', () => {
   beforeEach(() => {
@@ -127,6 +129,22 @@ describe('useDelayedClose', () => {
 
       // The delayed timer must not fire late and mutate state again.
       vi.advanceTimersByTime(5000)
+      expect(open.value).toBe(false)
+    })
+    scope.stop()
+  })
+
+  it('S7 — close delay defaults to DEFAULT_CLOSE_DELAY_MS when omitted', () => {
+    const scope = effectScope()
+    scope.run(() => {
+      const { open, onOpenChange } = useDelayedClose()
+      onOpenChange(true)
+      onOpenChange(false)
+
+      vi.advanceTimersByTime(DEFAULT_CLOSE_DELAY_MS - 1)
+      expect(open.value).toBe(true)
+
+      vi.advanceTimersByTime(1)
       expect(open.value).toBe(false)
     })
     scope.stop()

--- a/packages/logic/src/composables/useDelayedClose.ts
+++ b/packages/logic/src/composables/useDelayedClose.ts
@@ -1,6 +1,26 @@
 import { ref, onScopeDispose } from 'vue'
 
-export default function useDelayedClose(closeDelayMs: number) {
+/**
+ * Default close delay (ms): how long an operator-facing tooltip stays open
+ * after a hover-leave so the operator can move into it to read/select.
+ */
+export const DEFAULT_CLOSE_DELAY_MS = 3000
+
+/**
+ * Controlled `open` state for a tooltip with a delayed close.
+ *
+ * Reka UI / Nuxt UI Tooltip has no native close-delay: on hover-leave it
+ * closes at once. This wraps `open` so a hover-leave (`onOpenChange(false)`)
+ * waits `closeDelayMs` before closing, while a dismiss (`forceClose`) closes
+ * immediately.
+ *
+ * @param closeDelayMs - Delay before a hover-leave close applies. Negative
+ *   values are clamped to 0. Defaults to {@link DEFAULT_CLOSE_DELAY_MS}.
+ * @returns `open` (reactive state), `onOpenChange` (hover-leave path,
+ *   delayed) and `forceClose` (dismiss path, immediate).
+ */
+export default function useDelayedClose(closeDelayMs: number = DEFAULT_CLOSE_DELAY_MS) {
+  const delayMs = Math.max(0, closeDelayMs)
   const open = ref(false)
   let closeTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -24,7 +44,7 @@ export default function useDelayedClose(closeDelayMs: number) {
     closeTimer = setTimeout(() => {
       open.value = false
       closeTimer = null
-    }, closeDelayMs)
+    }, delayMs)
   }
 
   // Dismiss path: Escape, outside-click or a sibling tooltip opening must


### PR DESCRIPTION
> Apilado sobre #79 (#34) → #78 (#35). GitHub re-apunta la base al mergear los previos.

## Cambios (cleanups, no-comportamiento salvo el default param)

- **JSDoc** del composable y su shape de retorno.
- **`DEFAULT_CLOSE_DELAY_MS` (3000) exportado** y usado como default del parámetro → los llamadores pueden omitir el número mágico.
- **Clamp defensivo** `Math.max(0, closeDelayMs)`. `setTimeout` ya coacciona negativos a 0, así que es documentación-como-código, sin efecto observable.

## Scenario

`S7` — `useDelayedClose()` sin argumento usa `DEFAULT_CLOSE_DELAY_MS`: `open` sigue `true` a 2999ms y `false` a 3000ms.

## Honestidad de verificación

La primera versión de S7 probaba el clamp negativo — pero `setTimeout` ya coacciona negativos, así que pasaba **con y sin** el clamp (tautología / reward-hacking). Se reemplazó por el scenario del default param, que sí discrimina (red-green). El clamp queda como hardening **sin test**, en vez de un assert engañoso.

## Verificación

- `pnpm --filter @rentacar-main/logic test useDelayedClose.test.ts` → **7 passed**
- Suite logic → **242 passed**
- Red-green: S7 **falla** sin el default param (cierra a 0ms), **pasa** con él
- `pnpm --filter ui-alquilatucarro typecheck` → 640 (baseline #18, **0 nuevos**)

Closes #36