### PR TITLE
test(logic): exercise useDelayedClose cleanup via real mount/unmount (#38)

### DIFF
--- a/packages/logic/package.json
+++ b/packages/logic/package.json
@@ -41,6 +41,8 @@
     "@nuxt/kit": "^4.1.3",
     "@nuxt/ui": "^4.2.1",
     "@pinia/testing": "^1.0.3",
+    "@vue/test-utils": "^2.4.10",
+    "jsdom": "^29.1.1",
     "nuxt": "^4.1.3",
     "ofetch": "^1.3.0",
     "typescript": "^5.9.3",

--- a/packages/logic/src/composables/__tests__/useDelayedClose.test.ts
+++ b/packages/logic/src/composables/__tests__/useDelayedClose.test.ts
@@ -1,5 +1,7 @@
+// @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { effectScope, nextTick } from 'vue'
+import { effectScope, defineComponent, h } from 'vue'
+import { mount } from '@vue/test-utils'
 
 import useDelayedClose, { DEFAULT_CLOSE_DELAY_MS } from '../useDelayedClose'
 
@@ -15,8 +17,9 @@ import useDelayedClose, { DEFAULT_CLOSE_DELAY_MS } from '../useDelayedClose'
 //       then flips to false.
 //   S3  If opener re-requests open=true within the close delay window, the
 //       pending close timer is cancelled and `open` stays true.
-//   S4  When the owning effect scope is disposed with a pending close timer,
-//       the timer is cleared (no leak, no late mutation).
+//   S4  When the host component is unmounted with a pending close timer,
+//       onScopeDispose clears it (no leaked timer, no late mutation) — proven
+//       through the real component lifecycle with @vue/test-utils mount.
 //   S5  When the opener requests open=false while already closed, no close
 //       timer is scheduled (idempotent) — `open` stays false with no pending
 //       work.
@@ -81,19 +84,30 @@ describe('useDelayedClose', () => {
     scope.stop()
   })
 
-  it('S4 — disposing the scope clears a pending close timer', () => {
-    const scope = effectScope()
-    let openRef: { value: boolean } | undefined
-    scope.run(() => {
-      const { open, onOpenChange } = useDelayedClose(3000)
-      openRef = open
-      onOpenChange(true)
-      onOpenChange(false)
-    })
+  it('S4 — unmounting the host component clears a pending close timer', () => {
+    // Exercise the real Vue lifecycle: the composable runs inside a mounted
+    // component, and unmount() must trigger onScopeDispose(clearCloseTimer).
+    let api!: ReturnType<typeof useDelayedClose>
+    const wrapper = mount(
+      defineComponent({
+        setup() {
+          api = useDelayedClose(3000)
+          return () => h('div')
+        },
+      }),
+    )
 
-    scope.stop()
+    api.onOpenChange(true)
+    api.onOpenChange(false) // arm the delayed-close timer
+    expect(api.open.value).toBe(true)
+    expect(vi.getTimerCount()).toBe(1)
+
+    wrapper.unmount()
+    expect(vi.getTimerCount()).toBe(0) // onScopeDispose cleared it
+
+    // No late mutation: the cleared timer never fires.
     vi.advanceTimersByTime(10000)
-    expect(openRef!.value).toBe(true)
+    expect(api.open.value).toBe(true)
   })
 
   it('S5 — requesting close while already closed schedules no timer', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,12 @@ importers:
       '@pinia/testing':
         specifier: ^1.0.3
         version: 1.0.3(pinia@3.0.4(typescript@5.9.3)(vue@3.5.25(typescript@5.9.3)))
+      '@vue/test-utils':
+        specifier: ^2.4.10
+        version: 2.4.10(@vue/compiler-dom@3.5.25)(@vue/server-renderer@3.5.25(vue@3.5.25(typescript@5.9.3)))(vue@3.5.25(typescript@5.9.3))
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       nuxt:
         specifier: ^4.1.3
         version: 4.2.2(@parcel/watcher@2.5.1)(@types/node@25.0.1)(@vercel/blob@2.3.3)(@vue/compiler-sfc@3.5.25)(better-sqlite3@12.6.0)(cac@6.7.14)(commander@11.1.0)(db0@0.3.4(better-sqlite3@12.6.0))(ioredis@5.8.2)(lightningcss@1.30.2)(magicast@0.5.1)(rollup@4.53.3)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(vite@7.2.7(@types/node@25.0.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.2.2(typescript@5.9.3))(yaml@2.8.2)


### PR DESCRIPTION
> Apilado sobre #80 (#36) → #79 (#34) → #78 (#35). GitHub re-apunta la base al mergear los previos.

## Cambio

`S4` usaba `effectScope().stop()` como proxy del lifecycle de componente. Ahora maneja el **lifecycle real**: monta un componente host que corre el composable, arma un timer de cierre pendiente, hace `unmount()` y asierta que `onScopeDispose(clearCloseTimer)` lo limpió (`getTimerCount()===0`, sin mutación tardía). Más fuerte que el proxy anterior.

## Blast radius

- Requiere DOM + `mount`, así que agrega **`@vue/test-utils` + `jsdom`** como devDeps de `@rentacar-main/logic` y fija este archivo al entorno `jsdom` (`// @vitest-environment jsdom`). → `packages/logic/package.json` + `pnpm-lock.yaml`.
- Elimina el import muerto `nextTick`.
- `S1–S3/S5–S7` se quedan en `effectScope` (lógica del composable aislada, sin lifecycle que ejercitar) — el issue apunta solo al test de lifecycle.

## Verificación

- `pnpm --filter @rentacar-main/logic test useDelayedClose.test.ts` → **7 passed**
- Suite logic → **242 passed**
- Red-green: S4 **falla** sin `onScopeDispose` (timer queda colgado, `getTimerCount()===1`), **pasa** con él

Closes #38