### PR TITLE
fix(reservations): reset noAvailableCategories at the start of search() (#20)

### DIFF
--- a/packages/logic/src/stores/__tests__/useStoreSearchData.resetNoAvailableFlag.test.ts
+++ b/packages/logic/src/stores/__tests__/useStoreSearchData.resetNoAvailableFlag.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { ref } from 'vue'
+
+// Issue #20: search() resets error/pending/categoriesAvailabilityData at the
+// top but never resets noAvailableCategories. After a search returns LLNRAG009
+// (flag → true), a subsequent search that resolves to a DIFFERENT terminal
+// error (server_error, out_of_schedule_*, …) never touches the flag, so it
+// stays stuck at true from the previous run.
+
+const FETCH_AVAILABILITY = vi.fn()
+
+vi.mock('../../composables/useFetchCategoriesAvailabilityData', () => ({
+  default: () => FETCH_AVAILABILITY(),
+}))
+
+const baseCategory = (id: string, name: string, category: string) => ({
+  id,
+  code: id,
+  identification: id,
+  description: name,
+  name,
+  category,
+  models: [],
+  month_prices: {},
+  total_coverage_unit_charge: 0,
+  image: '',
+  ad: '',
+  extra_km_charge: 0,
+})
+
+const ADMIN_PAYLOAD = {
+  categories: [baseCategory('B', 'Económico', 'BÁSICO B')],
+  branches: [],
+  extras: undefined,
+  vehicleCategories: {},
+}
+
+const LLNRAG009 = {
+  error: 'no_available_categories_error' as const,
+  message: 'Lo sentimos, no se encontraron vehículos disponibles',
+  shortText: 'LLNRAG009',
+}
+
+const SERVER_ERROR = {
+  error: 'server_error' as const,
+  message: 'Error del servidor',
+  shortText: 'X',
+}
+
+describe('useStoreSearchData reset noAvailableCategories flag (#20)', () => {
+  beforeEach(() => {
+    FETCH_AVAILABILITY.mockReset()
+    vi.stubGlobal('useState', () => ref(ADMIN_PAYLOAD))
+    vi.stubGlobal('useToast', () => ({ add: vi.fn(), clear: vi.fn() }))
+    setActivePinia(createPinia())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('clears the flag when a later search resolves to a different terminal error', async () => {
+    const { default: useStoreSearchData } = await import('../useStoreSearchData')
+    const searchStore = useStoreSearchData()
+
+    // First search → LLNRAG009 sets the flag.
+    FETCH_AVAILABILITY.mockResolvedValue({ data: ref(null), error: ref({ ...LLNRAG009 }) })
+    await searchStore.search()
+    expect(searchStore.noAvailableCategories).toBe(true)
+
+    // Second search → a different terminal error. This path never assigns the
+    // flag, so it must have been reset at the top of search().
+    FETCH_AVAILABILITY.mockResolvedValue({ data: ref(null), error: ref({ ...SERVER_ERROR }) })
+    await searchStore.search()
+    expect(searchStore.noAvailableCategories).toBe(false)
+  })
+})

--- a/packages/logic/src/stores/useStoreSearchData.ts
+++ b/packages/logic/src/stores/useStoreSearchData.ts
@@ -50,6 +50,11 @@ const useStoreSearchData = defineStore("storeSearchData", () => {
     error.value = null;
     pending.value = true;
     categoriesAvailabilityData.value = null;
+    // Reset alongside the other per-search state: only the LLNRAG009 and
+    // empty-result paths re-assign this, so without resetting here a stale
+    // `true` from a prior LLNRAG009 search leaks into a later search that
+    // ends in a different terminal error. Issue #20.
+    noAvailableCategories.value = false;
 
     const { data, error: errorResponse } = await useFetchCategoriesAvailabilityData();
 


### PR DESCRIPTION
## Problema

`search()` resetea `error`, `pending` y `categoriesAvailabilityData` al inicio, pero **no** `noAvailableCategories`. Solo los paths LLNRAG009 y de resultado-vacío reasignan la bandera, así que tras una búsqueda LLNRAG009 (`flag=true`), una búsqueda posterior que termina en otro error terminal (`server_error`, `out_of_schedule_*`, …) deja la bandera **pegada en true**.

## Fix

Resetear `noAvailableCategories.value = false` junto al resto del estado per-search, al inicio de `search()`.

## Scenario

GIVEN una búsqueda previa LLNRAG009 (flag=true), WHEN una nueva `search()` resuelve a `server_error`, THEN `noAvailableCategories === false`.

## Verificación

- `pnpm --filter @rentacar-main/logic test useStoreSearchData.resetNoAvailableFlag.test.ts` → **1 passed**
- Suite logic → **240 passed**, sin regresión
- Red-green: **falla** sin el reset (queda true), **pasa** con él

Closes #20