### PR TITLE
fix(reservations): exclude monthly-only categories from LLNRAG009 unable cards (#54)

### DIFF
--- a/packages/logic/src/stores/__tests__/useStoreSearchData.llnrag009MonthlyExclusion.test.ts
+++ b/packages/logic/src/stores/__tests__/useStoreSearchData.llnrag009MonthlyExclusion.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { ref } from 'vue'
+
+// Issue #54: on monthly + no_available_categories_error (LLNRAG009) the
+// `categories` computed surfaced ALL admin categories as unable cards,
+// including the monthly-excluded ones (FU/FL/GL/LU). The monthly *success*
+// path already filters them out (useStoreSearchData.ts), but the LLNRAG009
+// branch did not. Non-monthly must keep surfacing every category.
+
+const FETCH_AVAILABILITY = vi.fn()
+
+vi.mock('../../composables/useFetchCategoriesAvailabilityData', () => ({
+  default: () => FETCH_AVAILABILITY(),
+}))
+
+const baseCategory = (id: string, name: string, category: string) => ({
+  id,
+  code: id,
+  identification: id,
+  description: name,
+  name,
+  category,
+  models: [],
+  month_prices: {},
+  total_coverage_unit_charge: 0,
+  image: '',
+  ad: '',
+  extra_km_charge: 0,
+})
+
+// Includes FU, a monthly-excluded code, alongside two regular ones.
+const ADMIN_PAYLOAD = {
+  categories: [
+    baseCategory('B', 'Económico', 'BÁSICO B'),
+    baseCategory('C', 'Compacto', 'COMPACTO C'),
+    baseCategory('FU', 'Furgón', 'FURGÓN FU'),
+  ],
+  branches: [],
+  extras: undefined,
+  vehicleCategories: {},
+}
+
+const LLNRAG009 = {
+  error: 'no_available_categories_error' as const,
+  message: 'Lo sentimos, no se encontraron vehículos disponibles',
+  shortText: 'LLNRAG009',
+}
+
+describe('useStoreSearchData LLNRAG009 monthly exclusion (#54)', () => {
+  beforeEach(() => {
+    FETCH_AVAILABILITY.mockReset()
+    FETCH_AVAILABILITY.mockResolvedValue({ data: ref(null), error: ref({ ...LLNRAG009 }) })
+    vi.stubGlobal('useState', () => ref(ADMIN_PAYLOAD))
+    vi.stubGlobal('useToast', () => ({ add: vi.fn(), clear: vi.fn() }))
+    setActivePinia(createPinia())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('monthly + LLNRAG009 excludes monthly-only categories (FU) from unable cards', async () => {
+    const { default: useStoreReservationForm } = await import('../useStoreReservationForm')
+    useStoreReservationForm().haveMonthlyReservation = true
+
+    const { default: useStoreSearchData } = await import('../useStoreSearchData')
+    const searchStore = useStoreSearchData()
+    await searchStore.search()
+
+    const codes = searchStore.categories.map((c) => c.categoryCode).sort()
+    expect(codes).toEqual(['B', 'C'])
+    expect(searchStore.categories.every((c) => c.estimatedTotalAmount === 999999999)).toBe(true)
+  })
+
+  it('non-monthly + LLNRAG009 still surfaces every admin category (regression guard)', async () => {
+    const { default: useStoreSearchData } = await import('../useStoreSearchData')
+    const searchStore = useStoreSearchData()
+    await searchStore.search()
+
+    const codes = searchStore.categories.map((c) => c.categoryCode).sort()
+    expect(codes).toEqual(['B', 'C', 'FU'])
+  })
+})

--- a/packages/logic/src/stores/useStoreSearchData.ts
+++ b/packages/logic/src/stores/useStoreSearchData.ts
@@ -141,10 +141,20 @@ const useStoreSearchData = defineStore("storeSearchData", () => {
      * short-circuit, and the inline "¡Oops!" rendered without the gray-card
      * grid below. SCEN-U2.
      */
-    if (error.value?.error === "no_available_categories_error")
-      return categoriesAdminData.value.map((categoryAdmin: CategoryData) =>
+    if (error.value?.error === "no_available_categories_error") {
+      // Mirror the monthly *success* path: monthly reservations never offer
+      // the monthly-excluded categories (FU/FL/GL/LU), so they must not appear
+      // as unable cards either. Non-monthly keeps surfacing every category.
+      // Issue #54.
+      const adminCategories = haveMonthlyReservation.value
+        ? categoriesAdminData.value.filter((categoryAdmin: CategoryData) =>
+            !noMonthlyCategories.includes(categoryAdmin.identification)
+          )
+        : categoriesAdminData.value;
+      return adminCategories.map((categoryAdmin: CategoryData) =>
         createCategoryAvailability(categoryAdmin, true)
       );
+    }
 
     if (categoriesAvailabilityData.value) {
 


### PR DESCRIPTION
> Apilado sobre #82 (#20). Base: `fix/issue-20-reset-noavail`. GitHub re-apunta a `main` al mergear #82.

## Problema

En monthly + `no_available_categories_error` (LLNRAG009), el computed `categories` mostraba **todas** las categorías admin como unable cards — incluidas las monthly-excluidas FU/FL/GL/LU. El path monthly de *éxito* ya las filtra; la rama LLNRAG009 no.

## Fix

Aplicar el mismo filtro por `identification` cuando `haveMonthlyReservation`. Non-monthly sigue mostrando todas (sin cambio).

## Scenarios

- monthly + LLNRAG009 con admin `[B, C, FU]` → unable cards `[B, C]` (FU excluido).
- non-monthly + LLNRAG009 → `[B, C, FU]` (regression guard, intacto).

## Verificación

- `pnpm --filter @rentacar-main/logic test useStoreSearchData.llnrag009MonthlyExclusion.test.ts` → **2 passed**
- Suite logic → **242 passed** (SCEN-U2 existente sigue verde — sus códigos B/C/D no son monthly-excluidos)
- Red-green: monthly **falla** sin el filtro (FU aparece), **pasa** con él

Closes #54