### PR TITLE
fix(reservations): title-case each segment of hyphenated city slugs (#30)

### DIFF
--- a/packages/logic/src/composables/__tests__/useUnavailabilityContext.test.ts
+++ b/packages/logic/src/composables/__tests__/useUnavailabilityContext.test.ts
@@ -28,6 +28,14 @@ const ADMIN_PAYLOAD = {
       slug: 'bogota-aeropuerto',
       schedule: '',
     },
+    {
+      id: 2,
+      code: 'POBLADO',
+      name: 'El Poblado',
+      city: 'el-poblado',
+      slug: 'el-poblado',
+      schedule: '',
+    },
   ],
   extras: undefined,
   vehicleCategories: {},
@@ -94,6 +102,15 @@ describe('useUnavailabilityContext', () => {
       const { locationLabel } = useUnavailabilityContext()
 
       expect(locationLabel.value).toBe('Bogotá · Bogotá Aeropuerto')
+    })
+
+    it('capitaliza cada segmento de un slug de ciudad con guión (#30)', () => {
+      const formStore = useStoreReservationForm()
+      formStore.lugarRecogida = 'POBLADO'
+
+      const { locationLabel } = useUnavailabilityContext()
+
+      expect(locationLabel.value).toBe('El Poblado · El Poblado')
     })
 
     it('retorna string vacío cuando lugarRecogida es null', () => {

--- a/packages/logic/src/composables/useUnavailabilityContext.ts
+++ b/packages/logic/src/composables/useUnavailabilityContext.ts
@@ -46,7 +46,12 @@ function formatCity(raw: string): string {
   if (!raw) return '';
   const key = raw.trim().toLowerCase();
   if (CITY_DISPLAY_MAP[key]) return CITY_DISPLAY_MAP[key];
-  return raw.charAt(0).toUpperCase() + raw.slice(1);
+  // Hyphenated slugs not in the map ('el-poblado') are multi-word cities:
+  // title-case each segment so they read 'El Poblado', not 'El-poblado'.
+  return raw
+    .split('-')
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
 }
 
 // Compact month abbreviations. Built manually because DateFormatter('es-CO',


### PR DESCRIPTION
## Problema

El fallback de `formatCity` (ciudad fuera de `CITY_DISPLAY_MAP`) solo capitalizaba la primera letra, así que un slug multi-palabra como `el-poblado` renderizaba `El-poblado`.

## Fix

Split por `-` y title-case de cada segmento → `El Poblado`. Slugs de una sola palabra quedan igual.

## Scenario

`locationLabel` con `branch.city = 'el-poblado'` → `'El Poblado · El Poblado'`.

## Verificación

- `pnpm --filter @rentacar-main/logic test useUnavailabilityContext.test.ts` → **10 passed**
- Suite logic → **240 passed**, sin regresión
- Red-green: **falla** sin el fix (`El-poblado`), **pasa** con él

Closes #30