### PR TITLE
fix(reservations): treat whitespace-only branch.city as empty in formatCity (#32)

### DIFF
--- a/packages/logic/src/composables/__tests__/useUnavailabilityContext.test.ts
+++ b/packages/logic/src/composables/__tests__/useUnavailabilityContext.test.ts
@@ -36,6 +36,22 @@ const ADMIN_PAYLOAD = {
       slug: 'el-poblado',
       schedule: '',
     },
+    {
+      id: 3,
+      code: 'BLANK',
+      name: 'Sucursal Centro',
+      city: '   ',
+      slug: 'centro',
+      schedule: '',
+    },
+    {
+      id: 4,
+      code: 'UNTRIM',
+      name: 'Sucursal Norte',
+      city: '  bogota ',
+      slug: 'norte',
+      schedule: '',
+    },
   ],
   extras: undefined,
   vehicleCategories: {},
@@ -111,6 +127,24 @@ describe('useUnavailabilityContext', () => {
       const { locationLabel } = useUnavailabilityContext()
 
       expect(locationLabel.value).toBe('El Poblado · El Poblado')
+    })
+
+    it('city solo-whitespace cae al nombre de la sucursal, sin separador malformado (#32)', () => {
+      const formStore = useStoreReservationForm()
+      formStore.lugarRecogida = 'BLANK'
+
+      const { locationLabel } = useUnavailabilityContext()
+
+      expect(locationLabel.value).toBe('Sucursal Centro')
+    })
+
+    it('city con espacios alrededor se normaliza vía el mapa (#32)', () => {
+      const formStore = useStoreReservationForm()
+      formStore.lugarRecogida = 'UNTRIM'
+
+      const { locationLabel } = useUnavailabilityContext()
+
+      expect(locationLabel.value).toBe('Bogotá · Sucursal Norte')
     })
 
     it('retorna string vacío cuando lugarRecogida es null', () => {

--- a/packages/logic/src/composables/useUnavailabilityContext.ts
+++ b/packages/logic/src/composables/useUnavailabilityContext.ts
@@ -43,12 +43,16 @@ const CITY_DISPLAY_MAP: Record<string, string> = {
 };
 
 function formatCity(raw: string): string {
-  if (!raw) return '';
-  const key = raw.trim().toLowerCase();
+  // Trim first: a whitespace-only city ('   ') must read as empty, otherwise
+  // locationLabel renders a malformed '   · Sucursal' with an orphan
+  // separator. The trimmed, lowercased key also drives the map lookup and the
+  // fallback, so surrounding whitespace never leaks into the output.
+  const key = raw?.trim().toLowerCase() ?? '';
+  if (!key) return '';
   if (CITY_DISPLAY_MAP[key]) return CITY_DISPLAY_MAP[key];
   // Hyphenated slugs not in the map ('el-poblado') are multi-word cities:
   // title-case each segment so they read 'El Poblado', not 'El-poblado'.
-  return raw
+  return key
     .split('-')
     .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
     .join(' ');


### PR DESCRIPTION
> Apilado sobre #84 (#30). Base: `fix/issue-30-formatcity-hyphen`. GitHub re-apunta a `main` al mergear #84.

## Problema

`formatCity` solo descartaba null/empty con `if(!raw)`; un `branch.city` solo-whitespace (`'   '`) pasaba el guard y el fallback lo devolvía tal cual, así que `locationLabel` renderizaba `'   · Sucursal'` con separador huérfano.

## Fix

Derivar todo del `key` (trim + lowercase) y early-return cuando queda vacío → `locationLabel` cae al `branch.name`. De paso, cualquier city con espacios alrededor se normaliza (no solo las del mapa).

## Scenarios

- `branch.city = '   '` → `locationLabel` = `'Sucursal Centro'` (sin separador). **Discriminante.**
- `branch.city = '  bogota '` → `'Bogotá · Sucursal Norte'` (guard de normalización; ya pasaba vía mapa).

## Verificación

- `pnpm --filter @rentacar-main/logic test useUnavailabilityContext.test.ts` → **12 passed**
- Suite logic → **242 passed**, sin regresión
- Red-green: el caso whitespace **falla** sin el fix (`'   · Sucursal Centro'`), **pasa** con él

Closes #32