### PR TITLE
fix(reservations): render single date when pickup equals return (#31)

### DIFF
--- a/packages/logic/src/composables/__tests__/useUnavailabilityContext.test.ts
+++ b/packages/logic/src/composables/__tests__/useUnavailabilityContext.test.ts
@@ -79,6 +79,16 @@ describe('useUnavailabilityContext', () => {
       expect(dateRangeLabel.value).toBe('12-15 mayo')
     })
 
+    it('mismo día recogida=devolución muestra una sola fecha, no "12-12" (#31)', () => {
+      const formStore = useStoreReservationForm()
+      formStore.fechaRecogida = '2026-05-12'
+      formStore.fechaDevolucion = '2026-05-12'
+
+      const { dateRangeLabel } = useUnavailabilityContext()
+
+      expect(dateRangeLabel.value).toBe('12 mayo')
+    })
+
     it('cross-month mismo año usa formato corto separado por " - "', () => {
       const formStore = useStoreReservationForm()
       formStore.fechaRecogida = '2026-04-30'

--- a/packages/logic/src/composables/useUnavailabilityContext.ts
+++ b/packages/logic/src/composables/useUnavailabilityContext.ts
@@ -101,6 +101,10 @@ export default function useUnavailabilityContext(): UnavailabilityContext {
     }
 
     if (pickup.month === ret.month) {
+      if (pickup.day === ret.day) {
+        // Same day (pickup === return): "12 mayo", not the ambiguous "12-12".
+        return `${pickup.day} ${longMonth(pickup)}`;
+      }
       // Same month: "12-15 mayo"
       return `${pickup.day}-${ret.day} ${longMonth(pickup)}`;
     }


### PR DESCRIPTION
> Apilado sobre #85 (#32) → #84 (#30). GitHub re-apunta la base al mergear los previos.

## Problema

Mismo día recogida=devolución renderizaba el rango ambiguo `'12-12 mayo'`.

## Fix

Dentro de la rama mismo-mes/mismo-año, si `pickup.day === ret.day` emitir una sola fecha `'12 mayo'`.

## Scenario

`fechaRecogida = fechaDevolucion = '2026-05-12'` → `dateRangeLabel` = `'12 mayo'`.

## Verificación

- `pnpm --filter @rentacar-main/logic test useUnavailabilityContext.test.ts` → **13 passed**
- Suite logic → **243 passed**, sin regresión (12-15 mayo, cross-month, cross-year intactos)
- Red-green: **falla** sin el fix (`'12-12 mayo'`), **pasa** con él

Closes #31