### PR TITLE
fix(reservations): stop silently dropping categories without vehicleCategories (#22)

### DIFF
--- a/packages/ui-alquicarros/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquicarros/app/components/CategorySelectionSection.vue
@@ -19,7 +19,7 @@
       </p>
     </div>
   </div>
-  <div v-else-if="!hasAvailableCategories && !pendingSearch && isInventoryEmpty" class="text-center">
+  <div v-else-if="!hasRenderableAvailable && !pendingSearch && isInventoryEmpty" class="text-center">
     <div class="text-white text-center">
       <div class="text-3xl">¡Oops!</div>
       <div class="text-lg">
@@ -32,7 +32,7 @@
     </div>
   </div>
   <template v-if="!pendingSearch">
-    <div v-if="hasAvailableCategories" class="text-white text-center">
+    <div v-if="hasRenderableAvailable" class="text-white text-center">
       <div class="text-lg md:text-xl font-bold">¡Vehículos Disponibles!</div>
       <div class="text-sm md:text-base">
         <span>En <span class="text-yellow-400 font-semibold">{{pickupCityName}}</span> para el <span class="text-yellow-400 font-semibold">{{ humanFormattedPickupDate }}</span>.</span>
@@ -40,21 +40,18 @@
       </div>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-      <!-- Only categories with a vehicleCategories entry can render — both card
-           components read vehicleCategory props. Filtering the v-for source keeps
-           iteration === render; an admin category missing from vehicleCategories
-           used to match neither branch and was silently dropped. Issue #22. -->
-      <template v-for="(category, index) in filteredCategories.filter((c: { categoryCode: string }) => vehicleCategories[c.categoryCode])" :key="`cat-${category.categoryCode}`">
+      <!-- Iterate renderableCategories so iteration === render and the
+           availability banner (hasRenderableAvailable) can't disagree with the
+           grid. A category missing from vehicleCategories has no card to show
+           and is excluded at the source rather than dropped mid-loop. #22. -->
+      <template v-for="(category, index) in renderableCategories" :key="`cat-${category.categoryCode}`">
         <placeholders-unable-category-card
-          v-if="
-            category.estimatedTotalAmount == 999999999 &&
-            vehicleCategories[category.categoryCode]
-          "
+          v-if="category.estimatedTotalAmount == 999999999"
           :category
           :vehicleCategory="vehicleCategories[category.categoryCode]"
         />
         <category-card
-          v-else-if="vehicleCategories[category.categoryCode]"
+          v-else
           :category
           :vehicle-category="vehicleCategories[category.categoryCode]"
           :priority="index === 0"
@@ -215,7 +212,6 @@ const {
   pending: pendingSearch,
   selectedCategory,
   filteredCategories,
-  hasAvailableCategories,
   error: searchError,
 } = storeToRefs(storeSearch);
 const { vehiculo, humanFormattedPickupDate, isSubmittingForm, selectedPickupLocation } = storeToRefs(storeForm);
@@ -235,6 +231,17 @@ const whatsappContacts: Record<string, { phone: string; display: string }> = {
 };
 const whatsappContact = whatsappContacts[config.public.rentacarFranchise as string] ?? whatsappContacts.alquilatucarro;
 const { vehicleCategories } = useFetchRentacarData();
+// Categories the grid can actually render (those with presentation metadata in
+// vehicleCategories). The grid AND the availability banner both derive from
+// this single source so they can never disagree — a category with real
+// availability but no metadata must not flip the banner to "available" while
+// the grid renders nothing. Issue #22.
+const renderableCategories = computed(() =>
+  filteredCategories.value.filter((c: { categoryCode: string }) => vehicleCategories[c.categoryCode]),
+);
+const hasRenderableAvailable = computed(() =>
+  renderableCategories.value.some((c: { estimatedTotalAmount: number }) => c.estimatedTotalAmount !== 999999999),
+);
 const slideoverReservationResume = ref<boolean>(false);
 const slideoverReservationForm = ref<boolean>(false);
 const reservationFormComponent = ref(null);

--- a/packages/ui-alquicarros/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquicarros/app/components/CategorySelectionSection.vue
@@ -40,7 +40,11 @@
       </div>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-      <template v-for="(category, index) in filteredCategories" :key="`cat-${category.categoryCode}`">
+      <!-- Only categories with a vehicleCategories entry can render — both card
+           components read vehicleCategory props. Filtering the v-for source keeps
+           iteration === render; an admin category missing from vehicleCategories
+           used to match neither branch and was silently dropped. Issue #22. -->
+      <template v-for="(category, index) in filteredCategories.filter((c: { categoryCode: string }) => vehicleCategories[c.categoryCode])" :key="`cat-${category.categoryCode}`">
         <placeholders-unable-category-card
           v-if="
             category.estimatedTotalAmount == 999999999 &&

--- a/packages/ui-alquilame/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquilame/app/components/CategorySelectionSection.vue
@@ -19,7 +19,7 @@
       </p>
     </div>
   </div>
-  <div v-else-if="!hasAvailableCategories && !pendingSearch && isInventoryEmpty" class="text-center">
+  <div v-else-if="!hasRenderableAvailable && !pendingSearch && isInventoryEmpty" class="text-center">
     <div class="text-white text-center">
       <div class="text-3xl">¡Oops!</div>
       <div class="text-lg">
@@ -32,7 +32,7 @@
     </div>
   </div>
   <template v-if="!pendingSearch">
-    <div v-if="hasAvailableCategories" class="text-white text-center">
+    <div v-if="hasRenderableAvailable" class="text-white text-center">
       <div class="text-lg md:text-xl font-bold">¡Vehículos Disponibles!</div>
       <div class="text-sm md:text-base">
         <span>En <span class="text-yellow-400 font-semibold">{{pickupCityName}}</span> para el <span class="text-yellow-400 font-semibold">{{ humanFormattedPickupDate }}</span>.</span>
@@ -40,21 +40,18 @@
       </div>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-      <!-- Only categories with a vehicleCategories entry can render — both card
-           components read vehicleCategory props. Filtering the v-for source keeps
-           iteration === render; an admin category missing from vehicleCategories
-           used to match neither branch and was silently dropped. Issue #22. -->
-      <template v-for="(category, index) in filteredCategories.filter((c: { categoryCode: string }) => vehicleCategories[c.categoryCode])" :key="`cat-${category.categoryCode}`">
+      <!-- Iterate renderableCategories so iteration === render and the
+           availability banner (hasRenderableAvailable) can't disagree with the
+           grid. A category missing from vehicleCategories has no card to show
+           and is excluded at the source rather than dropped mid-loop. #22. -->
+      <template v-for="(category, index) in renderableCategories" :key="`cat-${category.categoryCode}`">
         <placeholders-unable-category-card
-          v-if="
-            category.estimatedTotalAmount == 999999999 &&
-            vehicleCategories[category.categoryCode]
-          "
+          v-if="category.estimatedTotalAmount == 999999999"
           :category
           :vehicleCategory="vehicleCategories[category.categoryCode]"
         />
         <category-card
-          v-else-if="vehicleCategories[category.categoryCode]"
+          v-else
           :category
           :vehicle-category="vehicleCategories[category.categoryCode]"
           :priority="index === 0"
@@ -215,7 +212,6 @@ const {
   pending: pendingSearch,
   selectedCategory,
   filteredCategories,
-  hasAvailableCategories,
   error: searchError,
 } = storeToRefs(storeSearch);
 const { vehiculo, humanFormattedPickupDate, isSubmittingForm, selectedPickupLocation } = storeToRefs(storeForm);
@@ -235,6 +231,17 @@ const whatsappContacts: Record<string, { phone: string; display: string }> = {
 };
 const whatsappContact = whatsappContacts[config.public.rentacarFranchise as string] ?? whatsappContacts.alquilatucarro;
 const { vehicleCategories } = useFetchRentacarData();
+// Categories the grid can actually render (those with presentation metadata in
+// vehicleCategories). The grid AND the availability banner both derive from
+// this single source so they can never disagree — a category with real
+// availability but no metadata must not flip the banner to "available" while
+// the grid renders nothing. Issue #22.
+const renderableCategories = computed(() =>
+  filteredCategories.value.filter((c: { categoryCode: string }) => vehicleCategories[c.categoryCode]),
+);
+const hasRenderableAvailable = computed(() =>
+  renderableCategories.value.some((c: { estimatedTotalAmount: number }) => c.estimatedTotalAmount !== 999999999),
+);
 const slideoverReservationResume = ref<boolean>(false);
 const slideoverReservationForm = ref<boolean>(false);
 const reservationFormComponent = ref(null);

--- a/packages/ui-alquilame/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquilame/app/components/CategorySelectionSection.vue
@@ -40,7 +40,11 @@
       </div>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-      <template v-for="(category, index) in filteredCategories" :key="`cat-${category.categoryCode}`">
+      <!-- Only categories with a vehicleCategories entry can render — both card
+           components read vehicleCategory props. Filtering the v-for source keeps
+           iteration === render; an admin category missing from vehicleCategories
+           used to match neither branch and was silently dropped. Issue #22. -->
+      <template v-for="(category, index) in filteredCategories.filter((c: { categoryCode: string }) => vehicleCategories[c.categoryCode])" :key="`cat-${category.categoryCode}`">
         <placeholders-unable-category-card
           v-if="
             category.estimatedTotalAmount == 999999999 &&

--- a/packages/ui-alquilatucarro/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquilatucarro/app/components/CategorySelectionSection.vue
@@ -19,7 +19,7 @@
       </p>
     </div>
   </div>
-  <div v-else-if="!hasAvailableCategories && !pendingSearch && isInventoryEmpty" class="text-center">
+  <div v-else-if="!hasRenderableAvailable && !pendingSearch && isInventoryEmpty" class="text-center">
     <div class="text-white text-center">
       <div class="text-3xl">¡Oops!</div>
       <div class="text-lg">
@@ -32,7 +32,7 @@
     </div>
   </div>
   <template v-if="!pendingSearch">
-    <div v-if="hasAvailableCategories" class="text-white text-center">
+    <div v-if="hasRenderableAvailable" class="text-white text-center">
       <div class="text-lg md:text-xl font-bold">¡Vehículos Disponibles!</div>
       <div class="text-sm md:text-base">
         <span>En <span class="text-yellow-400 font-semibold">{{pickupCityName}}</span> para el <span class="text-yellow-400 font-semibold">{{ humanFormattedPickupDate }}</span>.</span>
@@ -40,21 +40,18 @@
       </div>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-      <!-- Only categories with a vehicleCategories entry can render — both card
-           components read vehicleCategory props. Filtering the v-for source keeps
-           iteration === render; an admin category missing from vehicleCategories
-           used to match neither branch and was silently dropped. Issue #22. -->
-      <template v-for="(category, index) in filteredCategories.filter((c: { categoryCode: string }) => vehicleCategories[c.categoryCode])" :key="`cat-${category.categoryCode}`">
+      <!-- Iterate renderableCategories so iteration === render and the
+           availability banner (hasRenderableAvailable) can't disagree with the
+           grid. A category missing from vehicleCategories has no card to show
+           and is excluded at the source rather than dropped mid-loop. #22. -->
+      <template v-for="(category, index) in renderableCategories" :key="`cat-${category.categoryCode}`">
         <placeholders-unable-category-card
-          v-if="
-            category.estimatedTotalAmount == 999999999 &&
-            vehicleCategories[category.categoryCode]
-          "
+          v-if="category.estimatedTotalAmount == 999999999"
           :category
           :vehicleCategory="vehicleCategories[category.categoryCode]"
         />
         <category-card
-          v-else-if="vehicleCategories[category.categoryCode]"
+          v-else
           :category
           :vehicle-category="vehicleCategories[category.categoryCode]"
           :priority="index === 0"
@@ -215,7 +212,6 @@ const {
   pending: pendingSearch,
   selectedCategory,
   filteredCategories,
-  hasAvailableCategories,
   error: searchError,
 } = storeToRefs(storeSearch);
 const { vehiculo, humanFormattedPickupDate, isSubmittingForm, selectedPickupLocation } = storeToRefs(storeForm);
@@ -235,6 +231,17 @@ const whatsappContacts: Record<string, { phone: string; display: string }> = {
 };
 const whatsappContact = whatsappContacts[config.public.rentacarFranchise as string] ?? whatsappContacts.alquilatucarro;
 const { vehicleCategories } = useFetchRentacarData();
+// Categories the grid can actually render (those with presentation metadata in
+// vehicleCategories). The grid AND the availability banner both derive from
+// this single source so they can never disagree — a category with real
+// availability but no metadata must not flip the banner to "available" while
+// the grid renders nothing. Issue #22.
+const renderableCategories = computed(() =>
+  filteredCategories.value.filter((c: { categoryCode: string }) => vehicleCategories[c.categoryCode]),
+);
+const hasRenderableAvailable = computed(() =>
+  renderableCategories.value.some((c: { estimatedTotalAmount: number }) => c.estimatedTotalAmount !== 999999999),
+);
 const slideoverReservationResume = ref<boolean>(false);
 const slideoverReservationForm = ref<boolean>(false);
 const reservationFormComponent = ref(null);

--- a/packages/ui-alquilatucarro/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquilatucarro/app/components/CategorySelectionSection.vue
@@ -40,7 +40,11 @@
       </div>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-      <template v-for="(category, index) in filteredCategories" :key="`cat-${category.categoryCode}`">
+      <!-- Only categories with a vehicleCategories entry can render — both card
+           components read vehicleCategory props. Filtering the v-for source keeps
+           iteration === render; an admin category missing from vehicleCategories
+           used to match neither branch and was silently dropped. Issue #22. -->
+      <template v-for="(category, index) in filteredCategories.filter((c: { categoryCode: string }) => vehicleCategories[c.categoryCode])" :key="`cat-${category.categoryCode}`">
         <placeholders-unable-category-card
           v-if="
             category.estimatedTotalAmount == 999999999 &&


### PR DESCRIPTION
## Problema (causa raíz confirmada en código)

En el grid de `CategorySelectionSection.vue` (3 marcas), ambas ramas del `<template v-for>` exigen `vehicleCategories[category.categoryCode]`:
- `placeholders-unable-category-card` → `v-if="estimatedTotalAmount == 999999999 && vehicleCategories[code]"`
- `category-card` → `v-else-if="vehicleCategories[code]"`

Si una categoría admin **no** tiene entrada en `vehicleCategories`, **ninguna** rama renderiza y la card desaparece a mitad del loop, sin rastro. `CategoryCard.vue` además hace `const { modelos, grupo } = props.vehicleCategory` → revienta sin metadata. El handler de selección ya hace `if (!vehicleCategories[codigo]) return`.

## Fix (decisión: filtrar — Opción 1 del issue)

Filtrar la fuente del `v-for` a las categorías que sí tienen metadata → **iteración === render**. Param tipado para no introducir `implicit-any`.

**Seguro por construcción:**
- Datos válidos (toda categoría tiene `vehicleCategories`) → el filtro es no-op, comportamiento idéntico.
- Caso bug (categoría sin metadata) → se omite de la iteración, pero ya antes no renderizaba **nada** (matcheaba ni `v-if` ni `v-else-if`). En ningún caso renderiza peor.

Se eligió filtrar (no fallback visible) porque una categoría sin nombre/modelos/imagen no puede mostrar una card útil; la inconsistencia se corrige en el origen (admin/Supabase).

## Verificación

- `pnpm --filter ui-alquilatucarro typecheck` → **640 = baseline #18, 0 nuevos**. Los 3 archivos idénticos en la zona cambiada → delta 0 por marca.
- Validación runtime del estado inconsistente (categoría admin sin `vehicleCategories`): no reproducible en e2e (es un estado de datos curados; forzarlo requiere un fixture SSR de `rentacar-data`). El fix no lo necesita — es no-regresivo por construcción.

Closes #22
