### PR TITLE
test(e2e): close-delay contract spec for price tooltip (skipped) (#37)

### DIFF
--- a/e2e/tooltip-price-close-delay.spec.ts
+++ b/e2e/tooltip-price-close-delay.spec.ts
@@ -1,55 +1,41 @@
-import { test, expect, type Route } from '@playwright/test';
+import { test, expect, type Route, type Page } from '@playwright/test';
 
 /**
  * Close-delay contract for the total-price tooltip on an available CategoryCard.
- * Issue #37. The composable contract (open/close timing) is unit-tested in
+ * Issue #37. The composable timing is unit-tested in
  * packages/logic/src/composables/__tests__/useDelayedClose.test.ts (S1–S7);
  * this spec is the integration-level proof against the real Reka/Nuxt UI
  * tooltip wired in CategoryCard.vue.
  *
  *   R1: hovering the price opens the tooltip (after Reka's open delay).
- *   R2: leaving the trigger keeps the tooltip open for the close delay, then
- *       it disappears (the operator can move into it to read price details).
+ *   R2: leaving the trigger keeps the tooltip open through the close delay,
+ *       then it disappears (so the operator can move into it to read details).
  *
- * SKIPPED — same blocker as SCEN-U4 in unable-cards-on-empty-inventory.spec.ts.
- * The price tooltip only exists on an *available* CategoryCard, which requires
- * the availability categoryCode to match an admin category that also has a
- * vehicleCategories entry. Admin data + vehicleCategories come from
- * /api/rentacar-data, which is SSR-loaded and NOT interceptable via
- * page.route — so stubbing only the availability response leaves the page in
- * the all-unable branch and `.precio-total` never renders (verified: this spec
- * fails with "`.precio-total` not found" against a dev server). Un-skip once a
- * server-side rentacar-data fixture exists. The close-delay contract is fully
- * covered meanwhile at the unit layer (useDelayedClose.test.ts S1–S7).
+ * The tooltip only renders on an *available* card, which needs an availability
+ * categoryCode that matches an admin category that also has a vehicleCategories
+ * entry. /api/rentacar-data (admin catalog + vehicleCategories) is SSR-loaded
+ * and NOT interceptable via page.route — but it IS fetchable over HTTP, and it
+ * loads from Supabase directly (not the :3000 booking backend). So instead of
+ * hardcoding a code (SCEN-U4's pitfall — a guessed 'B' may be absent), we
+ * discover a renderable code from the live catalog at runtime and stub only the
+ * availability POST (which IS client-side) for that exact code. This SOLVES the
+ * render — the available card with `.precio-total` appears reliably.
+ *
+ * SKIPPED, though, on the *open* path. The tooltip opens on Reka's hover-intent
+ * (delay-duration 3000ms of sustained hover); in headless Chromium under load
+ * that open is timing-fragile — `--repeat-each=3` gave R1 3/3 failures and R2
+ * 3/3 flaky (passes only on retry), even at a 12s wait. The close-delay
+ * contract itself (the point of this issue) holds once open, but a hover-intent
+ * tooltip with 3s open + 3s close is not a reliable e2e target. The durable
+ * fix is a test-only knob to shrink delay-duration / closeDelayMs (default
+ * unchanged in prod); enable this spec once that exists. Meanwhile the contract
+ * is fully covered, deterministically, at the unit layer (useDelayedClose
+ * S1–S7, fake timers).
  */
 
-const B_AVAILABILITY = [
-  {
-    categoryCode: 'B',
-    estimatedTotalAmount: 250000,
-    totalAmount: 250000,
-    numberDays: 3,
-    referenceToken: 'tok-b',
-    rateQualifier: 'rq-b',
-    returnFeeAmount: 0,
-    vehicleDayCharge: 80000,
-    taxFeeAmount: 0,
-    taxFeePercentage: 0,
-    IVAFeeAmount: 0,
-    coverageUnitCharge: 0,
-    coverageQuantity: 0,
-    coverageTotalAmount: 0,
-  },
-];
-
-function stubAvailabilityArray(payload: unknown) {
-  return (route: Route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(payload),
-    });
-}
+// City-restricted categories — skip them so the chosen code is renderable on
+// the Bogotá results URL regardless of city filters (see useStoreSearchData).
+const CITY_RESTRICTED = new Set(['CX', 'GY']);
 
 const BOGOTA_3DAY_URL =
   '/bogota/buscar-vehiculos' +
@@ -61,34 +47,79 @@ const BOGOTA_3DAY_URL =
   '/hora-devolucion/08:00am';
 
 const PRICE_TRIGGER = '.precio-total';
-// Distinctive line that only exists inside the tooltip content.
+// Line that only appears inside the tooltip content.
 const TOOLTIP_LINE = 'Seguro día:';
+
+function availabilityStub(categoryCode: string) {
+  const payload = [
+    {
+      categoryCode,
+      estimatedTotalAmount: 250000,
+      totalAmount: 250000,
+      numberDays: 3,
+      referenceToken: 'tok',
+      rateQualifier: 'rq',
+      returnFeeAmount: 0,
+      vehicleDayCharge: 80000,
+      taxFeeAmount: 0,
+      taxFeePercentage: 0,
+      IVAFeeAmount: 0,
+      coverageUnitCharge: 0,
+      coverageQuantity: 0,
+      coverageTotalAmount: 0,
+    },
+  ];
+  return (route: Route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(payload) });
+}
+
+// Resolve a category code present in BOTH the admin catalog and the
+// vehicleCategories map (so the available card actually renders), excluding
+// city-restricted codes. Returns null if the catalog has none (e.g. Supabase
+// unreachable in the test env) so the caller can skip with a clear reason.
+async function discoverRenderableCode(page: Page): Promise<string | null> {
+  const res = await page.request.get('/api/rentacar-data');
+  if (!res.ok()) return null;
+  const data = await res.json();
+  const vehicleCategories: Record<string, unknown> = data.vehicleCategories ?? {};
+  const categories: Array<{ id?: string }> = data.categories ?? [];
+  const match = categories.find(
+    (c) => c?.id && !CITY_RESTRICTED.has(c.id) && vehicleCategories[c.id],
+  );
+  return match?.id ?? null;
+}
 
 test.describe.skip('Total-price tooltip close-delay (#37)', () => {
   test.beforeEach(async ({ page }) => {
-    await page.route('**/api/reservations/availability', stubAvailabilityArray(B_AVAILABILITY));
+    const code = await discoverRenderableCode(page);
+    test.skip(!code, 'No category with a vehicleCategories entry in the live catalog (Supabase unreachable?)');
+
+    await page.route('**/api/reservations/availability', availabilityStub(code as string));
     await page.goto(BOGOTA_3DAY_URL);
   });
 
   test('R1: hovering the price opens the tooltip', async ({ page }) => {
     const trigger = page.locator(PRICE_TRIGGER).first();
     await expect(trigger).toBeVisible({ timeout: 30_000 });
+    await trigger.scrollIntoViewIfNeeded();
 
     await trigger.hover();
-    // Reka opens after its delay-duration (3s); allow margin.
-    await expect(page.getByText(TOOLTIP_LINE)).toBeVisible({ timeout: 8_000 });
+    // Reka opens only after sustained hover for its delay-duration (3s); the
+    // 12s budget absorbs that plus a cold-start render.
+    await expect(page.getByText(TOOLTIP_LINE)).toBeVisible({ timeout: 12_000 });
   });
 
   test('R2: leaving the trigger keeps the tooltip open through the close delay', async ({ page }) => {
     const trigger = page.locator(PRICE_TRIGGER).first();
     await expect(trigger).toBeVisible({ timeout: 30_000 });
+    await trigger.scrollIntoViewIfNeeded();
 
     await trigger.hover();
     const tooltip = page.getByText(TOOLTIP_LINE);
-    await expect(tooltip).toBeVisible({ timeout: 8_000 });
+    await expect(tooltip).toBeVisible({ timeout: 12_000 });
 
-    // Move the pointer off the trigger (hover-leave).
-    await page.locator('h1, header').first().hover();
+    // Hover-leave: move the pointer off the trigger.
+    await page.mouse.move(0, 0);
 
     // Still visible shortly after leaving (close delay is 3s).
     await page.waitForTimeout(1_000);

--- a/e2e/tooltip-price-close-delay.spec.ts
+++ b/e2e/tooltip-price-close-delay.spec.ts
@@ -86,7 +86,11 @@ async function discoverRenderableCode(page: Page): Promise<string | null> {
 }
 
 test.describe('Total-price tooltip close-delay (#37)', () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, isMobile }) => {
+    // Hover-intent tooltip: touch devices have no hover, so Reka never opens it.
+    // The Mobile Chrome / Mobile Safari projects can't exercise this contract.
+    test.skip(isMobile, 'hover-intent tooltip is desktop-pointer only (no hover on touch)');
+
     const code = await discoverRenderableCode(page);
     test.skip(!code, 'No category with a vehicleCategories entry in the live catalog (Supabase unreachable?)');
 

--- a/e2e/tooltip-price-close-delay.spec.ts
+++ b/e2e/tooltip-price-close-delay.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect, type Route } from '@playwright/test';
+
+/**
+ * Close-delay contract for the total-price tooltip on an available CategoryCard.
+ * Issue #37. The composable contract (open/close timing) is unit-tested in
+ * packages/logic/src/composables/__tests__/useDelayedClose.test.ts (S1–S7);
+ * this spec is the integration-level proof against the real Reka/Nuxt UI
+ * tooltip wired in CategoryCard.vue.
+ *
+ *   R1: hovering the price opens the tooltip (after Reka's open delay).
+ *   R2: leaving the trigger keeps the tooltip open for the close delay, then
+ *       it disappears (the operator can move into it to read price details).
+ *
+ * SKIPPED — same blocker as SCEN-U4 in unable-cards-on-empty-inventory.spec.ts.
+ * The price tooltip only exists on an *available* CategoryCard, which requires
+ * the availability categoryCode to match an admin category that also has a
+ * vehicleCategories entry. Admin data + vehicleCategories come from
+ * /api/rentacar-data, which is SSR-loaded and NOT interceptable via
+ * page.route — so stubbing only the availability response leaves the page in
+ * the all-unable branch and `.precio-total` never renders (verified: this spec
+ * fails with "`.precio-total` not found" against a dev server). Un-skip once a
+ * server-side rentacar-data fixture exists. The close-delay contract is fully
+ * covered meanwhile at the unit layer (useDelayedClose.test.ts S1–S7).
+ */
+
+const B_AVAILABILITY = [
+  {
+    categoryCode: 'B',
+    estimatedTotalAmount: 250000,
+    totalAmount: 250000,
+    numberDays: 3,
+    referenceToken: 'tok-b',
+    rateQualifier: 'rq-b',
+    returnFeeAmount: 0,
+    vehicleDayCharge: 80000,
+    taxFeeAmount: 0,
+    taxFeePercentage: 0,
+    IVAFeeAmount: 0,
+    coverageUnitCharge: 0,
+    coverageQuantity: 0,
+    coverageTotalAmount: 0,
+  },
+];
+
+function stubAvailabilityArray(payload: unknown) {
+  return (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(payload),
+    });
+}
+
+const BOGOTA_3DAY_URL =
+  '/bogota/buscar-vehiculos' +
+  '/lugar-recogida/bogota-aeropuerto' +
+  '/lugar-devolucion/bogota-aeropuerto' +
+  '/fecha-recogida/2026-10-04' +
+  '/fecha-devolucion/2026-10-07' +
+  '/hora-recogida/08:00am' +
+  '/hora-devolucion/08:00am';
+
+const PRICE_TRIGGER = '.precio-total';
+// Distinctive line that only exists inside the tooltip content.
+const TOOLTIP_LINE = 'Seguro día:';
+
+test.describe.skip('Total-price tooltip close-delay (#37)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/reservations/availability', stubAvailabilityArray(B_AVAILABILITY));
+    await page.goto(BOGOTA_3DAY_URL);
+  });
+
+  test('R1: hovering the price opens the tooltip', async ({ page }) => {
+    const trigger = page.locator(PRICE_TRIGGER).first();
+    await expect(trigger).toBeVisible({ timeout: 30_000 });
+
+    await trigger.hover();
+    // Reka opens after its delay-duration (3s); allow margin.
+    await expect(page.getByText(TOOLTIP_LINE)).toBeVisible({ timeout: 8_000 });
+  });
+
+  test('R2: leaving the trigger keeps the tooltip open through the close delay', async ({ page }) => {
+    const trigger = page.locator(PRICE_TRIGGER).first();
+    await expect(trigger).toBeVisible({ timeout: 30_000 });
+
+    await trigger.hover();
+    const tooltip = page.getByText(TOOLTIP_LINE);
+    await expect(tooltip).toBeVisible({ timeout: 8_000 });
+
+    // Move the pointer off the trigger (hover-leave).
+    await page.locator('h1, header').first().hover();
+
+    // Still visible shortly after leaving (close delay is 3s).
+    await page.waitForTimeout(1_000);
+    await expect(tooltip).toBeVisible();
+
+    // Gone once the close delay elapses.
+    await expect(tooltip).toBeHidden({ timeout: 6_000 });
+  });
+});

--- a/e2e/tooltip-price-close-delay.spec.ts
+++ b/e2e/tooltip-price-close-delay.spec.ts
@@ -7,31 +7,26 @@ import { test, expect, type Route, type Page } from '@playwright/test';
  * this spec is the integration-level proof against the real Reka/Nuxt UI
  * tooltip wired in CategoryCard.vue.
  *
- *   R1: hovering the price opens the tooltip (after Reka's open delay).
+ *   R1: hovering the price opens the tooltip.
  *   R2: leaving the trigger keeps the tooltip open through the close delay,
  *       then it disappears (so the operator can move into it to read details).
  *
- * The tooltip only renders on an *available* card, which needs an availability
- * categoryCode that matches an admin category that also has a vehicleCategories
- * entry. /api/rentacar-data (admin catalog + vehicleCategories) is SSR-loaded
- * and NOT interceptable via page.route — but it IS fetchable over HTTP, and it
- * loads from Supabase directly (not the :3000 booking backend). So instead of
- * hardcoding a code (SCEN-U4's pitfall — a guessed 'B' may be absent), we
- * discover a renderable code from the live catalog at runtime and stub only the
- * availability POST (which IS client-side) for that exact code. This SOLVES the
- * render — the available card with `.precio-total` appears reliably.
- *
- * SKIPPED, though, on the *open* path. The tooltip opens on Reka's hover-intent
- * (delay-duration 3000ms of sustained hover); in headless Chromium under load
- * that open is timing-fragile — `--repeat-each=3` gave R1 3/3 failures and R2
- * 3/3 flaky (passes only on retry), even at a 12s wait. The close-delay
- * contract itself (the point of this issue) holds once open, but a hover-intent
- * tooltip with 3s open + 3s close is not a reliable e2e target. The durable
- * fix is a test-only knob to shrink delay-duration / closeDelayMs (default
- * unchanged in prod); enable this spec once that exists. Meanwhile the contract
- * is fully covered, deterministically, at the unit layer (useDelayedClose
- * S1–S7, fake timers).
+ * Two affordances make this runnable:
+ *  - RENDER: the tooltip only lives on an *available* card, which needs an
+ *    availability categoryCode matching an admin category that also has a
+ *    vehicleCategories entry. /api/rentacar-data (admin catalog) is SSR-loaded
+ *    and not page.route-interceptable, but it IS HTTP-fetchable and Supabase-
+ *    backed — so we discover a renderable code from the live catalog at runtime
+ *    and stub only the (client-side) availability POST for it.
+ *  - TIMING: Reka's hover-intent open (delay-duration 3000ms) is too flaky to
+ *    drive headless, so CategoryCard honours a `?e2eTooltipDelays=1` test knob
+ *    that shrinks the open delay to 50ms and the close delay to
+ *    TEST_CLOSE_DELAY_MS (production stays 3000ms without the flag).
  */
+
+// Close delay applied by the ?e2eTooltipDelays=1 knob — keep in sync with
+// CategoryCard.vue's tooltipCloseDelayMs.
+const TEST_CLOSE_DELAY_MS = 600;
 
 // City-restricted categories — skip them so the chosen code is renderable on
 // the Bogotá results URL regardless of city filters (see useStoreSearchData).
@@ -44,7 +39,8 @@ const BOGOTA_3DAY_URL =
   '/fecha-recogida/2026-10-04' +
   '/fecha-devolucion/2026-10-07' +
   '/hora-recogida/08:00am' +
-  '/hora-devolucion/08:00am';
+  '/hora-devolucion/08:00am' +
+  '?e2eTooltipDelays=1';
 
 const PRICE_TRIGGER = '.precio-total';
 // Line that only appears inside the tooltip content.
@@ -89,7 +85,7 @@ async function discoverRenderableCode(page: Page): Promise<string | null> {
   return match?.id ?? null;
 }
 
-test.describe.skip('Total-price tooltip close-delay (#37)', () => {
+test.describe('Total-price tooltip close-delay (#37)', () => {
   test.beforeEach(async ({ page }) => {
     const code = await discoverRenderableCode(page);
     test.skip(!code, 'No category with a vehicleCategories entry in the live catalog (Supabase unreachable?)');
@@ -104,9 +100,8 @@ test.describe.skip('Total-price tooltip close-delay (#37)', () => {
     await trigger.scrollIntoViewIfNeeded();
 
     await trigger.hover();
-    // Reka opens only after sustained hover for its delay-duration (3s); the
-    // 12s budget absorbs that plus a cold-start render.
-    await expect(page.getByText(TOOLTIP_LINE)).toBeVisible({ timeout: 12_000 });
+    // Open delay is 50ms under the test knob; the budget covers render settle.
+    await expect(page.getByText(TOOLTIP_LINE)).toBeVisible({ timeout: 5_000 });
   });
 
   test('R2: leaving the trigger keeps the tooltip open through the close delay', async ({ page }) => {
@@ -116,16 +111,17 @@ test.describe.skip('Total-price tooltip close-delay (#37)', () => {
 
     await trigger.hover();
     const tooltip = page.getByText(TOOLTIP_LINE);
-    await expect(tooltip).toBeVisible({ timeout: 12_000 });
+    await expect(tooltip).toBeVisible({ timeout: 5_000 });
 
     // Hover-leave: move the pointer off the trigger.
     await page.mouse.move(0, 0);
 
-    // Still visible shortly after leaving (close delay is 3s).
-    await page.waitForTimeout(1_000);
+    // Still visible well within the close-delay window (the contract: it does
+    // NOT close immediately on leave).
+    await page.waitForTimeout(Math.round(TEST_CLOSE_DELAY_MS / 3));
     await expect(tooltip).toBeVisible();
 
     // Gone once the close delay elapses.
-    await expect(tooltip).toBeHidden({ timeout: 6_000 });
+    await expect(tooltip).toBeHidden({ timeout: TEST_CLOSE_DELAY_MS + 3_000 });
   });
 });

--- a/packages/ui-alquicarros/app/components/CategoryCard.vue
+++ b/packages/ui-alquicarros/app/components/CategoryCard.vue
@@ -674,11 +674,12 @@ const {
 
 const { modelos, grupo } = props.vehicleCategory;
 
-// Test-only knob: with ?e2eTooltipDelays=1 the open/close delays shrink so the
-// tooltip open/close contract can be exercised deterministically in e2e (Reka's
-// 3s hover-intent open is too flaky to drive headless). Production behaviour is
-// unchanged — without the flag both stay at 3000ms.
-const tooltipFastDelays = useRoute().query.e2eTooltipDelays === '1';
+// Test-only knob: in dev, ?e2eTooltipDelays=1 shrinks the open/close delays so
+// the tooltip contract can be driven deterministically in e2e (Reka's 3s
+// hover-intent open is too flaky headless). Gated on import.meta.dev so it is
+// tree-shaken out of production builds — in prod the query param has no effect
+// and both delays stay at 3000ms.
+const tooltipFastDelays = import.meta.dev && useRoute().query.e2eTooltipDelays === '1';
 const tooltipOpenDelayMs = tooltipFastDelays ? 50 : 3000;
 const tooltipCloseDelayMs = tooltipFastDelays ? 600 : 3000;
 const {

--- a/packages/ui-alquicarros/app/components/CategoryCard.vue
+++ b/packages/ui-alquicarros/app/components/CategoryCard.vue
@@ -81,7 +81,7 @@
             Total {{ haveMonthlyReservation ? "30 días" : getFormattedDays }}
           </p>
 
-          <UTooltip :open="totalPriceTooltipOpen" :delay-duration="3000" :content="{ onEscapeKeyDown: forceTotalPriceTooltipClose, onPointerDownOutside: forceTotalPriceTooltipClose }" :ui="{content: 'h-full select-text bg-white text-gray-900 shadow-lg border border-gray-200'}" @update:open="onTotalPriceTooltipOpenChange">
+          <UTooltip :open="totalPriceTooltipOpen" :delay-duration="tooltipOpenDelayMs" :content="{ onEscapeKeyDown: forceTotalPriceTooltipClose, onPointerDownOutside: forceTotalPriceTooltipClose }" :ui="{content: 'h-full select-text bg-white text-gray-900 shadow-lg border border-gray-200'}" @update:open="onTotalPriceTooltipOpenChange">
             <template #content>
               Día: $ {{ dayPriceTooltip }} <br />
               Seguro día: $ {{ coverageDayPriceTooltip }} <br />
@@ -674,11 +674,18 @@ const {
 
 const { modelos, grupo } = props.vehicleCategory;
 
+// Test-only knob: with ?e2eTooltipDelays=1 the open/close delays shrink so the
+// tooltip open/close contract can be exercised deterministically in e2e (Reka's
+// 3s hover-intent open is too flaky to drive headless). Production behaviour is
+// unchanged — without the flag both stay at 3000ms.
+const tooltipFastDelays = useRoute().query.e2eTooltipDelays === '1';
+const tooltipOpenDelayMs = tooltipFastDelays ? 50 : 3000;
+const tooltipCloseDelayMs = tooltipFastDelays ? 600 : 3000;
 const {
   open: totalPriceTooltipOpen,
   onOpenChange: onTotalPriceTooltipOpenChange,
   forceClose: forceTotalPriceTooltipClose,
-} = useDelayedClose(3000);
+} = useDelayedClose(tooltipCloseDelayMs);
 
 /** Product Schema for SEO */
 useProductSchema({

--- a/packages/ui-alquilame/app/components/CategoryCard.vue
+++ b/packages/ui-alquilame/app/components/CategoryCard.vue
@@ -674,11 +674,12 @@ const {
 
 const { modelos, grupo } = props.vehicleCategory;
 
-// Test-only knob: with ?e2eTooltipDelays=1 the open/close delays shrink so the
-// tooltip open/close contract can be exercised deterministically in e2e (Reka's
-// 3s hover-intent open is too flaky to drive headless). Production behaviour is
-// unchanged — without the flag both stay at 3000ms.
-const tooltipFastDelays = useRoute().query.e2eTooltipDelays === '1';
+// Test-only knob: in dev, ?e2eTooltipDelays=1 shrinks the open/close delays so
+// the tooltip contract can be driven deterministically in e2e (Reka's 3s
+// hover-intent open is too flaky headless). Gated on import.meta.dev so it is
+// tree-shaken out of production builds — in prod the query param has no effect
+// and both delays stay at 3000ms.
+const tooltipFastDelays = import.meta.dev && useRoute().query.e2eTooltipDelays === '1';
 const tooltipOpenDelayMs = tooltipFastDelays ? 50 : 3000;
 const tooltipCloseDelayMs = tooltipFastDelays ? 600 : 3000;
 const {

--- a/packages/ui-alquilame/app/components/CategoryCard.vue
+++ b/packages/ui-alquilame/app/components/CategoryCard.vue
@@ -81,7 +81,7 @@
             Total {{ haveMonthlyReservation ? "30 días" : getFormattedDays }}
           </p>
 
-          <UTooltip :open="totalPriceTooltipOpen" :delay-duration="3000" :content="{ onEscapeKeyDown: forceTotalPriceTooltipClose, onPointerDownOutside: forceTotalPriceTooltipClose }" :ui="{content: 'h-full select-text bg-white text-gray-900 shadow-lg border border-gray-200'}" @update:open="onTotalPriceTooltipOpenChange">
+          <UTooltip :open="totalPriceTooltipOpen" :delay-duration="tooltipOpenDelayMs" :content="{ onEscapeKeyDown: forceTotalPriceTooltipClose, onPointerDownOutside: forceTotalPriceTooltipClose }" :ui="{content: 'h-full select-text bg-white text-gray-900 shadow-lg border border-gray-200'}" @update:open="onTotalPriceTooltipOpenChange">
             <template #content>
               Día: $ {{ dayPriceTooltip }} <br />
               Seguro día: $ {{ coverageDayPriceTooltip }} <br />
@@ -674,11 +674,18 @@ const {
 
 const { modelos, grupo } = props.vehicleCategory;
 
+// Test-only knob: with ?e2eTooltipDelays=1 the open/close delays shrink so the
+// tooltip open/close contract can be exercised deterministically in e2e (Reka's
+// 3s hover-intent open is too flaky to drive headless). Production behaviour is
+// unchanged — without the flag both stay at 3000ms.
+const tooltipFastDelays = useRoute().query.e2eTooltipDelays === '1';
+const tooltipOpenDelayMs = tooltipFastDelays ? 50 : 3000;
+const tooltipCloseDelayMs = tooltipFastDelays ? 600 : 3000;
 const {
   open: totalPriceTooltipOpen,
   onOpenChange: onTotalPriceTooltipOpenChange,
   forceClose: forceTotalPriceTooltipClose,
-} = useDelayedClose(3000);
+} = useDelayedClose(tooltipCloseDelayMs);
 
 /** Product Schema for SEO */
 useProductSchema({

--- a/packages/ui-alquilatucarro/app/components/CategoryCard.vue
+++ b/packages/ui-alquilatucarro/app/components/CategoryCard.vue
@@ -674,11 +674,12 @@ const {
 
 const { modelos, grupo } = props.vehicleCategory;
 
-// Test-only knob: with ?e2eTooltipDelays=1 the open/close delays shrink so the
-// tooltip open/close contract can be exercised deterministically in e2e (Reka's
-// 3s hover-intent open is too flaky to drive headless). Production behaviour is
-// unchanged — without the flag both stay at 3000ms.
-const tooltipFastDelays = useRoute().query.e2eTooltipDelays === '1';
+// Test-only knob: in dev, ?e2eTooltipDelays=1 shrinks the open/close delays so
+// the tooltip contract can be driven deterministically in e2e (Reka's 3s
+// hover-intent open is too flaky headless). Gated on import.meta.dev so it is
+// tree-shaken out of production builds — in prod the query param has no effect
+// and both delays stay at 3000ms.
+const tooltipFastDelays = import.meta.dev && useRoute().query.e2eTooltipDelays === '1';
 const tooltipOpenDelayMs = tooltipFastDelays ? 50 : 3000;
 const tooltipCloseDelayMs = tooltipFastDelays ? 600 : 3000;
 const {

--- a/packages/ui-alquilatucarro/app/components/CategoryCard.vue
+++ b/packages/ui-alquilatucarro/app/components/CategoryCard.vue
@@ -81,7 +81,7 @@
             Total {{ haveMonthlyReservation ? "30 días" : getFormattedDays }}
           </p>
 
-          <UTooltip :open="totalPriceTooltipOpen" :delay-duration="3000" :content="{ onEscapeKeyDown: forceTotalPriceTooltipClose, onPointerDownOutside: forceTotalPriceTooltipClose }" :ui="{content: 'h-full select-text bg-white text-gray-900 shadow-lg border border-gray-200'}" @update:open="onTotalPriceTooltipOpenChange">
+          <UTooltip :open="totalPriceTooltipOpen" :delay-duration="tooltipOpenDelayMs" :content="{ onEscapeKeyDown: forceTotalPriceTooltipClose, onPointerDownOutside: forceTotalPriceTooltipClose }" :ui="{content: 'h-full select-text bg-white text-gray-900 shadow-lg border border-gray-200'}" @update:open="onTotalPriceTooltipOpenChange">
             <template #content>
               Día: $ {{ dayPriceTooltip }} <br />
               Seguro día: $ {{ coverageDayPriceTooltip }} <br />
@@ -674,11 +674,18 @@ const {
 
 const { modelos, grupo } = props.vehicleCategory;
 
+// Test-only knob: with ?e2eTooltipDelays=1 the open/close delays shrink so the
+// tooltip open/close contract can be exercised deterministically in e2e (Reka's
+// 3s hover-intent open is too flaky to drive headless). Production behaviour is
+// unchanged — without the flag both stay at 3000ms.
+const tooltipFastDelays = useRoute().query.e2eTooltipDelays === '1';
+const tooltipOpenDelayMs = tooltipFastDelays ? 50 : 3000;
+const tooltipCloseDelayMs = tooltipFastDelays ? 600 : 3000;
 const {
   open: totalPriceTooltipOpen,
   onOpenChange: onTotalPriceTooltipOpenChange,
   forceClose: forceTotalPriceTooltipClose,
-} = useDelayedClose(3000);
+} = useDelayedClose(tooltipCloseDelayMs);
 
 /** Product Schema for SEO */
 useProductSchema({


### PR DESCRIPTION
> Apilado sobre #81 (#38) → #80 → #79 → #78. Base: `fix/issue-38-delayed-test-mount` (el e2e prueba el composable+wiring de #34/#36). GitHub re-apunta al mergear.

## Qué hace

E2E de integración del contrato close-delay del tooltip de precio en `CategoryCard`, **verde y determinístico**:
- **R1**: hover sobre el precio abre el tooltip.
- **R2**: al salir, el tooltip queda abierto durante el close-delay y luego desaparece (no cierra inmediato).

## Dos afordances que lo hacen correr

1. **Render** — el tooltip solo vive en card *disponible*. `/api/rentacar-data` (catálogo admin) es SSR pero **HTTP-fetchable** y carga de Supabase directo; el spec **descubre en runtime** un code real presente en catálogo + `vehicleCategories` y stubea solo el POST de availability (client-side). Sin hardcodear 'B' (el pitfall de SCEN-U4).
2. **Timing (knob test-only)** — el open por hover-intent de Reka (3s) era inestable headless. `CategoryCard` ahora honra `?e2eTooltipDelays=1`: open→50ms, close→600ms. **Sin el flag, ambos siguen en 3000ms (prod intacto).** Cambio en 3 `CategoryCard.vue`.

## Verificación

- `playwright test tooltip-price-close-delay --project=chromium --repeat-each=3` → **6 passed, 0 flaky** (antes del knob: R1 3/3 fallos, R2 flaky).
- `pnpm --filter ui-alquilatucarro typecheck` → 641 vs 640 baseline: **+1 = artefacto auto-import `useRoute` (#18)**, no error real (el build lo resuelve). Mis consts no suman errores.
- Suite logic → **242 passed** (knob es UI, sin efecto en logic).
- Contrato también cubierto a nivel unit (`useDelayedClose` S1–S7).

## Nota
El flag `?e2eTooltipDelays=1` es una afordance de test inocua (solo escala timings de animación; default prod intacto). Si prefieres no exponerlo vía query, se puede mover a `runtimeConfig.public` + env del webServer — dímelo y lo cambio.

Closes #37
