### PR TITLE
fix(logic): stop app composables leaking into server typecheck project

### DIFF
--- a/docs/specs/logic-buildmode-residual/scenarios/logic-buildmode-residual.scenarios.md
+++ b/docs/specs/logic-buildmode-residual/scenarios/logic-buildmode-residual.scenarios.md
@@ -1,0 +1,87 @@
+---
+name: logic-buildmode-residual
+created_by: claude
+created_at: 2026-06-01T00:00:00Z
+follows: issue-18-typecheck-autoimports
+---
+
+# Residual de build-mode multi-proyecto en `logic/src/{composables,stores}`
+
+## Contexto
+
+Tras el fix de #18 (`vue-tsc -b` build-mode), quedaban ~140 TS2304 en
+`logic/src/{composables,stores}` (`useAppConfig`/`useSchemaOrg`/`useRoute`/`navigateTo`/…).
+Causa raíz (vía `vue-tsc --explainFiles`): los proyectos **server/node** del solution build
+arrastran los composables/stores app — que usan auto-imports solo-app — y los typechequean en un
+contexto sin esos globals. Dos puentes:
+
+1. `app/app.config.ts` (las 3 marcas) importaba `{ defaultConfig, uiConfig, organizationConfig }`
+   del **barrel completo** `@rentacar-main/logic/src` (que hace `export *` de todos los
+   composables/stores). Nitro incluye `app.config` para sus tipos → el barrel entero entra al
+   proyecto server. Los 3 símbolos viven en la entrada estrecha `@rentacar-main/logic/config`.
+2. `utils/index.ts` re-exportaba `ReservationResumeProps`, cuyo tipo es
+   `ReturnType<typeof useCategory>` (import de valor del composable `useCategory`). Server jala el
+   barrel de utils → arrastra `useCategory` y su subgrafo. Solo `ReservationResume.vue` (app) usa
+   ese tipo.
+
+**Fix:** (1) `app.config.ts` importa desde `@rentacar-main/logic/config`; (2) sacar
+`ReservationResumeProps` del barrel de utils y que los `.vue` lo importen por ruta estrecha.
+
+Línea base (`ui-alquilatucarro`, post-#18): 613 errores TS; residual composables/stores = 140.
+
+## SCEN-001: El residual de auto-imports en composables/stores de logic desaparece
+
+**Given**: las 3 marcas con `app.config.ts` importando desde `@rentacar-main/logic/config` y
+`utils/index.ts` sin re-exportar `ReservationResumeProps`, tras `nuxt prepare`.
+**When**: se corre `pnpm --filter ui-<marca> typecheck` (build-mode) en cada marca.
+**Then**: el conteo de `error TS2304` en archivos `logic/src/composables/*` y `logic/src/stores/*`
+pasa de ~140 (alquilatucarro) a **0** en las **3 marcas**.
+**Evidence**: stdout de typecheck — `grep 'error TS2304' | grep -E 'logic/src/(composables|stores)' | wc -l` == 0.
+
+## SCEN-002: No se regresan los auto-imports ya arreglados en #18
+
+**Given**: el mismo estado.
+**When**: se corre el typecheck.
+**Then**: la clase de auto-imports de #18 sigue en 0 — Vue reactivity
+(`ref|computed|watch|reactive|nextTick|onMounted`) == 0 y handlers de servidor
+(`defineEventHandler|sendRedirect|createError`) == 0 en las 3 marcas.
+**Evidence**: stdout de typecheck — ambos greps == 0.
+
+## SCEN-003: `app.config` no cambia de comportamiento
+
+**Given**: `app.config.ts` ahora importa de `@rentacar-main/logic/config`, que exporta los mismos
+`defaultConfig`, `uiConfig`, `organizationConfig` que antes venían vía el barrel.
+**When**: se corre `nuxt prepare` en cada marca.
+**Then**: prepare termina exit 0 y genera los tipos de app.config sin error; las 3 claves
+(`defaultTimezone`, `ui`, `organization`) siguen resolviéndose (mismo origen `src/config/*`).
+**Evidence**: exit code de prepare + `app.config.ts` typechea sin TS2307/TS2305 sobre esos símbolos.
+
+## SCEN-004: `ReservationResume.vue` sigue tipando su prop
+
+**Given**: las 3 `ReservationResume.vue` importan `ReservationResumeProps` por ruta estrecha
+`@rentacar-main/logic/utils/types/props/ReservationResumeProps`.
+**When**: se corre el typecheck.
+**Then**: `defineProps<ReservationResumeProps>()` resuelve sin nuevos TS2304/TS2305/TS2307 en esos
+componentes (el tipo sigue siendo `ReturnType<typeof useCategory>`, ahora en contexto app donde
+useCategory resuelve).
+**Evidence**: stdout de typecheck — 0 errores nuevos en `app/components/ReservationResume.vue`.
+
+## SCEN-005: Sin regresión en la suite de logic
+
+**Given**: el fix aplicado.
+**When**: `pnpm --filter @rentacar-main/logic test run`.
+**Then**: todos los archivos de test pasan (≥ 256 tests, los del baseline + el guard nuevo).
+**Evidence**: stdout de vitest — `Test Files N passed`, `Tests M passed`, 0 failed.
+
+## Non-goals
+
+- Errores de tipo reales pre-existentes (baseline drift, ~449): `typecheck` sigue exit 1 por
+  ellos. Fuera de alcance.
+- Los `import type { BlogPost } from '@rentacar-main/logic/src'` en páginas blog: type-only, viven
+  solo en el proyecto app (resuelven), no aportan al residual. Se dejan.
+
+## Anti-reward-hacking
+
+La aserción central (SCEN-001) mide **eliminación a 0** del residual de composables/stores, no
+"menos errores". SCEN-002 garantiza que no se logra moviendo el problema (no se rompe #18). Los
+errores reales del baseline se declaran Non-goal, no se ocultan.

--- a/packages/logic/src/__tests__/logic-buildmode-residual.test.ts
+++ b/packages/logic/src/__tests__/logic-buildmode-residual.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Regression guard for the build-mode multi-project residual (follows issue #18).
+ *
+ * In `vue-tsc -b`, the server/node projects pull in whatever the app's
+ * `app.config.ts` imports (Nitro needs app.config types). Two leaks dragged the
+ * app composables/stores — which use app-only auto-imports — into that context,
+ * producing TS2304:
+ *   1. app.config.ts importing the full barrel `@rentacar-main/logic/src`
+ *      (`export *` of every composable/store) instead of the narrow `/config`.
+ *   2. utils/index.ts re-exporting `ReservationResumeProps`, whose type is
+ *      `ReturnType<typeof useCategory>` — a value import of the useCategory
+ *      composable that the utils barrel then drags everywhere.
+ *
+ * These assertions lock both fixes so the leak cannot silently return.
+ */
+
+const BRANDS = ['ui-alquilatucarro', 'ui-alquilame', 'ui-alquicarros'] as const;
+
+function readRepoFile(relFromPackages: string): string {
+  const url = new URL(`../../../${relFromPackages}`, import.meta.url);
+  return readFileSync(fileURLToPath(url), 'utf8');
+}
+
+describe('logic build-mode residual: shared config stays composable-free', () => {
+  for (const brand of BRANDS) {
+    it(`${brand}/app.config.ts imports shared config from the narrow /config entry`, () => {
+      const src = readRepoFile(`${brand}/app/app.config.ts`);
+      // Must use the composable-free entry...
+      expect(src).toContain("from '@rentacar-main/logic/config'");
+      // ...and must NOT pull the full barrel, which re-exports every composable
+      // and store and leaks them into the server/node typecheck projects.
+      expect(src).not.toMatch(/from\s+['"]@rentacar-main\/logic\/src['"]/);
+    });
+  }
+
+  it('utils/index.ts does not re-export ReservationResumeProps (composable bridge)', () => {
+    const src = readRepoFile('logic/src/utils/index.ts');
+    expect(src).not.toMatch(/export\b.*ReservationResumeProps/);
+  });
+});

--- a/packages/logic/src/utils/index.ts
+++ b/packages/logic/src/utils/index.ts
@@ -58,7 +58,11 @@ export type { default as FormSubmitFields } from './types/fields/FormSubmitField
 // Type Definitions - Props
 // ============================================================================
 export type { default as CategoryProps } from './types/props/CategoryProps';
-export type { default as ReservationResumeProps } from './types/props/ReservationResumeProps';
+// ReservationResumeProps NO se re-exporta desde el barrel a propósito: deriva su
+// tipo de `ReturnType<typeof useCategory>`, así que re-exportarlo aquí arrastra el
+// composable useCategory (y su subgrafo) a cualquier proyecto que importe el barrel
+// de utils — incluido el proyecto server/node en `vue-tsc -b`, donde los globals de
+// auto-import app no existen (TS2304). Se importa por ruta estrecha desde su .vue.
 
 // ============================================================================
 // Type Definitions - General Types

--- a/packages/ui-alquicarros/app/app.config.ts
+++ b/packages/ui-alquicarros/app/app.config.ts
@@ -8,7 +8,7 @@ import {
   defaultConfig,
   uiConfig,
   organizationConfig,
-} from '@rentacar-main/logic/src'
+} from '@rentacar-main/logic/config'
 
 export default defineAppConfig({
   // Shared default timezone

--- a/packages/ui-alquicarros/app/components/ReservationResume.vue
+++ b/packages/ui-alquicarros/app/components/ReservationResume.vue
@@ -133,7 +133,7 @@ import { defineAsyncComponent } from 'vue'
 const Carrusel = defineAsyncComponent(() => import('./Carrusel.vue'))
 
 /** types */
-import type { ReservationResumeProps } from '@rentacar-main/logic/utils';
+import type ReservationResumeProps from '@rentacar-main/logic/utils/types/props/ReservationResumeProps';
 
 /** props */
 const props = defineProps<ReservationResumeProps>();

--- a/packages/ui-alquilame/app/app.config.ts
+++ b/packages/ui-alquilame/app/app.config.ts
@@ -8,7 +8,7 @@ import {
   defaultConfig,
   uiConfig,
   organizationConfig,
-} from '@rentacar-main/logic/src'
+} from '@rentacar-main/logic/config'
 
 export default defineAppConfig({
   // Shared default timezone

--- a/packages/ui-alquilame/app/components/ReservationResume.vue
+++ b/packages/ui-alquilame/app/components/ReservationResume.vue
@@ -133,7 +133,7 @@ import { defineAsyncComponent } from 'vue'
 const Carrusel = defineAsyncComponent(() => import('./Carrusel.vue'))
 
 /** types */
-import type { ReservationResumeProps } from '@rentacar-main/logic/utils';
+import type ReservationResumeProps from '@rentacar-main/logic/utils/types/props/ReservationResumeProps';
 
 /** props */
 const props = defineProps<ReservationResumeProps>();

--- a/packages/ui-alquilatucarro/app/app.config.ts
+++ b/packages/ui-alquilatucarro/app/app.config.ts
@@ -8,7 +8,7 @@ import {
   defaultConfig,
   uiConfig,
   organizationConfig,
-} from '@rentacar-main/logic/src'
+} from '@rentacar-main/logic/config'
 
 export default defineAppConfig({
   // Shared default timezone

--- a/packages/ui-alquilatucarro/app/components/ReservationResume.vue
+++ b/packages/ui-alquilatucarro/app/components/ReservationResume.vue
@@ -133,7 +133,7 @@ import { defineAsyncComponent } from 'vue'
 const Carrusel = defineAsyncComponent(() => import('./Carrusel.vue'))
 
 /** types */
-import type { ReservationResumeProps } from '@rentacar-main/logic/utils';
+import type ReservationResumeProps from '@rentacar-main/logic/utils/types/props/ReservationResumeProps';
 
 /** props */
 const props = defineProps<ReservationResumeProps>();


### PR DESCRIPTION
**Sigue a #18.** Tras mover el typecheck de marca a `vue-tsc -b` (build-mode), quedaban ~140 `TS2304` en `logic/src/{composables,stores}` (`useAppConfig`, `useRoute`, `navigateTo`, …) que no rompen runtime pero ensucian `pnpm typecheck`.

**Causa raíz** (`vue-tsc --explainFiles`): los proyectos **server/node** del solution build arrastran lo que importa `app/app.config.ts` (Nitro incluye `app.config` para sus tipos). Dos puentes metían los composables/stores app —que usan auto-imports solo-app— a ese contexto:

1. `app/app.config.ts` (las 3 marcas) importaba `{ defaultConfig, uiConfig, organizationConfig }` del **barrel completo** `@rentacar-main/logic/src`, que hace `export *` de todos los composables y stores.
2. `utils/index.ts` re-exportaba `ReservationResumeProps`, cuyo tipo es `ReturnType<typeof useCategory>` (import de **valor** del composable `useCategory`). El barrel de utils lo propagaba a todo consumidor.

**Cambio:**
- `app.config.ts` → importa de la entrada estrecha `@rentacar-main/logic/config` (mismos 3 símbolos, sin composables).
- `ReservationResumeProps` fuera del barrel de `utils/index.ts`; las 3 `ReservationResume.vue` (único consumidor) lo importan por ruta estrecha `@rentacar-main/logic/utils/types/props/ReservationResumeProps`.
- Guard de regresión en `logic` que fija ambos imports.

**Resultado** (residual de composables/stores TS2304):

| Marca | Total TS | residual composables/stores | #18 vue / server |
|---|---|---|---|
| alquilatucarro | 454 | 0 | 0 / 0 |
| alquilame | 341 | 0 | 0 / 0 |
| alquicarros | 330 | 0 | 0 / 0 |

**Fuera de alcance** (documentado en `docs/specs/logic-buildmode-residual/scenarios/`): los ~449 errores de tipo reales pre-existentes (baseline drift) — `typecheck` sigue exit 1 por ellos.

**Verificación:**
- `pnpm typecheck` (3 marcas): residual composables/stores = 0; auto-imports de #18 = 0
- `pnpm --filter @rentacar-main/logic test run` → 41 files, 260/260 pass
- `nuxt prepare` exit 0 en las 3 marcas; sin cambios de runtime en `app.config`
