### PR TITLE
fix(logic): drop invalid @nuxt/ui v4 header slot poisoning app.config types (baseline cluster A)

### DIFF
--- a/docs/specs/cluster-a-appconfig-typing/scenarios/cluster-a-appconfig-typing.scenarios.md
+++ b/docs/specs/cluster-a-appconfig-typing/scenarios/cluster-a-appconfig-typing.scenarios.md
@@ -1,0 +1,81 @@
+---
+name: cluster-a-appconfig-typing
+created_by: claude
+created_at: 2026-06-01T00:00:00Z
+follows: logic-buildmode-residual
+---
+
+# Cluster A — tipar app.config (franchise/organization/reservation)
+
+## Contexto
+
+Primer cluster del baseline de errores de tipo reales. En `ui-alquilatucarro`, 96 accesos a
+`franchise`/`organization`/`reservation` eran TS18046 (`is of type 'unknown'`) en composables SEO
+compartidos (`useBaseSEO`, `useAggregateRating`, `useLocalBusiness`…) y páginas/componentes de marca.
+
+Causa raíz (probada con un probe `const x: null = useAppConfig().franchise` y con `vue-tsc`): el
+`uiConfig` compartido (`logic/src/config/ui.config.ts`) definía `header.slots.close`, un slot que
+**no existe** en @nuxt/ui v4 (Header expone root/container/left/center/right/.../body). Eso hacía a
+`uiConfig` no asignable a `AppConfigUI`, violando el constraint `C extends AppConfigInput` de
+`defineAppConfig`. Ante la violación, TS colapsa `C` al constraint (índice `[key: string]: unknown`),
+así que TODO el app.config — incluidos franchise/organization/reservation — quedaba `unknown`.
+
+El override era además un no-op en runtime (el slot no existe → @nuxt/ui lo ignora).
+
+**Fix:** eliminar el bloque `header` inválido de `uiConfig`. Restaura la inferencia del app.config
+completo. Cambio cero-visual.
+
+Línea base (`ui-alquilatucarro`): 454 errores TS.
+
+## SCEN-001: franchise/organization/reservation dejan de ser `unknown`
+
+**Given**: `uiConfig` sin el slot inválido `header.close`, tras `nuxt prepare`.
+**When**: `pnpm --filter ui-<marca> typecheck` en las 3 marcas.
+**Then**: el conteo de `error TS18046: '<x>' is of type 'unknown'` para `x ∈ {franchise,
+organization, reservation}` pasa a **0** en las 3 marcas (era 96 en alquilatucarro).
+**Evidence**: stdout typecheck — `grep -E "'(franchise|organization|reservation)' is of type 'unknown'" | wc -l` == 0.
+
+## SCEN-002: el TS2322 de `ui` en app.config desaparece
+
+**Given**: el mismo estado.
+**When**: typecheck.
+**Then**: `app/app.config.ts ... error TS2322 ... not assignable to type 'AppConfigUI'` ya no aparece
+en ninguna marca (0).
+**Evidence**: stdout — `grep -c 'app.config.ts.*error TS2322'` == 0.
+
+## SCEN-003: sin regresión de #18 ni del residual de capa
+
+**Given**: el fix.
+**When**: typecheck.
+**Then**: auto-imports Vue (`ref|computed|watch|reactive|nextTick|onMounted`) == 0, handlers de
+servidor (`defineEventHandler|sendRedirect|createError`) == 0, y residual composables/stores
+(`logic/src/(composables|stores)` TS2304) == 0, en las 3 marcas. El total por marca baja respecto a
+su baseline (~-108 en alquilatucarro).
+**Evidence**: stdout typecheck — los tres greps == 0; total < baseline.
+
+## SCEN-004: sin regresión visual del header
+
+**Given**: `header.slots.close` era un no-op en runtime (slot inexistente en @nuxt/ui v4).
+**When**: se carga la home en navegador (agent-browser) y se abre el menú/header en viewport móvil.
+**Then**: el header y su botón de cierre se ven y funcionan igual que antes del cambio; 0 errores de
+consola, 0 requests fallidos.
+**Evidence**: screenshot del header (desktop + móvil) + consola limpia vía agent-browser.
+
+## SCEN-005: sin regresión en la suite de logic
+
+**Given**: el fix.
+**When**: `pnpm --filter @rentacar-main/logic test run`.
+**Then**: todos los tests pasan (≥ 260).
+**Evidence**: stdout vitest — `Test Files N passed`, 0 failed.
+
+## Non-goals
+
+- Otros clusters del baseline: páginas SEO con data `{}` (TS2339), fixtures de tests, blog
+  (`related`/`p` unknown). `typecheck` sigue exit 1 por ellos.
+- Re-implementar el estilo del botón de cierre del header bajo un slot v4 válido (era no-op; si se
+  desea, es enhancement aparte).
+
+## Anti-reward-hacking
+
+SCEN-001/002 miden eliminación a 0 de una clase concreta (no "menos errores"). SCEN-003 evita
+moverlo rompiendo trabajo previo. SCEN-004 exige verificación visual real (no asumir "no-op").

--- a/packages/logic/src/config/ui.config.ts
+++ b/packages/logic/src/config/ui.config.ts
@@ -2,17 +2,21 @@
  * UI component configuration shared across all brands
  * Defines slots and variants for Nuxt UI components
  */
+import type { AppConfigInput } from '@nuxt/schema'
+
 export const uiConfig = {
   slideover: {
     slots: {
       close: 'absolute top-4 end-4 bg-black text-white rounded-full hover:bg-gray-700',
     },
   },
-  header: {
-    slots: {
-      close: 'bg-black text-white rounded-full hover:bg-gray-700',
-    },
-  },
+  // Nota: NO hay override de `header` aquí. @nuxt/ui v4 Header no expone un slot
+  // `close` (sus slots son root/container/left/center/right/.../body), así que el
+  // antiguo `header.slots.close` no se aplicaba en runtime y, peor, hacía que
+  // `uiConfig` no fuera asignable a AppConfigUI → el constraint de defineAppConfig
+  // se violaba y TS colapsaba TODO el app.config a `unknown` (franchise,
+  // organization, reservation), generando ~115 TS18046 en composables SEO y
+  // páginas de marca. Quitarlo restaura la inferencia del app.config completo.
   pageSection: {
     slots: {
       container:
@@ -48,4 +52,4 @@ export const uiConfig = {
       label: "font-normal text-sm",
     },
   },
-} as const;
+} as const satisfies AppConfigInput['ui'];


### PR DESCRIPTION
**Baseline de errores de tipo — Cluster A: tipar `app.config`.**

Primer cluster del baseline drift. En las 3 marcas, ~96 accesos a `useAppConfig().{franchise,organization,reservation}` daban `TS18046: 'x' is of type 'unknown'` en composables SEO compartidos (`useBaseSEO`, `useAggregateRating`, `useLocalBusiness`…) y páginas/componentes de marca.

**Causa raíz** (probada con un probe `const x: null = useAppConfig().franchise` + `vue-tsc`): el `uiConfig` compartido (`logic/src/config/ui.config.ts`) definía `header.slots.close`, pero el componente `Header` de @nuxt/ui v4 **no tiene** un slot `close` (sus slots son `root/container/left/center/right/.../body`). Eso hacía a `uiConfig` no asignable a `AppConfigUI`, violando el constraint `C extends AppConfigInput` de `defineAppConfig`. Ante la violación, TS colapsa `C` al constraint (índice `[key: string]: unknown`), dejando **todo** el app.config en `unknown`. El override era además un no-op en runtime (el slot no existe; el botón de cierre del menú móvil es un `<UButton>` manual en `#body`, con su propia clase).

**Cambio** (`logic/src/config/ui.config.ts`):
- Quitar el bloque `header` inválido.
- Añadir `satisfies AppConfigInput['ui']` a `uiConfig`: guard de regresión que hace fallar **ruidoso** (TS2353) cualquier slot inválido futuro, en vez de re-colapsar la inferencia en silencio. Verificado red-green.

**Resultado** (errores TS por marca):

| Marca | Antes | Después |
|---|---|---|
| alquilatucarro | 454 | 346 |
| alquilame | 341 | 201 |
| alquicarros | 330 | 201 |

`franchise`/`organization`/`reservation` unknown → **0** en las 3; `ui` TS2322 → **0**.

**Sin regresión:** auto-imports de #18 (Vue/servidor) = 0, residual de capa = 0, `pnpm --filter @rentacar-main/logic test run` → 41 files, 260/260. **QA visual** (agent-browser): home 200, header renderiza, 0 errores de consola.

**Fuera de alcance** (ver `docs/specs/cluster-a-appconfig-typing/scenarios/`): otros clusters del baseline (páginas SEO con data `{}` → TS2339, fixtures de tests, blog). `pnpm typecheck` sigue exit 1 por ellos.
