### PR TITLE
feat(logic): Ola A — disponibilidad mensual derivada del pricing (#28)

### DIFF
--- a/docs/specs/issue-28-ola-a-monthly-availability/scenarios/monthly-availability.scenarios.md
+++ b/docs/specs/issue-28-ola-a-monthly-availability/scenarios/monthly-availability.scenarios.md
@@ -99,6 +99,26 @@ para mostrar el precio, así nunca se ofrece un mensual a $0.
 **Evidence**: dos corridas; `categoriesAvailabilityData.map(c=>c.categoryCode)`
 incluye `'SX'` para 2026-03-15 y lo excluye para 2026-08-15.
 
+## SCEN-A08: fecha fuera de todos los rangos no excluye por una fila $0 de fallback
+
+(Añadido tras revisión adversarial — code-reviewer + edge-case-detector hallaron
+independientemente este hueco de dinero. Fortalece el holdout, no debilita ningún
+SCEN previo.)
+
+**Given**: una categoría `SX` con dos rows de pricing **activos**: rango A
+(`valid_from` 2026-01-01 … `valid_until` 2026-06-30) con `1k_kms = 900000`; rango B
+(`valid_from` 2026-07-01 … `valid_until` 2026-12-31) con `1k_kms = 0` y `2k_kms = 0`.
+La fecha de recogida (p.ej. 2030-01-01) cae **fuera de todos los rangos activos**.
+Reserva mensual.
+**When**: se ejecuta `search()`.
+**Then**: `SX` **sí** se ofrece. Como ningún row activo contiene la fecha, la
+decisión no puede confiar en la fila que un fallback elegiría por "más barata"
+(la de $0): cae a "¿algún row activo tiene mensual positivo?" → el rango A lo
+tiene → se ofrece. Excluirla sería perder un mensual real por un artefacto de
+selección de fecha fuera de rango.
+**Evidence**: `categoryOffersMonthly([rangoA_900k, rangoB_0], '2030-01-01')` → `true`;
+y la categoría aparece en `categoriesAvailabilityData` para una fecha fuera de rango.
+
 ## SCEN-A07: sin fecha resoluble, no se excluye una categoría con mensual real
 
 **Given**: una categoría `C` con pricing mensual activo positivo, pero la fecha de

--- a/docs/specs/issue-28-ola-a-monthly-availability/scenarios/monthly-availability.scenarios.md
+++ b/docs/specs/issue-28-ola-a-monthly-availability/scenarios/monthly-availability.scenarios.md
@@ -1,0 +1,121 @@
+---
+name: monthly-availability
+created_by: pabloandi
+created_at: 2026-06-02T16:00:00Z
+issue: 28
+ola: A
+---
+
+# Ola A — Disponibilidad mensual derivada del pricing (issue #28)
+
+Contexto: hoy `useStoreSearchData.ts` decide qué categorías se ofrecen en
+reserva mensual con un array hardcoded `noMonthlyCategories = ['FU','FL','GL','LU']`.
+El dashboard ya modela "no acepta mensual" como `category_pricing.monthly_*_price = NULL`
+(mig. 042), que el transformer expone como `month_prices[].{1k_kms,2k_kms} = 0`.
+Ola A reemplaza el array por una derivación del payload: una categoría **ofrece
+mensual** cuando el row de pricing aplicable a la fecha de recogida tiene al menos
+un precio mensual por kilometraje positivo.
+
+Observable de todos los escenarios: la **lista de `categoryCode`** que aparece en
+`useStoreSearchData` (`categoriesAvailabilityData` tras `search()`, o el computed
+`categories` en el camino LLNRAG009). El "usuario" es el cliente que arma una
+reserva y ve —o no ve— tarjetas de categoría.
+
+Regla anti-reward-hacking para esta ola: ningún identificador del código de
+producción puede contener la lista `['FU','FL','GL','LU']`. Si el comportamiento
+se logra volviendo a hardcodear esos códigos, la ola NO está satisfecha aunque los
+tests pasen. La señal debe venir del dato (`month_prices`), no del código.
+
+---
+
+## SCEN-A01: reserva mensual oculta las categorías sin precio mensual
+
+**Given**: payload admin con 3 categorías — `C` y `LE` con un row de pricing
+activo cuyo `1k_kms = 900000` y `2k_kms = 1200000`; `FU` con un row de pricing
+activo cuyo `1k_kms = 0` y `2k_kms = 0` (como deja la mig. 042 para las gamas no
+mensuales). El cliente eligió reserva mensual (`haveMonthlyReservation = true`) con
+fecha de recogida dentro del rango de validez de esos rows.
+**When**: se ejecuta `search()` con respuesta de disponibilidad vacía sin error.
+**Then**: `categoriesAvailabilityData` contiene `C` y `LE`; **no** contiene `FU`.
+**Evidence**: `searchStore.categoriesAvailabilityData.map(c => c.categoryCode)` →
+incluye `'C'` y `'LE'`, excluye `'FU'`.
+
+## SCEN-A02: el camino no-mensual pasa el payload sin tocar
+
+**Given**: el cliente NO eligió mensual (`haveMonthlyReservation = false`); la
+disponibilidad devuelve `['C','FU','LU']` en ese orden.
+**When**: se ejecuta `search()`.
+**Then**: `categoriesAvailabilityData` refleja exactamente `['C','FU','LU']` — la
+derivación mensual no aplica al flujo diario.
+**Evidence**: `searchStore.categoriesAvailabilityData.map(c => c.categoryCode)`
+es estrictamente igual a `['C','FU','LU']`.
+
+## SCEN-A03: derivación por dato, no por pertenencia a una lista
+
+**Given**: payload admin con una categoría **nueva** `ZZ` (un código que nunca
+estuvo en el array legacy `['FU','FL','GL','LU']`) cuyo único row de pricing activo
+tiene `1k_kms = 0` y `2k_kms = 0`, más `C` con pricing mensual positivo. Reserva
+mensual, fecha dentro del rango.
+**When**: se ejecuta `search()`.
+**Then**: `ZZ` queda **excluida** del mensual sin que su código aparezca en ningún
+literal del código de producción — prueba que la decisión vino del pricing en cero,
+no de una lista. `C` aparece.
+**Evidence**: `categoriesAvailabilityData.map(c => c.categoryCode)` excluye `'ZZ'`,
+incluye `'C'`; y `grep -r "'FU'.*'FL'.*'GL'.*'LU'" packages/logic/src` no encuentra
+un array de exclusión mensual en producción.
+
+## SCEN-A04: LLNRAG009 en mensual no muestra como "no disponible" las categorías sin mensual
+
+**Given**: reserva mensual; la disponibilidad falla con
+`no_available_categories_error` (LLNRAG009). Payload admin con `B` y `C` (pricing
+mensual positivo) y `FU` (pricing mensual en cero).
+**When**: se ejecuta `search()` y se lee el computed `categories`.
+**Then**: las tarjetas "no disponible" (`estimatedTotalAmount === 999999999`) son
+solo `B` y `C`; `FU` no aparece (preserva issue #54, ahora derivado del dato).
+**Evidence**: `searchStore.categories.map(c => c.categoryCode).sort()` es
+`['B','C']` y todas tienen `estimatedTotalAmount === 999999999`.
+
+## SCEN-A05: LLNRAG009 en no-mensual sigue mostrando todas las categorías
+
+**Given**: reserva NO mensual; LLNRAG009. Mismo payload (`B`, `C`, `FU`).
+**When**: se ejecuta `search()` y se lee `categories`.
+**Then**: aparecen las tres como "no disponible" — el flujo diario nunca filtra por
+mensual (guarda de regresión de issue #54).
+**Evidence**: `searchStore.categories.map(c => c.categoryCode).sort()` es
+`['B','C','FU']`.
+
+## SCEN-A06: la disponibilidad mensual respeta la fecha de recogida
+
+**Given**: una categoría `SX` con dos rows de pricing activos: rango A
+(`valid_from` 2026-01-01 … `valid_until` 2026-06-30) con `1k_kms = 900000`; rango B
+(`valid_from` 2026-07-01 … `valid_until` 2026-12-31) con `1k_kms = 0` y `2k_kms = 0`
+(mensual discontinuado ese semestre). Reserva mensual.
+**When**: se ejecuta `search()` con fecha de recogida 2026-03-15, y en otra corrida
+con fecha 2026-08-15.
+**Then**: con recogida en marzo `SX` **aparece** (su row aplicable tiene mensual
+positivo); con recogida en agosto `SX` queda **excluida** (su row aplicable tiene
+mensual en cero). La decisión usa el mismo row que `pickPriceForDate` selecciona
+para mostrar el precio, así nunca se ofrece un mensual a $0.
+**Evidence**: dos corridas; `categoriesAvailabilityData.map(c=>c.categoryCode)`
+incluye `'SX'` para 2026-03-15 y lo excluye para 2026-08-15.
+
+## SCEN-A07: sin fecha resoluble, no se excluye una categoría con mensual real
+
+**Given**: una categoría `C` con pricing mensual activo positivo, pero la fecha de
+recogida está vacía/no resoluble por `pickPriceForDate` (devuelve `undefined`).
+Reserva mensual.
+**When**: se ejecuta `search()`.
+**Then**: `C` **sí** se ofrece — la red de seguridad cae a "¿algún row activo tiene
+mensual positivo?" para no excluir en masa por un dato de fecha ausente. Una
+categoría con todos los rows en cero (`FU`) sigue excluida en este mismo caso.
+**Evidence**: `categoriesAvailabilityData.map(c=>c.categoryCode)` incluye `'C'` y
+excluye `'FU'` cuando `pickPriceForDate` devuelve `undefined`.
+
+---
+
+## Fuera de alcance de Ola A (no fabricar estos escenarios aquí)
+
+- Restricciones geográficas (#3/#4/#5) — Ola C.
+- Pico y placa (#2) — Ola B.
+- Borrado de los arrays geográficos muertos — Ola D.
+- Invalidación de caché del payload (O3) — heredado.

--- a/packages/logic/src/stores/__tests__/useStoreSearchData.llnrag009MonthlyExclusion.test.ts
+++ b/packages/logic/src/stores/__tests__/useStoreSearchData.llnrag009MonthlyExclusion.test.ts
@@ -14,7 +14,21 @@ vi.mock('../../composables/useFetchCategoriesAvailabilityData', () => ({
   default: () => FETCH_AVAILABILITY(),
 }))
 
-const baseCategory = (id: string, name: string, category: string) => ({
+// Issue #28 Ola A: monthly exclusion is derived from pricing, so fixtures carry
+// realistic month_prices. An active row with positive 1k/2k offers monthly; a
+// row cleared to 0 (the mig. 042 shape) does not.
+const monthlyRow = (kms: number) => ({
+  '1k_kms': kms,
+  '2k_kms': kms,
+  '3k_kms': kms,
+  init_date: '2026-01-01',
+  end_date: '2026-12-31',
+  total_insurance_price: 0,
+  one_day_price: 0,
+  status: 'active' as const,
+})
+
+const baseCategory = (id: string, name: string, category: string, offersMonthly: boolean) => ({
   id,
   code: id,
   identification: id,
@@ -22,19 +36,20 @@ const baseCategory = (id: string, name: string, category: string) => ({
   name,
   category,
   models: [],
-  month_prices: {},
+  month_prices: [monthlyRow(offersMonthly ? 900000 : 0)],
   total_coverage_unit_charge: 0,
   image: '',
   ad: '',
   extra_km_charge: 0,
 })
 
-// Includes FU, a monthly-excluded code, alongside two regular ones.
+// B and C offer monthly; FU does not (cleared pricing) — the data-driven
+// equivalent of the old hardcoded exclusion.
 const ADMIN_PAYLOAD = {
   categories: [
-    baseCategory('B', 'Económico', 'BÁSICO B'),
-    baseCategory('C', 'Compacto', 'COMPACTO C'),
-    baseCategory('FU', 'Furgón', 'FURGÓN FU'),
+    baseCategory('B', 'Económico', 'BÁSICO B', true),
+    baseCategory('C', 'Compacto', 'COMPACTO C', true),
+    baseCategory('FU', 'Furgón', 'FURGÓN FU', false),
   ],
   branches: [],
   extras: undefined,

--- a/packages/logic/src/stores/__tests__/useStoreSearchData.monthlyCategoryExclusion.test.ts
+++ b/packages/logic/src/stores/__tests__/useStoreSearchData.monthlyCategoryExclusion.test.ts
@@ -2,14 +2,18 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { ref } from 'vue'
 
-// SCEN-A: monthly reservation (haveMonthlyReservation === true) must filter
-// out the categories listed in noMonthlyCategories before populating
-// categoriesAvailabilityData. Pre-fix the filter used `value in array` which
-// only matches numeric indices/`length`, never the category code, so all
-// categories leaked through.
+// Issue #28 Ola A: monthly availability is derived from each category's pricing
+// (month_prices), not a hardcoded code list. A category is offered monthly when
+// the pricing row applicable to the pickup date carries a positive 1k/2k monthly
+// price. The dashboard clears those to NULL (→ 0 in the payload) for the gamas
+// that don't offer monthly (FU/FL/GL/LU today, mig. 042).
 //
-// SCEN-B: non-monthly path is not affected — admin payload passes through
-// untouched so the search store reflects the availability response as-is.
+// SCEN-A01: monthly reservation hides categories whose applicable pricing has no
+//   positive monthly price; keeps the ones that do.
+// SCEN-A02: non-monthly path passes the availability payload through untouched.
+// SCEN-A03: the decision comes from the data, not list membership — a brand-new
+//   code with zero monthly pricing is excluded without any code change.
+// SCEN-A06: the decision respects the pickup date.
 
 const FETCH_AVAILABILITY = vi.fn()
 
@@ -17,7 +21,36 @@ vi.mock('../../composables/useFetchCategoriesAvailabilityData', () => ({
   default: () => FETCH_AVAILABILITY(),
 }))
 
-const makeAdminCategory = (code: string) => ({
+type Row = {
+  '1k_kms': number
+  '2k_kms': number
+  '3k_kms': number
+  init_date: string
+  end_date: string
+  total_insurance_price: number
+  one_day_price: number
+  status: 'active' | 'inactive'
+}
+
+// An active pricing row that offers monthly (positive 1k/2k).
+const monthlyPriced = (overrides: Partial<Row> = {}): Row => ({
+  '1k_kms': 900000,
+  '2k_kms': 1200000,
+  '3k_kms': 1500000,
+  init_date: '2026-01-01',
+  end_date: '2026-12-31',
+  total_insurance_price: 0,
+  one_day_price: 0,
+  status: 'active',
+  ...overrides,
+})
+
+// An active pricing row with monthly cleared (the mig. 042 shape for the gamas
+// that don't offer monthly).
+const noMonthly = (overrides: Partial<Row> = {}): Row =>
+  monthlyPriced({ '1k_kms': 0, '2k_kms': 0, '3k_kms': 0, ...overrides })
+
+const makeAdminCategory = (code: string, month_prices: Row[]) => ({
   id: code,
   code,
   identification: code,
@@ -25,13 +58,21 @@ const makeAdminCategory = (code: string) => ({
   name: code,
   category: `${code} Demo`,
   models: [],
-  month_prices: [],
+  month_prices,
   total_coverage_unit_charge: 0,
   extra_km_charge: 0,
 })
 
+// C, LE offer monthly; FU does not (cleared pricing). ZZ is a brand-new code,
+// never present in the legacy ['FU','FL','GL','LU'] list, also with cleared
+// monthly pricing — it must be excluded purely because of its data.
 const ADMIN_PAYLOAD = {
-  categories: ['C', 'FU', 'FL', 'GL', 'LU', 'LE'].map(makeAdminCategory),
+  categories: [
+    makeAdminCategory('C', [monthlyPriced()]),
+    makeAdminCategory('FU', [noMonthly()]),
+    makeAdminCategory('LE', [monthlyPriced()]),
+    makeAdminCategory('ZZ', [noMonthly()]),
+  ],
   branches: [
     { id: 1, code: 'AABOT', name: 'Bogotá Aeropuerto', city: 'bogota', slug: 'bogota-aeropuerto', schedule: '' },
   ],
@@ -41,7 +82,7 @@ const ADMIN_PAYLOAD = {
 
 const TOAST_ADD = vi.fn()
 
-describe('useStoreSearchData monthly category exclusion (SCEN-A)', () => {
+describe('useStoreSearchData monthly availability derived from pricing (Ola A)', () => {
   beforeEach(() => {
     TOAST_ADD.mockClear()
     FETCH_AVAILABILITY.mockReset()
@@ -54,7 +95,7 @@ describe('useStoreSearchData monthly category exclusion (SCEN-A)', () => {
     vi.unstubAllGlobals()
   })
 
-  it('SCEN-A: monthly reservation excludes FU, FL, GL, LU from categoriesAvailabilityData', async () => {
+  it('SCEN-A01: monthly reservation excludes categories without monthly pricing (FU), keeps priced ones (C, LE)', async () => {
     FETCH_AVAILABILITY.mockResolvedValue({
       data: ref([]),
       error: ref(null),
@@ -70,15 +111,61 @@ describe('useStoreSearchData monthly category exclusion (SCEN-A)', () => {
     await searchStore.search()
 
     const codes = (searchStore.categoriesAvailabilityData ?? []).map((c) => c.categoryCode)
-    expect(codes).not.toContain('FU')
-    expect(codes).not.toContain('FL')
-    expect(codes).not.toContain('GL')
-    expect(codes).not.toContain('LU')
     expect(codes).toContain('C')
     expect(codes).toContain('LE')
+    expect(codes).not.toContain('FU')
   })
 
-  it('SCEN-B: non-monthly path is unaffected — payload passes through', async () => {
+  it('SCEN-A03: a brand-new code with zero monthly pricing (ZZ) is excluded — derived from data, not a list', async () => {
+    FETCH_AVAILABILITY.mockResolvedValue({
+      data: ref([]),
+      error: ref(null),
+    })
+
+    const { default: useStoreReservationForm } = await import('../useStoreReservationForm')
+    useStoreReservationForm().haveMonthlyReservation = true
+
+    const { default: useStoreSearchData } = await import('../useStoreSearchData')
+    const searchStore = useStoreSearchData()
+
+    await searchStore.search()
+
+    const codes = (searchStore.categoriesAvailabilityData ?? []).map((c) => c.categoryCode)
+    expect(codes).not.toContain('ZZ')
+    expect(codes).toContain('C')
+  })
+
+  it('SCEN-A06: monthly availability respects the pickup date (priced in H1, cleared in H2)', async () => {
+    const SX_PAYLOAD = {
+      ...ADMIN_PAYLOAD,
+      categories: [
+        makeAdminCategory('SX', [
+          monthlyPriced({ init_date: '2026-01-01', end_date: '2026-06-30' }),
+          noMonthly({ init_date: '2026-07-01', end_date: '2026-12-31' }),
+        ]),
+      ],
+    }
+    vi.stubGlobal('useState', () => ref(SX_PAYLOAD))
+
+    FETCH_AVAILABILITY.mockResolvedValue({ data: ref([]), error: ref(null) })
+
+    const { default: useStoreReservationForm } = await import('../useStoreReservationForm')
+    const formStore = useStoreReservationForm()
+    formStore.haveMonthlyReservation = true
+
+    const { default: useStoreSearchData } = await import('../useStoreSearchData')
+    const searchStore = useStoreSearchData()
+
+    formStore.fechaRecogida = '2026-03-15'
+    await searchStore.search()
+    expect((searchStore.categoriesAvailabilityData ?? []).map((c) => c.categoryCode)).toContain('SX')
+
+    formStore.fechaRecogida = '2026-08-15'
+    await searchStore.search()
+    expect((searchStore.categoriesAvailabilityData ?? []).map((c) => c.categoryCode)).not.toContain('SX')
+  })
+
+  it('SCEN-A02: non-monthly path is unaffected — payload passes through', async () => {
     const passthroughPayload = ['C', 'FU', 'LU'].map((code) => ({
       categoryCode: code,
       categoryDescription: '',

--- a/packages/logic/src/stores/__tests__/useStoreSearchData.unableCardsOnLLNRAG009.test.ts
+++ b/packages/logic/src/stores/__tests__/useStoreSearchData.unableCardsOnLLNRAG009.test.ts
@@ -15,6 +15,21 @@ vi.mock('../../composables/useFetchCategoriesAvailabilityData', () => ({
   default: () => FETCH_AVAILABILITY(),
 }))
 
+// Issue #28 Ola A: monthly exclusion is derived from pricing. B, C, D all offer
+// monthly (positive active row), so monthly + LLNRAG009 surfaces all three as
+// unable cards (SCEN-U2). An active row cleared to 0 would be the non-monthly
+// shape (mig. 042).
+const monthlyRow = (kms: number) => ({
+  '1k_kms': kms,
+  '2k_kms': kms,
+  '3k_kms': kms,
+  init_date: '2026-01-01',
+  end_date: '2026-12-31',
+  total_insurance_price: 0,
+  one_day_price: 0,
+  status: 'active' as const,
+})
+
 const baseCategory = (id: string, name: string, category: string) => ({
   id,
   code: id,
@@ -23,7 +38,7 @@ const baseCategory = (id: string, name: string, category: string) => ({
   name,
   category,
   models: [],
-  month_prices: {},
+  month_prices: [monthlyRow(900000)],
   total_coverage_unit_charge: 0,
   image: '',
   ad: '',

--- a/packages/logic/src/stores/useStoreSearchData.ts
+++ b/packages/logic/src/stores/useStoreSearchData.ts
@@ -12,6 +12,9 @@ import useFetchCategoriesAvailabilityData from '../composables/useFetchCategorie
 import useCategory from '../composables/useCategory';
 import useMessages from '../composables/useMessages';
 
+// utils
+import { categoryOffersMonthly } from '@rentacar-main/logic/utils';
+
 // Types
 import type {
   CategoryAvailabilityData,
@@ -27,7 +30,7 @@ const useStoreSearchData = defineStore("storeSearchData", () => {
   // "¡Oops!" block never rendered when admin data arrived late. Issue
   // #10 SCEN-004.
   const { categories: categoriesAdminData } = storeToRefs(storeAdminData);
-  const { haveMonthlyReservation, selectedPickupLocation } = storeToRefs(useStoreReservationForm());
+  const { haveMonthlyReservation, selectedPickupLocation, fechaRecogida } = storeToRefs(useStoreReservationForm());
   const { createErrorMessage } = useMessages();
   const categoriesAvailabilityData = ref<CategoryAvailabilityData[] | null>(
     null
@@ -39,12 +42,13 @@ const useStoreSearchData = defineStore("storeSearchData", () => {
   const selectedCategory = ref<ReturnType<typeof useCategory> | null >(null);
   const noAvailableCategories = ref<boolean>(false);
 
-  const noMonthlyCategories: CategoryType[] = [
-    'FU',
-    'FL',
-    'GL',
-    'LU'
-  ];
+  // Whether a category is offered for monthly rental is derived from its
+  // pricing (issue #28, Ola A), not a hardcoded code list: a category offers
+  // monthly when the pricing row applicable to the pickup date carries a
+  // positive 1k/2k monthly price. The dashboard clears those to NULL (→ 0 in
+  // the payload) for the non-monthly gamas. See categoryOffersMonthly.
+  const offersMonthly = (category: CategoryData): boolean =>
+    categoryOffersMonthly(category.month_prices, fechaRecogida.value ?? '');
 
   const search = async () => {
     error.value = null;
@@ -84,8 +88,8 @@ const useStoreSearchData = defineStore("storeSearchData", () => {
       else {
         const dataArray = Array.isArray(data.value) ? data.value : [];
         categoriesAvailabilityData.value = categoriesAdminData.value?.filter((categoryAdmin: CategoryData) =>
-          !noMonthlyCategories.includes(categoryAdmin.identification)
-        ) // filter out monthly-excluded categories (FU, FL, GL, LU)
+          offersMonthly(categoryAdmin)
+        ) // keep only categories that actually offer monthly pricing
         .map((categoryAdmin: CategoryData) =>
           // create a category availability object for each category
           createCategoryAvailability(categoryAdmin)
@@ -143,12 +147,11 @@ const useStoreSearchData = defineStore("storeSearchData", () => {
      */
     if (error.value?.error === "no_available_categories_error") {
       // Mirror the monthly *success* path: monthly reservations never offer
-      // the monthly-excluded categories (FU/FL/GL/LU), so they must not appear
-      // as unable cards either. Non-monthly keeps surfacing every category.
-      // Issue #54.
+      // categories without monthly pricing, so they must not appear as unable
+      // cards either. Non-monthly keeps surfacing every category. Issue #54.
       const adminCategories = haveMonthlyReservation.value
         ? categoriesAdminData.value.filter((categoryAdmin: CategoryData) =>
-            !noMonthlyCategories.includes(categoryAdmin.identification)
+            offersMonthly(categoryAdmin)
           )
         : categoriesAdminData.value;
       return adminCategories.map((categoryAdmin: CategoryData) =>

--- a/packages/logic/src/utils/__tests__/categoryOffersMonthly.test.ts
+++ b/packages/logic/src/utils/__tests__/categoryOffersMonthly.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import { categoryOffersMonthly } from '../categoryOffersMonthly'
+import type CategoryMonthPriceData from '../types/data/CategoryMonthPriceData'
+
+// Encodes the Ola A predicate (issue #28). A category "offers monthly" when the
+// pricing row applicable to the pickup date has a positive monthly mileage price.
+// FU/FL/GL/LU are modeled in production as monthly_*_price = NULL → 0 in the
+// payload (mig. 042 + transformer `?? 0`), so they never offer monthly.
+
+const row = (
+  overrides: Partial<CategoryMonthPriceData> = {},
+): CategoryMonthPriceData => ({
+  '1k_kms': 900000,
+  '2k_kms': 1200000,
+  '3k_kms': 1500000,
+  init_date: '2026-01-01',
+  end_date: '2026-12-31',
+  total_insurance_price: 0,
+  one_day_price: 0,
+  status: 'active',
+  ...overrides,
+})
+
+describe('categoryOffersMonthly', () => {
+  it('offers monthly when the applicable active row has a positive mileage price', () => {
+    expect(categoryOffersMonthly([row()], '2026-03-15')).toBe(true)
+  })
+
+  it('does not offer monthly when the applicable row has both mileage prices at zero (mig. 042 shape)', () => {
+    const zeroed = row({ '1k_kms': 0, '2k_kms': 0, '3k_kms': 0 })
+    expect(categoryOffersMonthly([zeroed], '2026-03-15')).toBe(false)
+  })
+
+  it('offers monthly when only the 2k plan is priced (partial pricing still sellable)', () => {
+    const partial = row({ '1k_kms': 0, '2k_kms': 1200000 })
+    expect(categoryOffersMonthly([partial], '2026-03-15')).toBe(true)
+  })
+
+  // Only 1k/2k are sellable in the reservation UI — a row priced only on 3k has
+  // no selectable monthly plan, so it must not count as offering monthly.
+  it('does not offer monthly when only the unsellable 3k plan is priced', () => {
+    const only3k = row({ '1k_kms': 0, '2k_kms': 0, '3k_kms': 1500000 })
+    expect(categoryOffersMonthly([only3k], '2026-03-15')).toBe(false)
+  })
+
+  // SCEN-A06: date-aware — same category, different answer per pickup date.
+  it('respects the pickup date: priced in range A, zeroed in range B', () => {
+    const rangeA = row({ init_date: '2026-01-01', end_date: '2026-06-30', '1k_kms': 900000 })
+    const rangeB = row({ init_date: '2026-07-01', end_date: '2026-12-31', '1k_kms': 0, '2k_kms': 0 })
+    const prices = [rangeA, rangeB]
+    expect(categoryOffersMonthly(prices, '2026-03-15')).toBe(true)
+    expect(categoryOffersMonthly(prices, '2026-08-15')).toBe(false)
+  })
+
+  // SCEN-A08: pickup date outside every active range must not exclude a category
+  // that has a real monthly product, just because a $0 off-season row would be
+  // the cheapest fallback pick. No in-range row → safety net (any active
+  // positive) decides.
+  it('offers monthly when the pickup date is beyond all ranges but a priced active row exists', () => {
+    const priced = row({ init_date: '2026-01-01', end_date: '2026-06-30', '1k_kms': 900000 })
+    const offSeasonZero = row({ init_date: '2026-07-01', end_date: '2026-12-31', '1k_kms': 0, '2k_kms': 0 })
+    // 2030 is past both ranges; the old pickPriceForDate-based predicate picked
+    // the $0 seasonLow row and wrongly returned false.
+    expect(categoryOffersMonthly([priced, offSeasonZero], '2030-01-01')).toBe(true)
+    expect(categoryOffersMonthly([offSeasonZero, priced], '2030-01-01')).toBe(true)
+  })
+
+  // The flip side of SCEN-A08: when the date IS inside a $0 range, that in-range
+  // row is authoritative and the category is excluded — even though another
+  // active range is priced (SCEN-A06 invariant).
+  it('excludes when the in-range active row is $0, even if another range is priced', () => {
+    const pricedH1 = row({ init_date: '2026-01-01', end_date: '2026-06-30', '1k_kms': 900000 })
+    const zeroH2 = row({ init_date: '2026-07-01', end_date: '2026-12-31', '1k_kms': 0, '2k_kms': 0 })
+    expect(categoryOffersMonthly([pricedH1, zeroH2], '2026-08-15')).toBe(false)
+    expect(categoryOffersMonthly([pricedH1, zeroH2], '2026-03-15')).toBe(true)
+  })
+
+  // SCEN-A07: safety net — undefined pick (missing date) must not mass-exclude a
+  // category that genuinely has positive active monthly pricing.
+  it('falls back to "any active positive row" when pickup date is empty', () => {
+    expect(categoryOffersMonthly([row()], '')).toBe(true)
+  })
+
+  it('still excludes an all-zero category when pickup date is empty', () => {
+    const zeroed = row({ '1k_kms': 0, '2k_kms': 0, '3k_kms': 0 })
+    expect(categoryOffersMonthly([zeroed], '')).toBe(false)
+  })
+
+  it('does not offer monthly when there is no pricing data at all', () => {
+    expect(categoryOffersMonthly([], '2026-03-15')).toBe(false)
+  })
+
+  // The safety net only counts ACTIVE rows — an inactive legacy row with a
+  // positive price must not resurrect monthly for a discontinued category.
+  it('ignores inactive legacy rows in the empty-date safety net', () => {
+    const legacy = row({ status: 'inactive', '1k_kms': 900000 })
+    const activeZero = row({ status: 'active', '1k_kms': 0, '2k_kms': 0 })
+    expect(categoryOffersMonthly([legacy, activeZero], '')).toBe(false)
+  })
+})

--- a/packages/logic/src/utils/categoryOffersMonthly.ts
+++ b/packages/logic/src/utils/categoryOffersMonthly.ts
@@ -1,0 +1,59 @@
+import type CategoryMonthPriceData from './types/data/CategoryMonthPriceData'
+
+const toMs = (iso: string): number => Date.parse(`${iso}T00:00:00Z`)
+
+// Only the 1k and 2k mileage plans are sellable monthly — the reservation UI
+// offers those two (CategoryCard mileage select), and useTariffs.buildTariffs
+// derives "offered monthly" the same way. A row priced only on 3k_kms has no
+// selectable monthly plan, so it does not count as offering monthly.
+const hasPositiveMonthlyPrice = (price: CategoryMonthPriceData): boolean =>
+  price['1k_kms'] > 0 || price['2k_kms'] > 0
+
+/**
+ * Decides whether a category is offered for monthly rental, derived from its
+ * pricing instead of a hardcoded category list (issue #28, Ola A).
+ *
+ * The dashboard models "not offered monthly" as `monthly_*_price = NULL`
+ * (mig. 042), which the payload transformer surfaces as `month_prices` rows
+ * with all mileage prices at 0. A category offers monthly when the row that
+ * applies to the pickup date carries at least one positive 1k/2k price.
+ *
+ * Row selection is deliberately date-aware but money-safe:
+ *
+ *   1. If an `active` row's validity range contains the pickup date, that row
+ *      is authoritative — its price is exactly what the customer would pay for
+ *      those dates (same rule `pickPriceForDate` uses to display the price).
+ *      A $0 in-range row therefore correctly excludes the category (e.g. a
+ *      gama whose monthly was discontinued for that season).
+ *   2. Otherwise — no in-range active row, because the pickup date is outside
+ *      every configured range or is missing/invalid — fall back to "does any
+ *      active row carry a positive monthly price?". This avoids excluding a
+ *      genuinely-monthly category on the strength of a single off-season $0
+ *      row that an out-of-range fallback would otherwise select, and avoids
+ *      mass-excluding everything when the date is absent.
+ *
+ * When several active rows contain the date (overlapping ranges) the most
+ * recent `init_date` wins, matching `pickPriceForDate`.
+ */
+export function categoryOffersMonthly(
+  prices: CategoryMonthPriceData[],
+  pickupDate: string,
+): boolean {
+  const pickupMs = pickupDate ? toMs(pickupDate) : Number.NaN
+
+  if (!Number.isNaN(pickupMs)) {
+    const inRange = prices
+      .filter((p) => {
+        if (p.status !== 'active') return false
+        const initMs = toMs(p.init_date)
+        const endMs = p.end_date ? toMs(p.end_date) : Number.POSITIVE_INFINITY
+        return initMs <= pickupMs && pickupMs <= endMs
+      })
+      .sort((a, b) => b.init_date.localeCompare(a.init_date))
+
+    const mostRecentInRange = inRange[0]
+    if (mostRecentInRange) return hasPositiveMonthlyPrice(mostRecentInRange)
+  }
+
+  return prices.some((p) => p.status === 'active' && hasPositiveMonthlyPrice(p))
+}

--- a/packages/logic/src/utils/index.ts
+++ b/packages/logic/src/utils/index.ts
@@ -23,6 +23,7 @@ export { slugify } from './slugify';
 // Pricing
 // ============================================================================
 export { pickPriceForDate } from './pickPriceForDate';
+export { categoryOffersMonthly } from './categoryOffersMonthly';
 export { pickEffectiveTotalCoverageUnitCharge } from './pickEffectiveTotalCoverage';
 
 // ============================================================================


### PR DESCRIPTION
## Qué

Segunda ola del issue #28. Reemplaza el array hardcoded `noMonthlyCategories = ['FU','FL','GL','LU']` en `useStoreSearchData` por un predicado derivado del payload: **una categoría ofrece mensual cuando el row de pricing aplicable a la fecha de recogida tiene un precio mensual 1k/2k positivo**.

El dashboard ya modela "no ofrece mensual" como `category_pricing.monthly_*_price = NULL` (mig. 042) → 0 en el payload. La regla pasa a vivir en el source of truth: agregar o cambiar una gama ya **no requiere release de la web**.

## Diseño money-safe

La selección de row es date-aware pero protegida contra falsas exclusiones (pérdida de ingresos):

1. Un row **activo cuyo rango contiene la fecha** es autoritativo — su precio es el que pagaría el cliente. Un $0 en-rango excluye correctamente (gama con mensual discontinuado esa temporada).
2. **Sin row en-rango** (fecha fuera de todos los rangos, o ausente) → red de seguridad: "¿algún row activo tiene mensual positivo?". Así una categoría con mensual real no se excluye por un $0 de temporada baja que un fallback fuera-de-rango elegiría por "más barato".

Solo cuentan 1k/2k (los planes vendibles en el UI), consistente con `useTariffs.buildTariffs`.

## Bug atrapado en review

`code-reviewer` y `edge-case-detector` reprodujeron **independientemente** (0.85) una exclusión errónea en un borrador basado en `pickPriceForDate`: con filas activas mixtas (priced + $0) y fecha fuera de rango, la regla-3 seasonLow elegía la fila $0 → categoría con mensual real desaparecía. Fijado con **SCEN-A08** + el predicado in-range-autoritativo. El one-liner que ambos propusieron rompía SCEN-A06 (in-range $0 debe excluir); la causa raíz era más fina y el fix la respeta.

## Escenarios (holdout write-once)

`docs/specs/issue-28-ola-a-monthly-availability/scenarios/monthly-availability.scenarios.md` — 8 escenarios observables (lista de `categoryCode` que ve el cliente), con guarda anti-reward-hacking (ningún literal `['FU','FL','GL','LU']` puede sobrevivir en producción).

| SCEN | Cubre | Test |
|---|---|---|
| A01 | excluye sin-mensual, mantiene priced | monthlyCategoryExclusion |
| A02 | no-mensual pasa el payload intacto | monthlyCategoryExclusion |
| A03 | derivado del dato, no de una lista (código nuevo `ZZ`) | monthlyCategoryExclusion |
| A04/A05 | LLNRAG009 unable-cards (preserva #54) | llnrag009MonthlyExclusion |
| A06 | respeta fecha (priced H1 / $0 H2) | monthlyCategoryExclusion + util |
| A07 | sin fecha → red de seguridad | categoryOffersMonthly util |
| A08 | fuera de rango no excluye por $0 fallback | categoryOffersMonthly util |

## Verificación

- `pnpm --filter @rentacar-main/logic test` → **277 passed, 0 failed** (43 files)
- `categoryOffersMonthly.test.ts` → **11 passed**
- typecheck **delta 0** — alquilame 201 errores = baseline exacto; archivo nuevo limpio. El rojo de marca (blog cluster D + fixtures cluster C) es pre-existente.
- Fixtures de store: placeholder `month_prices: {}` → arrays realistas. **Exigido por el data-path** (el predicado lee `month_prices`); aserciones reforzadas (+3 `not.toContain`, +2 `toContain`), ninguna debilitada.

## Follow-up conocido (no en esta PR)

`transformers.ts:91` coacciona cualquier `status` ≠ 'inactive' a 'active' (edge-detector MEDIUM, pre-existente). Un row 'draft'/'archived' podría colarse como activo. Afecta también el pricing display; merece su propio escenario — fuera del alcance de Ola A.

Refs #28