### PR TITLE
fix(reservation): ocultar badge 'Dto Hoy' sin descuento (NaN en mensualidad)

### DIFF
--- a/docs/specs/monthly-discount-badge/scenarios/monthly-discount-badge.scenarios.md
+++ b/docs/specs/monthly-discount-badge/scenarios/monthly-discount-badge.scenarios.md
@@ -1,0 +1,68 @@
+---
+name: monthly-discount-badge
+created_by: pabloandi
+created_at: 2026-06-02T18:00:00Z
+issue: none
+---
+
+# Bug — badge "Dto Hoy" muestra "NaN %" en reserva mensual
+
+Reportado por operaciones: en el **Resumen de Reserva** (`ReservationResume.vue`),
+sección "Tarifa Diaria", el badge `Dto Hoy {{ getDiscount }} %` aparece como
+**"Dto Hoy NaN %"** cuando la reserva es mensual. Con mensualidad no debe salir el
+texto de descuento.
+
+Causa raíz (verificada): el badge en `ReservationResume.vue` se renderiza **sin
+guarda** — a diferencia de su hermano (el precio tachado, gated por
+`v-if="hasDiscount()"`) y de su equivalente en `CategoryCard.vue:67` (gated). En
+mensualidad el objeto de disponibilidad trae `vehicleDayCharge = 0` y
+`coverageUnitCharge = 0` (el precio real vive en `month_prices`), así que
+`getDiscount` calcula `100 * ((0 - 0) / |0|) = NaN`. El descuento "Dto Hoy" es un
+concepto de tarifa **diaria**; no aplica a la mensual.
+
+Observable: el texto renderizado del Resumen de Reserva, y la estructura del
+template (la guarda existe en las 3 marcas).
+
+---
+
+## SCEN-D01: reserva mensual no muestra el badge de descuento
+
+**Given**: un cliente con una reserva **mensual** (`haveMonthlyReservation = true`),
+cuya categoría tiene `vehicleDayCharge = 0` y `coverageUnitCharge = 0` (forma del
+objeto de disponibilidad mensual).
+**When**: se renderiza el Resumen de Reserva (`ReservationResume.vue`).
+**Then**: **no** aparece el badge "Dto Hoy …%". En particular, nunca se muestra
+"Dto Hoy NaN %".
+**Evidence**: el DOM del Resumen de Reserva no contiene el texto "Dto Hoy" en
+modo mensual (validación en navegador / e2e); y el badge en los 3
+`ReservationResume.vue` está gated por `hasDiscount()` (estructura del template),
+predicado que es `false` en mensual.
+
+## SCEN-D02: con descuento diario real, el badge aparece con su porcentaje
+
+**Given**: una reserva **diaria** con un descuento real
+(`discountAmount > 0` tal que `hasDiscount()` es `true`).
+**When**: se renderiza el Resumen de Reserva.
+**Then**: el badge aparece como "Dto Hoy N %" con un porcentaje finito (p.ej.
+"Dto Hoy 15 %"), nunca "NaN", y junto al precio base tachado.
+**Evidence**: el badge y el precio tachado comparten la misma condición
+`hasDiscount()`; el porcentaje es un número finito formateado.
+
+## SCEN-D03: getDiscount nunca produce el texto "NaN"
+
+**Given**: una categoría cuyo `vehicleDayCharge` y `coverageUnitCharge` son ambos
+0 (base nula — el caso mensual que disparaba el bug).
+**When**: se evalúa `getDiscount`.
+**Then**: devuelve un texto numérico finito ("0"), nunca "NaN" — una función de
+presentación no debe emitir "NaN" aunque se la invoque con base nula.
+**Evidence**: `getDiscount` con base 0 → string que no contiene "NaN"; defensa en
+profundidad además de la guarda del template.
+
+---
+
+## Fuera de alcance
+
+- `CategoryCard.vue` ya gatea el badge correctamente (`v-if="hasDiscount()"`, línea
+  67) — no se toca.
+- La lógica de cálculo de descuento diario para reservas con descuento real no
+  cambia; solo se evita el NaN y se oculta el badge cuando no hay descuento.

--- a/packages/logic/src/__tests__/reservationDiscountBadgeGate.test.ts
+++ b/packages/logic/src/__tests__/reservationDiscountBadgeGate.test.ts
@@ -1,0 +1,77 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Bug guard: the "Dto Hoy {{ getDiscount }} %" badge in the reservation summary
+ * rendered "Dto Hoy NaN %" on monthly reservations. Root cause: the badge in
+ * ReservationResume.vue had no v-if, unlike its sibling (the struck base price)
+ * and unlike CategoryCard.vue:67 — both gated by hasDiscount(). Monthly
+ * availability carries vehicleDayCharge = coverageUnitCharge = 0, so getDiscount
+ * divides 0/0 → NaN.
+ *
+ * Cross-brand structural guard (mirrors brand-tsconfig-hygiene): the badge must
+ * be gated by hasDiscount() in all three brands, and getDiscount must never be
+ * able to emit "NaN". See docs/specs/monthly-discount-badge/scenarios.
+ */
+
+const BRANDS = ['ui-alquilatucarro', 'ui-alquilame', 'ui-alquicarros'] as const
+
+const readBrandFile = (brand: string, rel: string): string =>
+  readFileSync(
+    fileURLToPath(new URL(`../../../${brand}/${rel}`, import.meta.url)),
+    'utf8',
+  )
+
+const logicSource = readFileSync(
+  fileURLToPath(new URL('../composables/useCategory.ts', import.meta.url)),
+  'utf8',
+)
+
+describe('reservation summary discount badge gate (monthly NaN bug)', () => {
+  // SCEN-D01: the badge must be gated so it does not appear when there is no
+  // daily discount (which includes every monthly reservation).
+  for (const brand of BRANDS) {
+    it(`${brand} ReservationResume gates the "Dto Hoy" badge with hasDiscount()`, () => {
+      const vue = readBrandFile(brand, 'app/components/ReservationResume.vue')
+      const idx = vue.indexOf('Dto Hoy')
+      expect(idx, `${brand}: "Dto Hoy" badge not found`).toBeGreaterThan(-1)
+
+      // The badge's OWN wrapping element must carry the hasDiscount() guard —
+      // not a sibling. Scope the window to just the badge's enclosing element by
+      // starting at the previous closing tag (the struck-price </div> above),
+      // so the struck-price's own v-if is excluded.
+      const prevClose = Math.max(
+        vue.lastIndexOf('</div>', idx),
+        vue.lastIndexOf('</span>', idx),
+      )
+      const badgeElement = vue.slice(prevClose, idx)
+      expect(
+        badgeElement.includes('v-if="hasDiscount()"'),
+        `${brand}: "Dto Hoy" badge is rendered unconditionally — must be gated by v-if="hasDiscount()"`,
+      ).toBe(true)
+    })
+  }
+
+  // SCEN-D03: getDiscount must never produce the string "NaN" — defense in depth
+  // for a presentation function, even if the template gate is ever removed.
+  it('getDiscount guards against a zero/non-finite base (no NaN)', () => {
+    const start = logicSource.indexOf('const getDiscount = computed')
+    expect(start, 'getDiscount computed not found').toBeGreaterThan(-1)
+    const end = logicSource.indexOf('\n   });', start)
+    const block = logicSource.slice(start, end)
+
+    // Accept any explicit guard against the 0/0 → NaN path: a finite check, a
+    // zero-base early return, or a NaN check.
+    const hasGuard =
+      /Number\.isFinite/.test(block) ||
+      /isNaN/.test(block) ||
+      /initial\s*===?\s*0/.test(block) ||
+      /initial\s*<=\s*0/.test(block) ||
+      /\?\s*0\s*:/.test(block) // ternary producing 0 when base is empty
+    expect(
+      hasGuard,
+      'getDiscount must guard the 0/0 division so it cannot format "NaN"',
+    ).toBe(true)
+  })
+})

--- a/packages/logic/src/composables/useCategory.ts
+++ b/packages/logic/src/composables/useCategory.ts
@@ -282,7 +282,12 @@ export default function useCategory(categoryAvailableData: CategoryAvailabilityD
       let initial: number = 0, final: number = 0;
       initial = ((hasDiscount()) ? vehicleDayCharge.value + (discountAmount.value ?? 0) : vehicleDayCharge.value) + coverageUnitCharge.value;
       final = vehicleDayCharge.value + coverageUnitCharge.value;
-      
+
+      // Base nula (p.ej. reserva mensual: vehicleDayCharge y coverageUnitCharge
+      // son 0, el precio vive en month_prices) → no hay descuento diario que
+      // mostrar. Sin esta guarda el cálculo hace 100 * (0 / |0|) = NaN.
+      if (initial <= 0) return "0";
+
       const formatter = new Intl.NumberFormat("es-CO", {
          style: "decimal",
       });

--- a/packages/ui-alquicarros/app/components/ReservationResume.vue
+++ b/packages/ui-alquicarros/app/components/ReservationResume.vue
@@ -75,7 +75,7 @@
             <div class="text-right text-sm line-through text-black" v-if="hasDiscount()">
               $ {{ currencyDailyBasePrice }}
             </div>
-            <div class="text-right">
+            <div class="text-right" v-if="hasDiscount()">
               <span class="bg-[#a3f78b] text-black text-xs px-1 inline-block">Dto Hoy {{ getDiscount }} %</span>
             </div>
             <div class="text-right text-sm">

--- a/packages/ui-alquilame/app/components/ReservationResume.vue
+++ b/packages/ui-alquilame/app/components/ReservationResume.vue
@@ -75,7 +75,7 @@
             <div class="text-right text-sm line-through text-black" v-if="hasDiscount()">
               $ {{ currencyDailyBasePrice }}
             </div>
-            <div class="text-right">
+            <div class="text-right" v-if="hasDiscount()">
               <span class="bg-[#a3f78b] text-black text-xs px-1 inline-block">Dto Hoy {{ getDiscount }} %</span>
             </div>
             <div class="text-right text-sm">

--- a/packages/ui-alquilatucarro/app/components/ReservationResume.vue
+++ b/packages/ui-alquilatucarro/app/components/ReservationResume.vue
@@ -75,7 +75,7 @@
             <div class="text-right text-sm line-through text-black" v-if="hasDiscount()">
               $ {{ currencyDailyBasePrice }}
             </div>
-            <div class="text-right">
+            <div class="text-right" v-if="hasDiscount()">
               <span class="bg-[#a3f78b] text-black text-xs px-1 inline-block">Dto Hoy {{ getDiscount }} %</span>
             </div>
             <div class="text-right text-sm">


### PR DESCRIPTION
## Bug (reportado por operaciones)

En el **Resumen de Reserva**, sección "Tarifa Diaria", el badge `Dto Hoy {{ getDiscount }} %` aparece como **"Dto Hoy NaN %"** cuando la reserva es mensual. Con mensualidad no debe salir el texto de descuento.

## Causa raíz

El badge en `ReservationResume.vue` se renderizaba **sin `v-if`** — a diferencia de su hermano (el precio base tachado, gateado por `v-if="hasDiscount()"`, línea 75) y de su equivalente en `CategoryCard.vue:67` (que sí lo gatea). En mensualidad el objeto de disponibilidad trae `vehicleDayCharge = 0` y `coverageUnitCharge = 0` (el precio real vive en `month_prices`), así que `getDiscount` calculaba `100 * ((0 - 0) / |0|) = NaN`.

## Fix (espejo de la referencia que ya funciona, CategoryCard)

1. **Badge gateado** con `v-if="hasDiscount()"` en las 3 marcas. `hasDiscount()` es `false` en mensual (base 0 ≤ precio mensual diario) → el badge no aparece. De paso deja de mostrar el ruido "Dto Hoy 0 %" en diarias sin descuento, igual que ya hace CategoryCard.
2. **Guarda en `getDiscount`** contra base 0 → una función de presentación nunca emite "NaN" (defensa en profundidad).

## Verificación

- `pnpm --filter @rentacar-main/logic test` → **268 passed, 0 failed** (43 files)
- `reservationDiscountBadgeGate.test.ts` → **4/4** (guarda cross-brand del `v-if` + guarda de `getDiscount`)
- **red→green probado**: revertir el `v-if` en una marca hace fallar su test; restaurar → verde
- typecheck **delta 0** (alquilatucarro 268 = baseline; archivos cambiados sin errores)

Holdout: `docs/specs/monthly-discount-badge/scenarios` (SCEN-D01..D03).

**Nota**: no se ejecutó validación en navegador vivo (el resumen en flujo mensual requiere backend + flujo completo). La cadena estructural + lógica (`hasDiscount()=false` en mensual → badge oculto) lo cubre; el render se valida por e2e como el resto del repo.

Bug pre-existente, **independiente** de las olas del issue #28.