### PR TITLE
refactor(logic): rename hasPicoyPlaca() → isPicoyPlacaExempt() (#28 Ola B1)

### DIFF
--- a/docs/specs/issue-28-ola-b1-picoyplaca-rename/scenarios/picoyplaca-rename.scenarios.md
+++ b/docs/specs/issue-28-ola-b1-picoyplaca-rename/scenarios/picoyplaca-rename.scenarios.md
@@ -1,0 +1,44 @@
+---
+name: picoyplaca-rename
+created_by: pabloandi
+created_at: 2026-06-02T19:00:00Z
+issue: 28
+ola: B1
+---
+
+# Ola B1 — renombrar el flag de pico y placa por su semántica real (issue #28, O4)
+
+El flag `useCategory.hasPicoyPlaca()` **miente**: devuelve `true` para las gamas
+que muestran el badge **"sin pico y placa"**, es decir las **exentas**. El nombre
+afirma lo contrario de lo que hace. Ola B1 lo renombra a `isPicoyPlacaExempt()`
+en todo el flujo (10 archivos), sin cambiar comportamiento ni el texto del badge.
+El array hardcoded `["FU","FL","GL","LY","LP","LU"]` se mantiene en B1; moverlo al
+dashboard es B2.
+
+Refactor puro: las escenas observables del comportamiento previo deben seguir
+satisfechas; solo cambia el nombre del identificador.
+
+## SCEN-B1-01: el badge sigue apareciendo en las mismas 6 gamas
+
+**Given**: las gamas exentas FU, FL, GL, LY, LP, LU y una no exenta (C).
+**When**: se evalúa el predicado de exención de pico y placa.
+**Then**: es `true` para las 6 exentas y `false` para C — idéntico al
+comportamiento previo a B1 (issue #93). El texto del badge sigue siendo
+"sin pico y placa".
+**Evidence**: el whitelist del predicado contiene exactamente FU/FL/GL/LY/LP/LU
+y no C (test source-level sobre `isPicoyPlacaExempt`).
+
+## SCEN-B1-02: ningún identificador del flujo afirma lo contrario de lo que hace
+
+**Given**: el código de las 3 marcas + el composable de logic.
+**When**: se busca el símbolo `hasPicoyPlaca` en producción.
+**Then**: no existe — fue renombrado a `isPicoyPlacaExempt` en el composable
+(definición + export) y en sus consumidores (`CategoryTags`, `ReservationResume`,
+`CategoryCard` de las 3 marcas). El nombre ahora dice que `true` = exenta.
+**Evidence**: `grep -r "hasPicoyPlaca" packages/` (sin tests) → vacío;
+`isPicoyPlacaExempt` presente en los 10 archivos.
+
+## Fuera de alcance de B1
+
+- Mover el array al dashboard (`picoyplaca_exempt` columna + backfill + lectura) — B2.
+- Cambiar el texto o estilo del badge — no se toca.

--- a/packages/logic/src/composables/__tests__/useCategory.isPicoyPlacaExempt.test.ts
+++ b/packages/logic/src/composables/__tests__/useCategory.isPicoyPlacaExempt.test.ts
@@ -5,10 +5,10 @@ import { fileURLToPath } from 'node:url'
 // Scenario captured (issue #93): the LU category is exempt from pico y placa
 // — like the rest of its "L" family (LP, LY) — but its result card never
 // rendered the "sin pico y placa" badge. CategoryTags.vue (all three brands)
-// gates that badge on hasPicoyPlaca(), whose whitelist is the single source
-// of truth. LU was missing from the array, so hasPicoyPlaca() returned false.
+// gates that badge on isPicoyPlacaExempt(), whose whitelist is the single source
+// of truth. LU was missing from the array, so isPicoyPlacaExempt() returned false.
 //
-// Fix: add "LU" to the whitelist. Since hasPicoyPlaca is `categoryCode
+// Fix: add "LU" to the whitelist. Since isPicoyPlacaExempt is `categoryCode
 // ? WHITELIST.includes(categoryCode) : false`, the array membership set IS
 // the observable behavior — asserting the literal pins the scenario exactly.
 // Source-level test mirrors the sibling suites, which deliberately avoid
@@ -19,15 +19,15 @@ const source = readFileSync(
   'utf8',
 )
 
-function extractHasPicoyPlaca(): string {
-  const start = source.indexOf('const hasPicoyPlaca =')
-  expect(start, 'missing hasPicoyPlaca').toBeGreaterThan(-1)
+function extractIsPicoyPlacaExempt(): string {
+  const start = source.indexOf('const isPicoyPlacaExempt =')
+  expect(start, 'missing isPicoyPlacaExempt').toBeGreaterThan(-1)
   const end = source.indexOf(';', source.indexOf('.includes', start)) + 1
   return source.slice(start, end)
 }
 
 function whitelist(): string[] {
-  const block = extractHasPicoyPlaca()
+  const block = extractIsPicoyPlacaExempt()
   const captured = block.match(/\[([^\]]*)\]/)?.[1]
   if (captured === undefined) throw new Error('missing whitelist array literal')
   return captured
@@ -36,7 +36,7 @@ function whitelist(): string[] {
     .filter(Boolean)
 }
 
-describe('useCategory.hasPicoyPlaca — pico y placa exemption whitelist (issue #93)', () => {
+describe('useCategory.isPicoyPlacaExempt — pico y placa exemption whitelist (issue #93)', () => {
   const codes = whitelist()
 
   it('SCEN-LU-1: LU is exempt → badge renders', () => {
@@ -54,7 +54,7 @@ describe('useCategory.hasPicoyPlaca — pico y placa exemption whitelist (issue 
   })
 
   it('returns false when categoryCode is falsy, true only via the whitelist', () => {
-    const block = extractHasPicoyPlaca()
+    const block = extractIsPicoyPlacaExempt()
     expect(block).toMatch(/categoryCode\.value\)\s*\?/)
     expect(block).toMatch(/\.includes\(categoryCode\.value\)\s*:\s*false/)
   })

--- a/packages/logic/src/composables/useCategory.ts
+++ b/packages/logic/src/composables/useCategory.ts
@@ -93,7 +93,7 @@ export default function useCategory(categoryAvailableData: CategoryAvailabilityD
       return pickPriceForDate(categoryMonthPrices.value, fechaRecogida.value ?? '');
    };
    
-   const hasPicoyPlaca = (): boolean =>
+   const isPicoyPlacaExempt = (): boolean =>
       (categoryCode.value) ? ["FU", "FL", "GL", "LY", "LP", "LU"].includes(categoryCode.value) : false;
    
    const hasReturnFee = (): boolean => returnFeeAmount.value ? true  : false;
@@ -463,7 +463,7 @@ export default function useCategory(categoryAvailableData: CategoryAvailabilityD
       currencyTotalWithAdditionals,
       
       // other functions
-      hasPicoyPlaca,
+      isPicoyPlacaExempt,
       hasDiscount,
       hasExtraHours,
       hasReturnFee,

--- a/packages/ui-alquicarros/app/components/CategoryCard.vue
+++ b/packages/ui-alquicarros/app/components/CategoryCard.vue
@@ -653,7 +653,7 @@ const {
   currencyReturnFee,
   getDiscount,
   getFormattedDays,
-  hasPicoyPlaca,
+  isPicoyPlacaExempt,
   hasDiscount,
   hasExtraHours,
   hasReturnFee,

--- a/packages/ui-alquicarros/app/components/CategoryTags.vue
+++ b/packages/ui-alquicarros/app/components/CategoryTags.vue
@@ -1,6 +1,6 @@
 <template>
     <span class="space-x-1">
-        <span v-if="hasPicoyPlaca()" class="etiqueta-carro">sin pico y placa</span>
+        <span v-if="isPicoyPlacaExempt()" class="etiqueta-carro">sin pico y placa</span>
         <span v-for="tag in categoryTags[categoryCode]" :key="tag" class="etiqueta-carro" v-text="tag"></span>
     </span>
 </template>
@@ -14,7 +14,7 @@ const props = defineProps<{
 
 const {
     categoryCode,
-    hasPicoyPlaca
+    isPicoyPlacaExempt
 } = props.category;
 
 type categoryTagsType = Partial<{

--- a/packages/ui-alquicarros/app/components/ReservationResume.vue
+++ b/packages/ui-alquicarros/app/components/ReservationResume.vue
@@ -13,7 +13,7 @@
           
           <div class="category-name" v-text="`Gama ${categoryCode}`"></div>
           <div class="category-description" v-text="categoryDescription"></div>
-          <div v-if="hasPicoyPlaca()" class="category-picoyplaca" >
+          <div v-if="isPicoyPlacaExempt()" class="category-picoyplaca" >
             <span class="inline-block px-2 py-0.5 text-xs border border-blue-500 text-blue-600 rounded-full">sin pico y placa</span>
           </div>
           <div class="pickup-info">
@@ -159,7 +159,7 @@ const {
   currencyAdditionalsTotal,
   currencyTotalWithAdditionals,
   numberDays,
-  hasPicoyPlaca,
+  isPicoyPlacaExempt,
   hasDiscount,
   hasExtraHours,
   hasReturnFee,

--- a/packages/ui-alquilame/app/components/CategoryCard.vue
+++ b/packages/ui-alquilame/app/components/CategoryCard.vue
@@ -653,7 +653,7 @@ const {
   currencyReturnFee,
   getDiscount,
   getFormattedDays,
-  hasPicoyPlaca,
+  isPicoyPlacaExempt,
   hasDiscount,
   hasExtraHours,
   hasReturnFee,

--- a/packages/ui-alquilame/app/components/CategoryTags.vue
+++ b/packages/ui-alquilame/app/components/CategoryTags.vue
@@ -1,6 +1,6 @@
 <template>
     <span class="space-x-1">
-        <span v-if="hasPicoyPlaca()" class="etiqueta-carro">sin pico y placa</span>
+        <span v-if="isPicoyPlacaExempt()" class="etiqueta-carro">sin pico y placa</span>
         <span v-for="tag in categoryTags[categoryCode]" :key="tag" class="etiqueta-carro" v-text="tag"></span>
     </span>
 </template>
@@ -14,7 +14,7 @@ const props = defineProps<{
 
 const {
     categoryCode,
-    hasPicoyPlaca
+    isPicoyPlacaExempt
 } = props.category;
 
 type categoryTagsType = Partial<{

--- a/packages/ui-alquilame/app/components/ReservationResume.vue
+++ b/packages/ui-alquilame/app/components/ReservationResume.vue
@@ -13,7 +13,7 @@
           
           <div class="category-name" v-text="`Gama ${categoryCode}`"></div>
           <div class="category-description" v-text="categoryDescription"></div>
-          <div v-if="hasPicoyPlaca()" class="category-picoyplaca" >
+          <div v-if="isPicoyPlacaExempt()" class="category-picoyplaca" >
             <span class="inline-block px-2 py-0.5 text-xs border border-blue-500 text-blue-600 rounded-full">sin pico y placa</span>
           </div>
           <div class="pickup-info">
@@ -159,7 +159,7 @@ const {
   currencyAdditionalsTotal,
   currencyTotalWithAdditionals,
   numberDays,
-  hasPicoyPlaca,
+  isPicoyPlacaExempt,
   hasDiscount,
   hasExtraHours,
   hasReturnFee,

--- a/packages/ui-alquilatucarro/app/components/CategoryCard.vue
+++ b/packages/ui-alquilatucarro/app/components/CategoryCard.vue
@@ -653,7 +653,7 @@ const {
   currencyReturnFee,
   getDiscount,
   getFormattedDays,
-  hasPicoyPlaca,
+  isPicoyPlacaExempt,
   hasDiscount,
   hasExtraHours,
   hasReturnFee,

--- a/packages/ui-alquilatucarro/app/components/CategoryTags.vue
+++ b/packages/ui-alquilatucarro/app/components/CategoryTags.vue
@@ -1,6 +1,6 @@
 <template>
     <span class="space-x-1">
-        <span v-if="hasPicoyPlaca()" class="etiqueta-carro">sin pico y placa</span>
+        <span v-if="isPicoyPlacaExempt()" class="etiqueta-carro">sin pico y placa</span>
         <span v-for="tag in categoryTags[categoryCode]" :key="tag" class="etiqueta-carro" v-text="tag"></span>
     </span>
 </template>
@@ -14,7 +14,7 @@ const props = defineProps<{
 
 const {
     categoryCode,
-    hasPicoyPlaca
+    isPicoyPlacaExempt
 } = props.category;
 
 type categoryTagsType = Partial<{

--- a/packages/ui-alquilatucarro/app/components/ReservationResume.vue
+++ b/packages/ui-alquilatucarro/app/components/ReservationResume.vue
@@ -13,7 +13,7 @@
           
           <div class="category-name" v-text="`Gama ${categoryCode}`"></div>
           <div class="category-description" v-text="categoryDescription"></div>
-          <div v-if="hasPicoyPlaca()" class="category-picoyplaca" >
+          <div v-if="isPicoyPlacaExempt()" class="category-picoyplaca" >
             <span class="inline-block px-2 py-0.5 text-xs border border-blue-500 text-blue-600 rounded-full">sin pico y placa</span>
           </div>
           <div class="pickup-info">
@@ -159,7 +159,7 @@ const {
   currencyAdditionalsTotal,
   currencyTotalWithAdditionals,
   numberDays,
-  hasPicoyPlaca,
+  isPicoyPlacaExempt,
   hasDiscount,
   hasExtraHours,
   hasReturnFee,


### PR DESCRIPTION
## Qué

Primera mitad de la Ola B del issue #28. **Refactor puro, cero cambio de comportamiento.**

El flag `useCategory.hasPicoyPlaca()` **mentía**: devuelve `true` para las gamas que muestran el badge **"sin pico y placa"**, es decir las **exentas**. El nombre afirmaba lo contrario de lo que hace. Se renombra a `isPicoyPlacaExempt()` para que el identificador diga la verdad (`true` = exenta).

## Alcance (10 archivos + test)

- `packages/logic/src/composables/useCategory.ts` — definición + export.
- `CategoryTags.vue`, `ReservationResume.vue`, `CategoryCard.vue` × 3 marcas — `v-if` + destructure.
- Test del issue #93 renombrado (`useCategory.isPicoyPlacaExempt.test.ts`), aserciones byte-idénticas.

## Lo que NO cambia

- El array hardcoded `['FU','FL','GL','LY','LP','LU']` se mantiene — moverlo al dashboard (`picoyplaca_exempt` columna + backfill + lectura) es **Ola B2**.
- El texto del badge "sin pico y placa" — intacto.
- Las 6 gamas que muestran el badge — las mismas.

## Verificación

- `pnpm --filter @rentacar-main/logic test` → **264 passed, 0 failed** (42 files)
- `useCategory.isPicoyPlacaExempt.test.ts` → **4/4** (whitelist preservado: FU/FL/GL/LY/LP/LU exentas, C no)
- typecheck **delta 0** (alquilatucarro 268 = baseline; sin errores en los archivos renombrados)
- `grep -r hasPicoyPlaca packages/` → **0** símbolos en código
- code-reviewer: rename limpio y consistente en las 3 marcas; sin referencias perdidas

Holdout: `docs/specs/issue-28-ola-b1-picoyplaca-rename/scenarios` (SCEN-B1-01/02).

Refs #28