### PR TITLE
fix(reservations): count real rental days in search copy (#99)

### DIFF
--- a/docs/specs/issue-99-search-copy-day-count/scenarios/search-copy-day-count.scenarios.md
+++ b/docs/specs/issue-99-search-copy-day-count/scenarios/search-copy-day-count.scenarios.md
@@ -1,0 +1,71 @@
+---
+name: search-copy-day-count
+created_by: claude
+created_at: 2026-06-02T00:00:00Z
+issue: 99
+---
+
+# Conteo de días del alquiler (copia de búsqueda)
+
+`selectedDays` (store `useStoreReservationForm`) cuenta los días facturables del
+alquiler y alimenta el texto de la función de copia (icono de pin), la detección
+de reserva mensual (`== 30`) y el registro analítico. El precio al cliente lo
+calcula el backend desde `pickupDateTime`/`returnDateTime`, no desde este valor.
+
+Regla de negocio: se factura cada bloque de 24 h completo más un día extra
+cuando la sobra supera una ventana de gracia de 4 h. Toda duración positiva
+factura al menos 1 día.
+
+## SCEN-001: devolución más temprana en el día, < 24 h (bug reportado)
+**Given**: recogida 3 jun 2026 12:00 p. m., devolución 4 jun 2026 5:00 a. m. (17 h reales)
+**When**: se calcula `selectedDays`
+**Then**: el valor es `1` (no `2`); el texto de copia muestra `🗓 1 día`
+**Evidence**: valor retornado por `rentalDayCount`; línea del mensaje de `buildWhatsappMessage`
+
+## SCEN-002: exactamente 24 h
+**Given**: recogida 3 jun 2026 12:00 p. m., devolución 4 jun 2026 12:00 p. m.
+**When**: se calcula `selectedDays`
+**Then**: el valor es `1`
+**Evidence**: valor retornado por `rentalDayCount`
+
+## SCEN-003: 29 h, sobra supera la gracia
+**Given**: recogida 3 jun 2026 12:00 p. m., devolución 4 jun 2026 5:00 p. m. (29 h)
+**When**: se calcula `selectedDays`
+**Then**: el valor es `2`
+**Evidence**: valor retornado por `rentalDayCount`
+
+## SCEN-004: mismo día, varias horas
+**Given**: recogida 3 jun 2026 8:00 a. m., devolución 3 jun 2026 5:00 p. m. (9 h)
+**When**: se calcula `selectedDays`
+**Then**: el valor es `1`
+**Evidence**: valor retornado por `rentalDayCount`
+
+## SCEN-005: mismo día, pocas horas (mínimo 1 día)
+**Given**: recogida 3 jun 2026 8:00 a. m., devolución 3 jun 2026 10:00 a. m. (2 h)
+**When**: se calcula `selectedDays`
+**Then**: el valor es `1`
+**Evidence**: valor retornado por `rentalDayCount`
+
+## SCEN-006: sobra exactamente en el límite de gracia (28 h)
+**Given**: recogida 3 jun 2026 12:00 p. m., devolución 4 jun 2026 4:00 p. m. (28 h, sobra = 4 h)
+**When**: se calcula `selectedDays`
+**Then**: el valor es `1` (la gracia es estrictamente `> 4 h`)
+**Evidence**: valor retornado por `rentalDayCount`
+
+## SCEN-007: reserva mensual de 30 días preservada
+**Given**: recogida 1 jun 2026 12:00 p. m., devolución 1 jul 2026 12:00 p. m. (30×24 h)
+**When**: se calcula `selectedDays`
+**Then**: el valor es `30` (la detección mensual `selectedDays == 30` sigue funcionando)
+**Evidence**: valor retornado por `rentalDayCount`
+
+## SCEN-008: devolución no posterior a la recogida
+**Given**: recogida y devolución idénticas (0 h), o devolución anterior a recogida
+**When**: se calcula `selectedDays`
+**Then**: el valor es `0` (no hay alquiler)
+**Evidence**: valor retornado por `rentalDayCount`
+
+## SCEN-009: singular vs plural en el texto de copia
+**Given**: `selectedDays` es `1`, luego `2`
+**When**: `buildWhatsappMessage` arma la línea de días
+**Then**: muestra `🗓 1 día` (singular) y `🗓 2 días` (plural) respectivamente
+**Evidence**: línea del mensaje de `buildWhatsappMessage` (regresión ya cubierta por S5)

--- a/packages/logic/src/stores/__tests__/useStoreReservationForm.selectedDays.test.ts
+++ b/packages/logic/src/stores/__tests__/useStoreReservationForm.selectedDays.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+// Scenarios: docs/specs/issue-99-search-copy-day-count/scenarios/search-copy-day-count.scenarios.md
+//
+// Wiring guard for `selectedDays` (issue #99). The day-count math lives in the
+// pure `rentalDayCount` util — verified behaviorally in
+// utils/__tests__/rentalDayCount.test.ts. This test guards that the store
+// computed delegates to it using the FULL pickup/return datetimes (date +
+// selected hour), so it can never regress to the calendar-day + abs(hour)
+// heuristic that over-counted by one day. Source-level to avoid booting
+// Pinia/Nuxt auto-imports, matching useStoreReservationForm.minReturnDate.test.ts.
+
+const source = readFileSync(
+  fileURLToPath(new URL('../useStoreReservationForm.ts', import.meta.url)),
+  'utf8',
+)
+
+function extractComputed(name: string): string {
+  const start = source.indexOf(`const ${name} = computed`)
+  expect(start, `missing computed ${name}`).toBeGreaterThan(-1)
+  const end = source.indexOf('\n  });', start) + '\n  });'.length
+  return source.slice(start, end)
+}
+
+describe('useStoreReservationForm — selectedDays delegates to rentalDayCount', () => {
+  const block = extractComputed('selectedDays')
+
+  it('delegates the day count to the rentalDayCount util', () => {
+    expect(block).toMatch(/rentalDayCount\(/)
+  })
+
+  it('feeds rentalDayCount full datetimes built from date + selected hour', () => {
+    expect(block).toMatch(/toDatetime\(/)
+    expect(block).toContain('selectedPickupHour.value')
+    expect(block).toContain('selectedReturnHour.value')
+  })
+
+  it('no longer relies on the calendar-day + abs(hour) heuristic', () => {
+    expect(block).not.toMatch(/dayDifference\(/)
+    expect(block).not.toMatch(/selectedHours\.value/)
+  })
+
+  it('imports rentalDayCount and no longer imports the dropped date helpers', () => {
+    expect(source).toMatch(/rentalDayCount/)
+    expect(source).not.toMatch(/\bdayDifference\b/)
+    expect(source).not.toMatch(/\bhourDifference\b/)
+  })
+})

--- a/packages/logic/src/stores/useStoreReservationForm.ts
+++ b/packages/logic/src/stores/useStoreReservationForm.ts
@@ -15,8 +15,7 @@ import {
   createCurrentDateObject,
   createDateFromString,
   createTimeFromString,
-  dayDifference,
-  hourDifference,
+  rentalDayCount,
   formatHumanDate,
   formatHumanTime,
   toDatetime,
@@ -159,25 +158,19 @@ const useStoreReservationForm = defineStore("reservationForm", () => {
   );
 
   const selectedDays = computed<number>(() => {
-    let days = 0;
-    let hours = selectedHours.value;
+    const pickupDate = selectedPickupDate.value;
+    const returnDate = selectedReturnDate.value;
+    if (!pickupDate || !returnDate) return 0;
 
-    if (selectedPickupDate.value && selectedReturnDate.value) {
-      days = dayDifference(selectedPickupDate.value, selectedReturnDate.value);
-      if (days == 0) {
-        if (hours > 0) days = 1;
-      } else if (days > 0 && hours > 4) {
-        days++;
-      }
-    }
+    // Anchor each calendar date to its selected time-of-day (midnight when an
+    // hour isn't picked yet) so the count reflects the real rental window, not
+    // just the calendar-day gap. Mirrors the pickup/return datetimes the admin
+    // backend prices against.
+    const midnight = createTimeFromString('00:00');
+    const pickupAt = toDatetime(pickupDate, selectedPickupHour.value ?? midnight);
+    const returnAt = toDatetime(returnDate, selectedReturnHour.value ?? midnight);
 
-    return days;
-  });
-
-  const selectedHours = computed<number>(() => {
-    return selectedPickupHour.value && selectedReturnHour.value
-      ? hourDifference(selectedPickupHour.value, selectedReturnHour.value)
-      : 0;
+    return rentalDayCount(pickupAt, returnAt);
   });
 
   const minPickupDate = computed<DateObject>(() => {

--- a/packages/logic/src/utils/__tests__/rentalDayCount.test.ts
+++ b/packages/logic/src/utils/__tests__/rentalDayCount.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+
+// Scenarios: docs/specs/issue-99-search-copy-day-count/scenarios/search-copy-day-count.scenarios.md
+//
+// rentalDayCount counts billable rental days between two datetimes. It bills
+// each full 24h block plus one extra day when the leftover exceeds a 4h grace
+// window, with a minimum of 1 day for any positive duration. This replaces the
+// calendar-day + abs(hour-of-day) heuristic that over-counted by one day when
+// the return time-of-day was earlier than pickup (issue #99).
+
+import { createDateTimeFromString, rentalDayCount } from '../useDateFunctions'
+
+const dt = (iso: string) => createDateTimeFromString(iso)
+
+describe('rentalDayCount', () => {
+  it('SCEN-001: 12pm → 5am next day (17h) counts 1 day, not 2', () => {
+    expect(rentalDayCount(dt('2026-06-03T12:00:00'), dt('2026-06-04T05:00:00'))).toBe(1)
+  })
+
+  it('SCEN-002: exactly 24h counts 1 day', () => {
+    expect(rentalDayCount(dt('2026-06-03T12:00:00'), dt('2026-06-04T12:00:00'))).toBe(1)
+  })
+
+  it('SCEN-003: 29h (leftover 5h > grace) counts 2 days', () => {
+    expect(rentalDayCount(dt('2026-06-03T12:00:00'), dt('2026-06-04T17:00:00'))).toBe(2)
+  })
+
+  it('SCEN-004: same day 9h counts 1 day', () => {
+    expect(rentalDayCount(dt('2026-06-03T08:00:00'), dt('2026-06-03T17:00:00'))).toBe(1)
+  })
+
+  it('SCEN-005: same day 2h counts 1 day (minimum)', () => {
+    expect(rentalDayCount(dt('2026-06-03T08:00:00'), dt('2026-06-03T10:00:00'))).toBe(1)
+  })
+
+  it('SCEN-006: 28h with leftover exactly 4h stays 1 day (grace is strictly > 4h)', () => {
+    expect(rentalDayCount(dt('2026-06-03T12:00:00'), dt('2026-06-04T16:00:00'))).toBe(1)
+  })
+
+  it('SCEN-006b: 28h01m (leftover just over grace) counts 2 days', () => {
+    expect(rentalDayCount(dt('2026-06-03T12:00:00'), dt('2026-06-04T16:01:00'))).toBe(2)
+  })
+
+  it('SCEN-007: 30-day monthly rental counts 30 days', () => {
+    expect(rentalDayCount(dt('2026-06-01T12:00:00'), dt('2026-07-01T12:00:00'))).toBe(30)
+  })
+
+  it('SCEN-008: identical pickup/return counts 0 days', () => {
+    expect(rentalDayCount(dt('2026-06-03T12:00:00'), dt('2026-06-03T12:00:00'))).toBe(0)
+  })
+
+  it('SCEN-008b: return before pickup counts 0 days', () => {
+    expect(rentalDayCount(dt('2026-06-04T12:00:00'), dt('2026-06-03T12:00:00'))).toBe(0)
+  })
+})

--- a/packages/logic/src/utils/useDateFunctions.ts
+++ b/packages/logic/src/utils/useDateFunctions.ts
@@ -136,6 +136,38 @@ export function hourDifference(
     else return 0;
 }
 
+/**
+ * Counts billable rental days between two datetimes.
+ *
+ * Bills each full 24h block, plus one extra day when the leftover beyond the
+ * last full block exceeds a 4h grace window. Any positive duration bills at
+ * least one day. Returns 0 when the return is not strictly after the pickup.
+ *
+ * Replaces the prior calendar-day + abs(hour-of-day) heuristic, which
+ * over-counted by one day when the return time-of-day was earlier than pickup
+ * (e.g. 12 p. m. → 5 a. m. next day = 17 h was counted as 2 days). See issue #99.
+ *
+ * @param pickup pickup datetime
+ * @param return_ return datetime
+ * @returns number of billable days
+ */
+export function rentalDayCount(
+    pickup: DateTimeObject,
+    return_: DateTimeObject,
+): number {
+    const GRACE_HOURS = 4;
+    const totalHours =
+        (return_.toDate('UTC').getTime() - pickup.toDate('UTC').getTime()) / (1000 * 60 * 60);
+
+    if (totalHours <= 0) return 0;
+
+    const fullDays = Math.floor(totalHours / 24);
+    const leftoverHours = totalHours - fullDays * 24;
+    const days = fullDays + (leftoverHours > GRACE_HOURS ? 1 : 0);
+
+    return days === 0 ? 1 : days;
+}
+
 export function isTimeObject(obj: TimeObject | DateTimeObject | null): obj is TimeObject {
     return obj !== null && !('toDate' in obj)
 }


### PR DESCRIPTION
## Qué

Corrige el conteo de días en la función de copia (icono de pin junto al buscador de disponibilidad). Cuando la hora de devolución era más temprana en el día que la de recogida y la duración real era menor a 24 h, el texto mostraba **un día de más**.

Reproducción: recogida 3 jun 12:00 p. m., devolución 4 jun 5:00 a. m. (17 h reales) → mostraba `🗓 2 días`, ahora `🗓 1 día`.

## Causa raíz

`selectedDays` (`packages/logic/src/stores/useStoreReservationForm.ts`) combinaba:
1. `dayDifference` sobre fechas-a-medianoche → diferencia de **calendario** (3 jun → 4 jun = 1), no duración real.
2. `selectedHours` → `hourDifference` sobre `TimeObject` = `Math.abs(returnHour − pickupHour)`. El **valor absoluto perdía el signo**: 12 p. m. → 5 a. m. daba `|5−12| = 7 h`, disparando `days++` aunque el alquiler durara 17 h.

## Cambio

- Nueva función pura `rentalDayCount(pickup, return)` en `useDateFunctions.ts`: calcula desde las fecha-hora completas (bloques de 24 h + ventana de gracia estricta de 4 h, mínimo 1 día). Es la misma fuente que el backend usa para tarifar (`pickupDateTime`/`returnDateTime`).
- `selectedDays` delega en ella usando `toDatetime(fecha, hora)`.
- Se eliminan el computed `selectedHours` (sin otros consumidores) y los imports muertos `dayDifference`/`hourDifference`.

## Alcance

`selectedDays` alimenta: texto de copia (el bug), detección mensual (`== 30`), registro analítico (`selected_days`) y filtro de horas mensual. **El precio al cliente no se ve afectado** — lo calcula el backend desde los datetimes, no desde este valor. `selectedHours`/`hourDifference` se usaban solo dentro de `selectedDays`, así que el cambio queda contenido al conteo de días.

## Verificación

- `pnpm --filter @rentacar-main/logic test` → **278/278** (estable en 2 corridas)
- Red-green: sin el fix los 14 tests nuevos fallan; con el fix pasan
- `pnpm --filter ui-alquilame typecheck` → **202 → 201** errores (delta −1, cero nuevos; los restantes son baseline pre-existente)
- Barrido exhaustivo (86.401 casos a resolución de minuto, 0–60 días) sin divergencia de redondeo; UTC en ambos extremos evita skew de zona horaria
- code-reviewer + edge-case-detector: aprobado; detección mensual `== 30` preservada (y corregida en casos de 30 días que antes daban 31)

## Escenarios

Holdout en `docs/specs/issue-99-search-copy-day-count/scenarios/` — 9 escenarios (17 h→1, 24 h→1, 29 h→2, mismo día→1, gracia exacta 28 h→1, mensual 30 d→30, devolución ≤ recogida→0, singular/plural).

Closes #99
