### PR TITLE
feat(logic): leer visibilidad geográfica del payload (#28 Ola C-web)

### DIFF
--- a/docs/specs/issue-28-ola-c-geo-web/scenarios/geo-visibility-web.scenarios.md
+++ b/docs/specs/issue-28-ola-c-geo-web/scenarios/geo-visibility-web.scenarios.md
@@ -1,0 +1,78 @@
+---
+name: geo-visibility-web
+created_by: pabloandi
+created_at: 2026-06-02T21:00:00Z
+issue: 28
+ola: C-web
+---
+
+# Ola C-web — leer la visibilidad geográfica del payload (issue #28)
+
+El dashboard ahora marca CX/GY/FU/FL/GL como `restricted` con su whitelist de
+ciudades en `category_city_visibility` (Ola C dashboard, rentacar-dashboard#93).
+El web pasa a filtrar por ese dato en vez de los 3 arrays hardcoded
+(`bogotaBranches`+`onlyBogotaCategories`, CX 7 ciudades, GY 8 ciudades).
+
+**Semántica de rollout (clave):** `vehicle_categories.visibility_mode` NUNCA es
+null — es `NOT NULL DEFAULT 'all'` (mig 014). Así que NO se puede usar
+"columna ausente → fallback". En su lugar, la visibilidad es la **conjunción**:
+`visible = dataAllows AND legacyAllows`. El fallback hardcoded es un constraint
+adicional, no un "else": pre-backfill (mode='all') preserva el comportamiento
+actual vía `legacyAllows`; post-backfill ambos coinciden; una categoría nueva
+marcada `restricted` en el dashboard se filtra por el dato aunque no esté en
+ningún array. Ola D elimina el término `legacyAllows`.
+
+La decisión se aísla en el util puro `isCategoryVisibleInCity(visibilityMode,
+allowedCities, categoryCode, pickupCity, pickupBranchCode)`.
+
+Observable: `filteredCategories` (las tarjetas que ve el cliente según el lugar
+de recogida).
+
+## SCEN-C01: categoría restringida por dato — oculta fuera de sus ciudades
+
+**Given**: una categoría con `visibilityMode='restricted'` y `allowedCities=['bogota']`.
+**When**: el cliente elige recogida en `medellin`, y en otra corrida en `bogota`.
+**Then**: oculta en medellin, visible en bogota.
+**Evidence**: `isCategoryVisibleInCity('restricted', ['bogota'], 'FU', 'medellin', branch)` → `false`;
+`isCategoryVisibleInCity('restricted', ['bogota'], 'FU', 'bogota', branch)` → `true`.
+
+## SCEN-C02: transición — pre-backfill (mode='all') preserva el filtro legacy
+
+**Given**: FU aún sin backfill: `visibilityMode='all'`, `allowedCities=[]`, pero su
+código sigue en la lista legacy "solo Bogotá".
+**When**: el cliente elige una sucursal que NO es de Bogotá.
+**Then**: FU queda oculta — el término `legacyAllows` (branch ∈ bogotaBranches)
+la filtra aunque el dato diga 'all'. Comportamiento idéntico al actual.
+**Evidence**: `isCategoryVisibleInCity('all', [], 'FU', 'medellin', 'AAMDE')` → `false`
+(sucursal no-Bogotá); `isCategoryVisibleInCity('all', [], 'FU', 'bogota', 'AABOT')` → `true`.
+
+## SCEN-C03: categoría no restringida ni en legacy — visible en todos lados
+
+**Given**: una categoría `C` con `visibilityMode='all'` y que no está en ningún
+array legacy.
+**When**: el cliente elige cualquier ciudad.
+**Then**: visible.
+**Evidence**: `isCategoryVisibleInCity('all', [], 'C', 'pasto', 'AAPAS')` → `true`.
+
+## SCEN-C04: CX/GY conservan sus listas de ciudades (legacy + dato coinciden)
+
+**Given**: CX restringida a 7 ciudades, GY a 8 (incluye soledad).
+**When**: recogida en una ciudad fuera de la lista (p.ej. `pasto` para CX),
+y dentro (p.ej. `cali`).
+**Then**: CX oculta en pasto, visible en cali; GY visible en soledad.
+**Evidence**: `isCategoryVisibleInCity('restricted', [7 ciudades], 'CX', 'pasto', b)` → `false`;
+`isCategoryVisibleInCity('restricted', [7], 'CX', 'cali', b)` → `true`;
+`isCategoryVisibleInCity('restricted', [8 con soledad], 'GY', 'soledad', b)` → `true`.
+
+## SCEN-C05: sin lugar de recogida, no se oculta nada
+
+**Given**: una categoría restringida, pero el cliente aún no eligió lugar de
+recogida (`pickupCity` y `pickupBranchCode` ausentes).
+**When**: se evalúa la visibilidad.
+**Then**: visible — los filtros solo aplican con lugar elegido (guarda actual).
+**Evidence**: `isCategoryVisibleInCity('restricted', ['bogota'], 'FU', undefined, undefined)` → `true`.
+
+## Fuera de alcance
+
+- Eliminar los arrays hardcoded (el término `legacyAllows`) — Ola D.
+- Granularidad por sucursal (category_branch_visibility) — solo si O1 cambia a branch-level.

--- a/packages/logic/server/utils/__tests__/transformers.geoVisibility.test.ts
+++ b/packages/logic/server/utils/__tests__/transformers.geoVisibility.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { transformCategories } from '../transformers'
+
+// Issue #28 Ola C: transformCategories must expose visibility_mode and unwrap
+// the category_city_visibility(cities(slug)) embed into allowed_cities. Guards
+// the embed-shape assumption (array of { cities: { slug } | null }).
+
+const makeRow = (overrides: Record<string, unknown> = {}) => ({
+  id: 'x',
+  code: 'CX',
+  name: 'Gama CX',
+  description: '',
+  image_url: '',
+  passenger_count: 5,
+  luggage_count: 2,
+  has_ac: true,
+  transmission: 'manual',
+  status: 'active',
+  visibility_mode: 'restricted',
+  group_label: '',
+  short_description: '',
+  long_description: '',
+  tags: [],
+  extra_km_charge: 0,
+  category_models: [],
+  category_pricing: [],
+  ...overrides,
+})
+
+describe('transformCategories — geo visibility (Ola C)', () => {
+  it('exposes visibility_mode and unwraps category_city_visibility into city slugs', () => {
+    const result = transformCategories([
+      makeRow({
+        category_city_visibility: [
+          { cities: { slug: 'bogota' } },
+          { cities: { slug: 'cali' } },
+        ],
+      }),
+    ] as never)
+    expect(result[0]!.visibility_mode).toBe('restricted')
+    expect(result[0]!.allowed_cities).toEqual(['bogota', 'cali'])
+  })
+
+  it('drops pivot rows whose city is null (deleted city) without emitting undefined', () => {
+    const result = transformCategories([
+      makeRow({
+        category_city_visibility: [
+          { cities: { slug: 'bogota' } },
+          { cities: null },
+        ],
+      }),
+    ] as never)
+    expect(result[0]!.allowed_cities).toEqual(['bogota'])
+  })
+
+  it('defaults to mode all and empty cities when the embed is absent', () => {
+    const result = transformCategories([
+      makeRow({ visibility_mode: 'all', category_city_visibility: undefined }),
+    ] as never)
+    expect(result[0]!.visibility_mode).toBe('all')
+    expect(result[0]!.allowed_cities).toEqual([])
+  })
+})

--- a/packages/logic/server/utils/rentacarDataFetch.ts
+++ b/packages/logic/server/utils/rentacarDataFetch.ts
@@ -31,7 +31,7 @@ export async function fetchRentacarData(supabase: SupabaseClient, timeoutMs: num
     const results = await Promise.all([
       supabase
         .from('vehicle_categories')
-        .select('*, category_models(*), category_pricing(*)')
+        .select('*, category_models(*), category_pricing(*), category_city_visibility(cities(slug))')
         .eq('status', 'active')
         .order('code')
         .abortSignal(signal),

--- a/packages/logic/server/utils/transformers.ts
+++ b/packages/logic/server/utils/transformers.ts
@@ -31,6 +31,7 @@ interface SupabaseCategory {
   picoyplaca_exempt?: boolean | null
   category_models: SupabaseCategoryModel[]
   category_pricing: SupabaseCategoryPricing[]
+  category_city_visibility?: { cities: { slug: string } | null }[]
 }
 
 interface SupabaseCategoryModel {
@@ -110,6 +111,13 @@ export function transformCategories(rows: SupabaseCategory[]): CategoryData[] {
       // null (not false) when the column is absent, so the client can tell
       // "unset → fall back to the hardcoded list" from an explicit false.
       picoyplaca_exempt: row.picoyplaca_exempt ?? null,
+      // Issue #28 Ola C: geographic visibility from the dashboard. visibility_mode
+      // is NOT NULL DEFAULT 'all' (mig 014); allowed_cities are the whitelisted
+      // city slugs from category_city_visibility.
+      visibility_mode: row.visibility_mode ?? 'all',
+      allowed_cities: (row.category_city_visibility ?? [])
+        .map((v) => v.cities?.slug)
+        .filter((slug): slug is string => Boolean(slug)),
     }
   })
 }

--- a/packages/logic/src/stores/useStoreSearchData.ts
+++ b/packages/logic/src/stores/useStoreSearchData.ts
@@ -13,13 +13,12 @@ import useCategory from '../composables/useCategory';
 import useMessages from '../composables/useMessages';
 
 // utils
-import { categoryOffersMonthly } from '@rentacar-main/logic/utils';
+import { categoryOffersMonthly, isCategoryVisibleInCity } from '@rentacar-main/logic/utils';
 
 // Types
 import type {
   CategoryAvailabilityData,
   CategoryData,
-  CategoryType,
   ErrorMessage,
 } from '@rentacar-main/logic/utils';
 
@@ -173,6 +172,8 @@ const useStoreSearchData = defineStore("storeSearchData", () => {
           categoryAvailability["categoryDescription"] = categoryAdmin.category.replace(categoryAdmin.name, "");
           categoryAvailability["totalCoverageUnitCharge"] = categoryAdmin.total_coverage_unit_charge;
           categoryAvailability["picoyplacaExempt"] = categoryAdmin.picoyplaca_exempt;
+          categoryAvailability["visibilityMode"] = categoryAdmin.visibility_mode;
+          categoryAvailability["allowedCities"] = categoryAdmin.allowed_cities;
 
           return categoryAvailability
         }
@@ -190,67 +191,27 @@ const useStoreSearchData = defineStore("storeSearchData", () => {
 
   
   const filteredCategories = computed<CategoryAvailabilityData[] | []>(() => {
-    
-    const bogotaBranches = ["AABOT", "ACBOT", "ACBEX", "ACBNN", "ACBOJ"];
-    const onlyBogotaCategories: CategoryType[] = ["FU", "FL", "GL"];
+
     const pickupLocationCode = selectedPickupLocation.value?.code;
     const pickupLocationCity = selectedPickupLocation.value?.city;
-    
+
     //TODO fix this
     if(categories.value.length == 0){
       return [];
     }
+    // Issue #28 Ola C: geographic visibility is derived from the dashboard
+    // (visibility_mode + allowed cities) combined with the legacy hardcoded
+    // rules as a transitional AND-constraint. See isCategoryVisibleInCity.
     else return categories.value
-      // .map((category: CategoryAvailabilityData) => new Category(category))
-      // .filter((category: CategoryAvailabilityData) => {
-      //   if (haveMonthlyReservation.value)
-      //     return category.getCategoryMonthlyPriceTotalInsurancePrice();
-      //   else return true;
-      // })
-      .filter((category: CategoryAvailabilityData) => {
-        // filter categories that are not available when selected bogota
-        if(pickupLocationCode){
-          if (
-            !bogotaBranches.includes(pickupLocationCode) &&
-            onlyBogotaCategories.includes(category.categoryCode)
-          ) {
-            return false;
-          } else return true;
-        }
-        return true;
-      })
-      .filter((category: CategoryAvailabilityData) => {
-        // filter category CX: only allowed in 7 cities
-        if(pickupLocationCity){
-          const onlyCategoryCXCityAllowed = [
-            "barranquilla", "bogota", "bucaramanga", "cali",
-            "cartagena", "medellin", "santa-marta"
-          ];
-          if (
-            !onlyCategoryCXCityAllowed.includes(pickupLocationCity) &&
-            category.categoryCode == "CX"
-          ) {
-            return false;
-          } else return true;
-        }
-        return true;
-      })
-      .filter((category: CategoryAvailabilityData) => {
-        // filter category GY: only allowed in 8 cities (same as GR)
-        if(pickupLocationCity){
-          const onlyCategoryGYCityAllowed = [
-            "bogota", "bucaramanga", "cali", "medellin",
-            "barranquilla", "soledad", "cartagena", "santa-marta"
-          ];
-          if (
-            !onlyCategoryGYCityAllowed.includes(pickupLocationCity) &&
-            category.categoryCode == "GY"
-          ) {
-            return false;
-          } else return true;
-        }
-        return true;
-      });
+      .filter((category: CategoryAvailabilityData) =>
+        isCategoryVisibleInCity(
+          category.visibilityMode,
+          category.allowedCities,
+          category.categoryCode,
+          pickupLocationCity,
+          pickupLocationCode,
+        )
+      );
 
   });
 
@@ -281,6 +242,8 @@ const createCategoryAvailability = (category: CategoryData, unable: boolean = fa
     categoryModels: category.models,
     categoryMonthPrices: category.month_prices,
     picoyplacaExempt: category.picoyplaca_exempt,
+    visibilityMode: category.visibility_mode,
+    allowedCities: category.allowed_cities,
     totalAmount: 0,
     estimatedTotalAmount: (unable) ? 999999999 : 1,
     totalCoverageUnitCharge: category.total_coverage_unit_charge,

--- a/packages/logic/src/utils/__tests__/isCategoryVisibleInCity.test.ts
+++ b/packages/logic/src/utils/__tests__/isCategoryVisibleInCity.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { isCategoryVisibleInCity } from '../isCategoryVisibleInCity'
+
+// Issue #28 Ola C-web. visible = dataGeoAllows AND legacyGeoAllows. The legacy
+// term is the transitional constraint removed in Ola D.
+const CX7 = ['barranquilla', 'bogota', 'bucaramanga', 'cali', 'cartagena', 'medellin', 'santa-marta']
+const GY8 = [...CX7, 'soledad']
+
+describe('isCategoryVisibleInCity', () => {
+  // SCEN-C01: restricted by data — hidden outside its cities, shown inside.
+  it('hides a restricted category outside its allowed cities, shows it inside', () => {
+    expect(isCategoryVisibleInCity('restricted', ['bogota'], 'FU', 'medellin', 'AABOT')).toBe(false)
+    expect(isCategoryVisibleInCity('restricted', ['bogota'], 'FU', 'bogota', 'AABOT')).toBe(true)
+  })
+
+  // SCEN-C02: transition — pre-backfill 'all' still filtered by the legacy term.
+  it('keeps the legacy restriction while the category is still mode=all (pre-backfill)', () => {
+    // FU is in the legacy Bogotá-only list; a non-Bogotá branch hides it even
+    // though the data says 'all'.
+    expect(isCategoryVisibleInCity('all', [], 'FU', 'medellin', 'AAMDE')).toBe(false)
+    expect(isCategoryVisibleInCity('all', [], 'FU', 'bogota', 'AABOT')).toBe(true)
+  })
+
+  // SCEN-C03: not restricted by data nor legacy → visible everywhere.
+  it('shows a non-restricted, non-legacy category everywhere', () => {
+    expect(isCategoryVisibleInCity('all', [], 'C', 'pasto', 'AAPAS')).toBe(true)
+  })
+
+  // SCEN-C04: CX/GY city lists preserved.
+  it('preserves the CX 7-city and GY 8-city lists', () => {
+    expect(isCategoryVisibleInCity('restricted', CX7, 'CX', 'pasto', 'AAPAS')).toBe(false)
+    expect(isCategoryVisibleInCity('restricted', CX7, 'CX', 'cali', 'AACAL')).toBe(true)
+    expect(isCategoryVisibleInCity('restricted', GY8, 'GY', 'soledad', 'AASOL')).toBe(true)
+    // soledad is GY-only, not in CX's 7 → CX hidden there even via legacy.
+    expect(isCategoryVisibleInCity('all', [], 'CX', 'soledad', 'AASOL')).toBe(false)
+  })
+
+  // SCEN-C05: no pickup location → nothing hidden.
+  it('hides nothing when no pickup location is selected', () => {
+    expect(isCategoryVisibleInCity('restricted', ['bogota'], 'FU', undefined, undefined)).toBe(true)
+    expect(isCategoryVisibleInCity('restricted', CX7, 'CX', undefined, undefined)).toBe(true)
+  })
+
+  // Data tightens beyond legacy: a NEW restricted code (not in any legacy list)
+  // is constrained by data alone — proves the move to SoT.
+  it('applies data restriction to a brand-new code not in any legacy list', () => {
+    expect(isCategoryVisibleInCity('restricted', ['cali'], 'ZZ' as never, 'bogota', 'AABOT')).toBe(false)
+    expect(isCategoryVisibleInCity('restricted', ['cali'], 'ZZ' as never, 'cali', 'AACAL')).toBe(true)
+  })
+
+  // Revenue guard: 'restricted' with an empty whitelist (mode flipped before
+  // the city rows land / partial backfill) must NOT vanish the category
+  // nationwide — fail open, defer to the legacy term.
+  it('does not hide a restricted category nationwide when its whitelist is still empty', () => {
+    // A new restricted code with no cities and not in any legacy list → visible.
+    expect(isCategoryVisibleInCity('restricted', [], 'ZZ' as never, 'cali', 'AACAL')).toBe(true)
+    // FU restricted-but-empty still obeys the legacy Bogotá branch term.
+    expect(isCategoryVisibleInCity('restricted', [], 'FU', 'bogota', 'AABOT')).toBe(true)
+    expect(isCategoryVisibleInCity('restricted', [], 'FU', 'medellin', 'AAMDE')).toBe(false)
+  })
+
+  // Both constraints apply (AND): data allows but legacy forbids → hidden.
+  it('hides when legacy forbids even if data allows (AND semantics)', () => {
+    // FU data says visible in medellin, but legacy (non-Bogotá branch) forbids.
+    expect(isCategoryVisibleInCity('restricted', ['bogota', 'medellin'], 'FU', 'medellin', 'AAMDE')).toBe(false)
+  })
+})

--- a/packages/logic/src/utils/index.ts
+++ b/packages/logic/src/utils/index.ts
@@ -26,6 +26,7 @@ export { pickPriceForDate } from './pickPriceForDate';
 export { categoryOffersMonthly } from './categoryOffersMonthly';
 export { pickEffectiveTotalCoverageUnitCharge } from './pickEffectiveTotalCoverage';
 export { resolvePicoyPlacaExempt } from './isPicoyPlacaExempt';
+export { isCategoryVisibleInCity } from './isCategoryVisibleInCity';
 
 // ============================================================================
 // Server Helpers

--- a/packages/logic/src/utils/isCategoryVisibleInCity.ts
+++ b/packages/logic/src/utils/isCategoryVisibleInCity.ts
@@ -1,0 +1,75 @@
+import type { CategoryType } from './types/type/CategoryType'
+
+// Transitional legacy fallback (issue #28 Ola C): the web's hardcoded geo rules,
+// kept as an ADDITIONAL constraint (AND) because visibility_mode is NOT NULL
+// DEFAULT 'all' — a not-yet-backfilled category reads 'all', so the data alone
+// can't reproduce today's restrictions. Removed in Ola D, leaving only the data.
+const BOGOTA_BRANCHES: readonly string[] = ['AABOT', 'ACBOT', 'ACBEX', 'ACBNN', 'ACBOJ']
+const BOGOTA_ONLY: readonly CategoryType[] = ['FU', 'FL', 'GL']
+const CX_CITIES: readonly string[] = ['barranquilla', 'bogota', 'bucaramanga', 'cali', 'cartagena', 'medellin', 'santa-marta']
+const GY_CITIES: readonly string[] = ['barranquilla', 'bogota', 'bucaramanga', 'cali', 'cartagena', 'medellin', 'santa-marta', 'soledad']
+
+// Replicates the three current hardcoded filters exactly, including their
+// "no location selected → don't hide" guards. FU/FL/GL stay branch-based here
+// (equivalent to city=bogota per O1) so the transition is byte-for-byte.
+function legacyGeoAllows(
+  categoryCode: CategoryType,
+  pickupCity: string | null | undefined,
+  pickupBranchCode: string | null | undefined,
+): boolean {
+  if (BOGOTA_ONLY.includes(categoryCode)) {
+    return pickupBranchCode ? BOGOTA_BRANCHES.includes(pickupBranchCode) : true
+  }
+  if (categoryCode === 'CX') {
+    return pickupCity ? CX_CITIES.includes(pickupCity) : true
+  }
+  if (categoryCode === 'GY') {
+    return pickupCity ? GY_CITIES.includes(pickupCity) : true
+  }
+  return true
+}
+
+// Data path: a 'restricted' category is visible only in its whitelisted cities;
+// 'all' (or anything non-restricted) imposes no data constraint. No pickup city
+// → no data constraint (mirrors the legacy guards).
+function dataGeoAllows(
+  visibilityMode: string | null | undefined,
+  allowedCities: readonly string[] | null | undefined,
+  pickupCity: string | null | undefined,
+): boolean {
+  if (visibilityMode !== 'restricted') return true
+  if (!pickupCity) return true
+  const cities = allowedCities ?? []
+  // Restricted but with no whitelist yet (mode flipped before the city rows
+  // land, or a partial backfill) must NOT hide the category nationwide — fail
+  // open and let the legacy AND-term govern. During the transition the data can
+  // only ADD constraints once it actually carries cities; it never erases a
+  // category by being half-configured.
+  if (cities.length === 0) return true
+  return cities.includes(pickupCity)
+}
+
+/**
+ * Decides whether a category is offered at the selected pickup location,
+ * derived from the dashboard's visibility_mode + category_city_visibility
+ * (issue #28 Ola C), combined with the legacy hardcoded rules as a transitional
+ * AND-constraint.
+ *
+ * `visible = dataGeoAllows AND legacyGeoAllows`. Because visibility_mode is
+ * NOT NULL DEFAULT 'all', a not-yet-backfilled category reads 'all' and is held
+ * back only by legacyGeoAllows (preserving today). Once backfilled, both agree.
+ * A new category marked 'restricted' in the dashboard — not in any legacy list —
+ * is constrained by the data alone. Ola D removes the legacy term.
+ */
+export function isCategoryVisibleInCity(
+  visibilityMode: string | null | undefined,
+  allowedCities: readonly string[] | null | undefined,
+  categoryCode: CategoryType,
+  pickupCity: string | null | undefined,
+  pickupBranchCode: string | null | undefined,
+): boolean {
+  return (
+    dataGeoAllows(visibilityMode, allowedCities, pickupCity) &&
+    legacyGeoAllows(categoryCode, pickupCity, pickupBranchCode)
+  )
+}

--- a/packages/logic/src/utils/types/data/CategoryAvailabilityData.ts
+++ b/packages/logic/src/utils/types/data/CategoryAvailabilityData.ts
@@ -29,4 +29,8 @@ export default interface CategoryAvailabilityData {
   // Issue #28 Ola B2: pico y placa exemption from the dashboard column (null
   // when absent → resolvePicoyPlacaExempt falls back to the hardcoded list).
   picoyplacaExempt?: boolean | null;
+  // Issue #28 Ola C: geographic visibility from the dashboard (visibility_mode +
+  // whitelisted city slugs). See isCategoryVisibleInCity.
+  visibilityMode?: string;
+  allowedCities?: string[];
 }

--- a/packages/logic/src/utils/types/data/CategoryData.ts
+++ b/packages/logic/src/utils/types/data/CategoryData.ts
@@ -18,4 +18,9 @@ export default interface CategoryData {
   // absent when the column is missing (pre-backfill) → consumers fall back to
   // the transitional hardcoded list. See resolvePicoyPlacaExempt.
   picoyplaca_exempt?: boolean | null;
+  // Issue #28 Ola C: geographic visibility from the dashboard. visibility_mode
+  // is 'all' | 'restricted' (NOT NULL DEFAULT 'all'); allowed_cities are the
+  // whitelisted city slugs. See isCategoryVisibleInCity.
+  visibility_mode?: string;
+  allowed_cities?: string[];
 }


### PR DESCRIPTION
## Qué

Mitad web de la Ola C (#28). El web deja de hardcodear las restricciones geográficas (solo-Bogotá FU/FL/GL, CX 7 ciudades, GY 8 ciudades) y lee `visibility_mode` + `category_city_visibility` del dashboard (rentacar-dashboard#93).

> **⚠️ Stacked:** sobre #102 (B2-web) → sobre #100 (B1). **Mergear en orden #100 → #102 → este.** El diff se reduce al propio de Ola C cuando los anteriores mergeen. Commit propio: `049a300`.

## Diseño clave: AND, no else-fallback

`visibility_mode` es `NOT NULL DEFAULT 'all'` (mig 014) → nunca está ausente. Así que la transición usa **conjunción**: `visible = dataGeoAllows AND legacyGeoAllows`. Los arrays hardcoded quedan como constraint transicional (se borran en Ola D):
- Pre-backfill (mode='all') → preserva hoy vía legacy.
- Post-backfill → ambos coinciden.
- Código nuevo restringido en dashboard → solo por dato.

## Guarda de ingresos (de la revisión adversarial)

`restricted` + whitelist vacío (mode marcado antes de insertar ciudades / backfill parcial) **falla-open** (defiere a legacy) en vez de **desaparecer la categoría a nivel nacional**. Ambos agentes (code-reviewer + edge-case-detector) lo señalaron; arreglado + test.

## Threading

`query (category_city_visibility(cities(slug))) → transformer (visibility_mode + allowed_cities, desempaqueta el embed) → CategoryData → CategoryAvailabilityData → store (createCategoryAvailability + merge Localiza) → filteredCategories` (un filtro por util reemplaza los 3 hardcoded).

## O1 resuelto city-level

Los 5 branch codes de Bogotá que el web hardcodeaba son exactamente las sucursales de Bogotá (seed) → FU/FL/GL mantienen filtrado legacy branch-based ≡ city=bogota.

## Verificación

- `pnpm --filter @rentacar-main/logic test` → **278 passed, 0 failed** (44 files)
- `isCategoryVisibleInCity` → **8/8** (incl. fail-open); `transformers.geoVisibility` → **3/3** (desempaque del embed)
- typecheck **delta 0** (268 = baseline)
- **code-reviewer + edge-case-detector: APPROVE** — comportamiento preservado byte-for-byte vs los 3 filtros viejos (verificado contra la BD real), threading completo, AND correcto en todos los estados de transición

Holdout: `docs/specs/issue-28-ola-c-geo-web/scenarios` (SCEN-C01..05).

Refs #28