### PR TITLE
refactor(logic): eliminar fallbacks transicionales geo/pico y placa (#28 Ola D)

### DIFF
--- a/docs/specs/issue-28-ola-d-remove-fallbacks/scenarios/remove-geo-picoyplaca-fallbacks.scenarios.md
+++ b/docs/specs/issue-28-ola-d-remove-fallbacks/scenarios/remove-geo-picoyplaca-fallbacks.scenarios.md
@@ -1,0 +1,58 @@
+---
+name: issue-28-ola-d-remove-fallbacks
+created_by: pablo
+created_at: 2026-06-03T00:00:00Z
+---
+
+# Issue #28 Ola D — remove transitional fallbacks
+
+Final wave of issue #28: the dashboard (Supabase) is now the SOLE source of truth
+for pico y placa exemption and geographic visibility. Migrations 053
+(`picoyplaca_exempt`) and 054 (geo backfill) are applied + verified in prod
+(2026-06-03), and prod render was validated on real data. These scenarios lock
+the end-state contract — the decision derives ONLY from dashboard data, with NO
+hardcoded category lists surviving in the web. Removing the fallbacks must not
+change the observable behavior for the backfilled categories, and must change it
+for the now-impossible "missing data" inputs (no silent hardcoded whitelist).
+
+## SCEN-D01: dashboard marks a gama exempt → badge shows
+**Given**: a category whose `picoyplaca_exempt` column arrives as `true`
+**When**: the web resolves its pico y placa exemption
+**Then**: it is exempt (the "sin pico y placa" badge renders)
+**Evidence**: `resolvePicoyPlacaExempt(true)` returns `true`; prod render shows FU/FL/GL/LU with "sin pico y placa" badge in Bogotá
+
+## SCEN-D02: dashboard revokes exemption on a historically-exempt gama → no badge
+**Given**: gama FU (hardcoded as exempt before Ola B2) whose `picoyplaca_exempt` column now arrives as `false`
+**When**: the web resolves its pico y placa exemption
+**Then**: it is NOT exempt — the column overrides any legacy whitelist, so no badge renders
+**Evidence**: `resolvePicoyPlacaExempt(false)` returns `false` (the old `EXEMPT_FALLBACK` whitelist no longer forces FU exempt)
+
+## SCEN-D03: exemption column absent → not exempt (no hardcoded fallback)
+**Given**: a category whose `picoyplaca_exempt` arrives as `null`/`undefined` (e.g. stale cache or a new category before save)
+**When**: the web resolves its pico y placa exemption
+**Then**: it is NOT exempt — there is no hardcoded list to fall back to; absence means "not exempt" (operators grant exemption explicitly in the dashboard)
+**Evidence**: `resolvePicoyPlacaExempt(null)` returns `false` and `resolvePicoyPlacaExempt(undefined)` returns `false`
+
+## SCEN-D04: visibility_mode 'all' → visible anywhere, even a historically Bogotá-only gama
+**Given**: gama FU (hardcoded Bogotá-only before Ola C) whose `visibility_mode` arrives as `'all'` with no city rows
+**When**: the web decides visibility for a Medellín pickup
+**Then**: it IS visible — `'all'` imposes no geographic constraint; the legacy BOGOTA_ONLY list no longer hides it
+**Evidence**: `isCategoryVisibleInCity('all', [], 'medellin')` returns `true`
+
+## SCEN-D05: restricted category visible only in its whitelisted cities
+**Given**: a category with `visibility_mode='restricted'` and `allowed_cities=['bogota']`
+**When**: the web decides visibility for different pickups
+**Then**: visible in Bogotá, hidden in Medellín — purely from the data, no category-code branching
+**Evidence**: `isCategoryVisibleInCity('restricted', ['bogota'], 'bogota')` returns `true`; `isCategoryVisibleInCity('restricted', ['bogota'], 'medellin')` returns `false`
+
+## SCEN-D06: restricted but unbackfilled cities → fail open (permanent revenue guard)
+**Given**: a category an operator marked `restricted` but for which no `allowed_cities` were added yet
+**When**: the web decides visibility for any pickup city
+**Then**: it stays visible nationwide — a half-configured restriction must never silently delist a sellable category; operators must populate cities to actually restrict
+**Evidence**: `isCategoryVisibleInCity('restricted', [], 'medellin')` returns `true`
+
+## SCEN-D07: no pickup city selected → don't hide
+**Given**: a `restricted` category and a search where no pickup city is resolved yet (`null`)
+**When**: the web decides visibility
+**Then**: it stays visible — visibility is only narrowed once a city is known
+**Evidence**: `isCategoryVisibleInCity('restricted', ['bogota'], null)` returns `true`

--- a/packages/logic/src/composables/useCategory.ts
+++ b/packages/logic/src/composables/useCategory.ts
@@ -94,10 +94,9 @@ export default function useCategory(categoryAvailableData: CategoryAvailabilityD
       return pickPriceForDate(categoryMonthPrices.value, fechaRecogida.value ?? '');
    };
    
-   // Issue #28 Ola B2: read the exemption from the dashboard column, with a
-   // transitional fallback to the hardcoded list (resolvePicoyPlacaExempt).
+   // Issue #28: pico y placa exemption comes solely from the dashboard column.
    const isPicoyPlacaExempt = (): boolean =>
-      resolvePicoyPlacaExempt(picoyplacaExempt.value, categoryCode.value);
+      resolvePicoyPlacaExempt(picoyplacaExempt.value);
    
    const hasReturnFee = (): boolean => returnFeeAmount.value ? true  : false;
    

--- a/packages/logic/src/stores/useStoreSearchData.ts
+++ b/packages/logic/src/stores/useStoreSearchData.ts
@@ -192,24 +192,20 @@ const useStoreSearchData = defineStore("storeSearchData", () => {
   
   const filteredCategories = computed<CategoryAvailabilityData[] | []>(() => {
 
-    const pickupLocationCode = selectedPickupLocation.value?.code;
     const pickupLocationCity = selectedPickupLocation.value?.city;
 
     //TODO fix this
     if(categories.value.length == 0){
       return [];
     }
-    // Issue #28 Ola C: geographic visibility is derived from the dashboard
-    // (visibility_mode + allowed cities) combined with the legacy hardcoded
-    // rules as a transitional AND-constraint. See isCategoryVisibleInCity.
+    // Issue #28: geographic visibility is derived solely from the dashboard
+    // (visibility_mode + allowed cities). See isCategoryVisibleInCity.
     else return categories.value
       .filter((category: CategoryAvailabilityData) =>
         isCategoryVisibleInCity(
           category.visibilityMode,
           category.allowedCities,
-          category.categoryCode,
           pickupLocationCity,
-          pickupLocationCode,
         )
       );
 

--- a/packages/logic/src/utils/__tests__/isCategoryVisibleInCity.test.ts
+++ b/packages/logic/src/utils/__tests__/isCategoryVisibleInCity.test.ts
@@ -1,67 +1,36 @@
 import { describe, it, expect } from 'vitest'
 import { isCategoryVisibleInCity } from '../isCategoryVisibleInCity'
 
-// Issue #28 Ola C-web. visible = dataGeoAllows AND legacyGeoAllows. The legacy
-// term is the transitional constraint removed in Ola D.
-const CX7 = ['barranquilla', 'bogota', 'bucaramanga', 'cali', 'cartagena', 'medellin', 'santa-marta']
-const GY8 = [...CX7, 'soledad']
+// Issue #28 Ola D. Geographic visibility now derives SOLELY from the dashboard
+// (visibility_mode + category_city_visibility). The transitional legacy hardcoded
+// lists (BOGOTA_ONLY/CX_CITIES/GY_CITIES + branch codes) are gone — no
+// category-code branching remains.
 
 describe('isCategoryVisibleInCity', () => {
-  // SCEN-C01: restricted by data — hidden outside its cities, shown inside.
-  it('hides a restricted category outside its allowed cities, shows it inside', () => {
-    expect(isCategoryVisibleInCity('restricted', ['bogota'], 'FU', 'medellin', 'AABOT')).toBe(false)
-    expect(isCategoryVisibleInCity('restricted', ['bogota'], 'FU', 'bogota', 'AABOT')).toBe(true)
+  // SCEN-D04: 'all' imposes no geographic constraint, even for a gama that used
+  // to be hardcoded Bogotá-only.
+  it('shows a mode=all category anywhere (no legacy Bogotá-only restriction)', () => {
+    expect(isCategoryVisibleInCity('all', [], 'medellin')).toBe(true)
+    expect(isCategoryVisibleInCity('all', [], 'pasto')).toBe(true)
   })
 
-  // SCEN-C02: transition — pre-backfill 'all' still filtered by the legacy term.
-  it('keeps the legacy restriction while the category is still mode=all (pre-backfill)', () => {
-    // FU is in the legacy Bogotá-only list; a non-Bogotá branch hides it even
-    // though the data says 'all'.
-    expect(isCategoryVisibleInCity('all', [], 'FU', 'medellin', 'AAMDE')).toBe(false)
-    expect(isCategoryVisibleInCity('all', [], 'FU', 'bogota', 'AABOT')).toBe(true)
+  // SCEN-D05: restricted → visible only in its whitelisted cities, purely from data.
+  it('shows a restricted category only in its allowed cities', () => {
+    expect(isCategoryVisibleInCity('restricted', ['bogota'], 'bogota')).toBe(true)
+    expect(isCategoryVisibleInCity('restricted', ['bogota'], 'medellin')).toBe(false)
+    expect(isCategoryVisibleInCity('restricted', ['cali', 'medellin'], 'medellin')).toBe(true)
+    expect(isCategoryVisibleInCity('restricted', ['cali', 'medellin'], 'bogota')).toBe(false)
   })
 
-  // SCEN-C03: not restricted by data nor legacy → visible everywhere.
-  it('shows a non-restricted, non-legacy category everywhere', () => {
-    expect(isCategoryVisibleInCity('all', [], 'C', 'pasto', 'AAPAS')).toBe(true)
+  // SCEN-D06: restricted but no cities yet → fail open (permanent revenue guard).
+  it('keeps a restricted-but-unbackfilled category visible nationwide (fail open)', () => {
+    expect(isCategoryVisibleInCity('restricted', [], 'medellin')).toBe(true)
+    expect(isCategoryVisibleInCity('restricted', null, 'bogota')).toBe(true)
   })
 
-  // SCEN-C04: CX/GY city lists preserved.
-  it('preserves the CX 7-city and GY 8-city lists', () => {
-    expect(isCategoryVisibleInCity('restricted', CX7, 'CX', 'pasto', 'AAPAS')).toBe(false)
-    expect(isCategoryVisibleInCity('restricted', CX7, 'CX', 'cali', 'AACAL')).toBe(true)
-    expect(isCategoryVisibleInCity('restricted', GY8, 'GY', 'soledad', 'AASOL')).toBe(true)
-    // soledad is GY-only, not in CX's 7 → CX hidden there even via legacy.
-    expect(isCategoryVisibleInCity('all', [], 'CX', 'soledad', 'AASOL')).toBe(false)
-  })
-
-  // SCEN-C05: no pickup location → nothing hidden.
-  it('hides nothing when no pickup location is selected', () => {
-    expect(isCategoryVisibleInCity('restricted', ['bogota'], 'FU', undefined, undefined)).toBe(true)
-    expect(isCategoryVisibleInCity('restricted', CX7, 'CX', undefined, undefined)).toBe(true)
-  })
-
-  // Data tightens beyond legacy: a NEW restricted code (not in any legacy list)
-  // is constrained by data alone — proves the move to SoT.
-  it('applies data restriction to a brand-new code not in any legacy list', () => {
-    expect(isCategoryVisibleInCity('restricted', ['cali'], 'ZZ' as never, 'bogota', 'AABOT')).toBe(false)
-    expect(isCategoryVisibleInCity('restricted', ['cali'], 'ZZ' as never, 'cali', 'AACAL')).toBe(true)
-  })
-
-  // Revenue guard: 'restricted' with an empty whitelist (mode flipped before
-  // the city rows land / partial backfill) must NOT vanish the category
-  // nationwide — fail open, defer to the legacy term.
-  it('does not hide a restricted category nationwide when its whitelist is still empty', () => {
-    // A new restricted code with no cities and not in any legacy list → visible.
-    expect(isCategoryVisibleInCity('restricted', [], 'ZZ' as never, 'cali', 'AACAL')).toBe(true)
-    // FU restricted-but-empty still obeys the legacy Bogotá branch term.
-    expect(isCategoryVisibleInCity('restricted', [], 'FU', 'bogota', 'AABOT')).toBe(true)
-    expect(isCategoryVisibleInCity('restricted', [], 'FU', 'medellin', 'AAMDE')).toBe(false)
-  })
-
-  // Both constraints apply (AND): data allows but legacy forbids → hidden.
-  it('hides when legacy forbids even if data allows (AND semantics)', () => {
-    // FU data says visible in medellin, but legacy (non-Bogotá branch) forbids.
-    expect(isCategoryVisibleInCity('restricted', ['bogota', 'medellin'], 'FU', 'medellin', 'AAMDE')).toBe(false)
+  // SCEN-D07: no pickup city resolved yet → don't hide.
+  it('hides nothing when no pickup city is selected', () => {
+    expect(isCategoryVisibleInCity('restricted', ['bogota'], null)).toBe(true)
+    expect(isCategoryVisibleInCity('restricted', ['bogota'], undefined)).toBe(true)
   })
 })

--- a/packages/logic/src/utils/__tests__/isPicoyPlacaExempt.test.ts
+++ b/packages/logic/src/utils/__tests__/isPicoyPlacaExempt.test.ts
@@ -1,48 +1,25 @@
 import { describe, it, expect } from 'vitest'
 import { resolvePicoyPlacaExempt } from '../isPicoyPlacaExempt'
 
-// Issue #28 Ola B2-web. The dashboard column picoyplaca_exempt is the source of
-// truth; a transitional fallback to the legacy hardcoded list applies only when
-// the column is absent (null/undefined), until Ola D removes it.
+// Issue #28 Ola D. The dashboard column picoyplaca_exempt is now the SOLE source
+// of truth — the transitional hardcoded fallback list is gone. Exemption derives
+// only from the column; absence means "not exempt".
 
 describe('resolvePicoyPlacaExempt', () => {
-  // SCEN-B2-01: column true wins even for a code not in the fallback list.
-  it('returns true from the column for a brand-new exempt code (ZZ)', () => {
-    expect(resolvePicoyPlacaExempt(true, 'ZZ' as never)).toBe(true)
+  // SCEN-D01: column true → exempt.
+  it('returns true when the column marks the gama exempt', () => {
+    expect(resolvePicoyPlacaExempt(true)).toBe(true)
   })
 
-  // SCEN-B2-02: column false wins even for a code that IS in the fallback list.
-  it('returns false from the column for FU (column revokes a legacy exemption)', () => {
-    expect(resolvePicoyPlacaExempt(false, 'FU')).toBe(false)
+  // SCEN-D02: column false → not exempt, even for a historically-exempt gama.
+  // (No hardcoded EXEMPT_FALLBACK forces FU/FL/GL/LY/LP/LU exempt anymore.)
+  it('returns false when the column revokes exemption', () => {
+    expect(resolvePicoyPlacaExempt(false)).toBe(false)
   })
 
-  // SCEN-B2-03: null falls back to the legacy hardcoded list (preserves today).
-  it('falls back to the hardcoded list when the column is null', () => {
-    for (const code of ['FU', 'FL', 'GL', 'LY', 'LP', 'LU'] as const) {
-      expect(resolvePicoyPlacaExempt(null, code), `${code} should be exempt via fallback`).toBe(true)
-    }
-    expect(resolvePicoyPlacaExempt(null, 'C')).toBe(false)
-  })
-
-  // LU regression (issue #93) preserved through the fallback path.
-  it('keeps LU exempt via fallback (issue #93)', () => {
-    expect(resolvePicoyPlacaExempt(null, 'LU')).toBe(true)
-  })
-
-  it('treats undefined like null (fallback)', () => {
-    expect(resolvePicoyPlacaExempt(undefined, 'FU')).toBe(true)
-    expect(resolvePicoyPlacaExempt(undefined, 'C')).toBe(false)
-  })
-
-  it('returns false when there is no code and no column value', () => {
-    expect(resolvePicoyPlacaExempt(null, null)).toBe(false)
-    expect(resolvePicoyPlacaExempt(undefined, undefined)).toBe(false)
-  })
-
-  // The column is authoritative even when it agrees with the fallback, so the
-  // decision provably came from data, not list membership.
-  it('returns the column value when present regardless of the fallback list', () => {
-    expect(resolvePicoyPlacaExempt(true, 'C')).toBe(true)
-    expect(resolvePicoyPlacaExempt(false, 'LU')).toBe(false)
+  // SCEN-D03: column absent → not exempt (no hardcoded list to fall back to).
+  it('returns false when the column is absent (null/undefined)', () => {
+    expect(resolvePicoyPlacaExempt(null)).toBe(false)
+    expect(resolvePicoyPlacaExempt(undefined)).toBe(false)
   })
 })

--- a/packages/logic/src/utils/isCategoryVisibleInCity.ts
+++ b/packages/logic/src/utils/isCategoryVisibleInCity.ts
@@ -1,38 +1,16 @@
-import type { CategoryType } from './types/type/CategoryType'
-
-// Transitional legacy fallback (issue #28 Ola C): the web's hardcoded geo rules,
-// kept as an ADDITIONAL constraint (AND) because visibility_mode is NOT NULL
-// DEFAULT 'all' — a not-yet-backfilled category reads 'all', so the data alone
-// can't reproduce today's restrictions. Removed in Ola D, leaving only the data.
-const BOGOTA_BRANCHES: readonly string[] = ['AABOT', 'ACBOT', 'ACBEX', 'ACBNN', 'ACBOJ']
-const BOGOTA_ONLY: readonly CategoryType[] = ['FU', 'FL', 'GL']
-const CX_CITIES: readonly string[] = ['barranquilla', 'bogota', 'bucaramanga', 'cali', 'cartagena', 'medellin', 'santa-marta']
-const GY_CITIES: readonly string[] = ['barranquilla', 'bogota', 'bucaramanga', 'cali', 'cartagena', 'medellin', 'santa-marta', 'soledad']
-
-// Replicates the three current hardcoded filters exactly, including their
-// "no location selected → don't hide" guards. FU/FL/GL stay branch-based here
-// (equivalent to city=bogota per O1) so the transition is byte-for-byte.
-function legacyGeoAllows(
-  categoryCode: CategoryType,
-  pickupCity: string | null | undefined,
-  pickupBranchCode: string | null | undefined,
-): boolean {
-  if (BOGOTA_ONLY.includes(categoryCode)) {
-    return pickupBranchCode ? BOGOTA_BRANCHES.includes(pickupBranchCode) : true
-  }
-  if (categoryCode === 'CX') {
-    return pickupCity ? CX_CITIES.includes(pickupCity) : true
-  }
-  if (categoryCode === 'GY') {
-    return pickupCity ? GY_CITIES.includes(pickupCity) : true
-  }
-  return true
-}
-
-// Data path: a 'restricted' category is visible only in its whitelisted cities;
-// 'all' (or anything non-restricted) imposes no data constraint. No pickup city
-// → no data constraint (mirrors the legacy guards).
-function dataGeoAllows(
+/**
+ * Decides whether a category is offered at the selected pickup city, derived
+ * solely from the dashboard's visibility_mode + category_city_visibility
+ * (issue #28). A `'restricted'` category is visible only in its whitelisted
+ * cities; any other mode (`'all'`) imposes no geographic constraint. With no
+ * pickup city resolved yet, nothing is hidden.
+ *
+ * Fail-open guard: a `'restricted'` category with an empty whitelist stays
+ * visible nationwide. A half-configured restriction (mode flipped before the
+ * city rows land) must never silently delist a sellable category — operators
+ * must populate cities for a restriction to take effect.
+ */
+export function isCategoryVisibleInCity(
   visibilityMode: string | null | undefined,
   allowedCities: readonly string[] | null | undefined,
   pickupCity: string | null | undefined,
@@ -40,36 +18,6 @@ function dataGeoAllows(
   if (visibilityMode !== 'restricted') return true
   if (!pickupCity) return true
   const cities = allowedCities ?? []
-  // Restricted but with no whitelist yet (mode flipped before the city rows
-  // land, or a partial backfill) must NOT hide the category nationwide — fail
-  // open and let the legacy AND-term govern. During the transition the data can
-  // only ADD constraints once it actually carries cities; it never erases a
-  // category by being half-configured.
-  if (cities.length === 0) return true
+  if (cities.length === 0) return true // fail open: restricted-but-unbackfilled never delists nationwide
   return cities.includes(pickupCity)
-}
-
-/**
- * Decides whether a category is offered at the selected pickup location,
- * derived from the dashboard's visibility_mode + category_city_visibility
- * (issue #28 Ola C), combined with the legacy hardcoded rules as a transitional
- * AND-constraint.
- *
- * `visible = dataGeoAllows AND legacyGeoAllows`. Because visibility_mode is
- * NOT NULL DEFAULT 'all', a not-yet-backfilled category reads 'all' and is held
- * back only by legacyGeoAllows (preserving today). Once backfilled, both agree.
- * A new category marked 'restricted' in the dashboard — not in any legacy list —
- * is constrained by the data alone. Ola D removes the legacy term.
- */
-export function isCategoryVisibleInCity(
-  visibilityMode: string | null | undefined,
-  allowedCities: readonly string[] | null | undefined,
-  categoryCode: CategoryType,
-  pickupCity: string | null | undefined,
-  pickupBranchCode: string | null | undefined,
-): boolean {
-  return (
-    dataGeoAllows(visibilityMode, allowedCities, pickupCity) &&
-    legacyGeoAllows(categoryCode, pickupCity, pickupBranchCode)
-  )
 }

--- a/packages/logic/src/utils/isPicoyPlacaExempt.ts
+++ b/packages/logic/src/utils/isPicoyPlacaExempt.ts
@@ -1,26 +1,14 @@
-import type { CategoryType } from './types/type/CategoryType'
-
-// Transitional fallback (issue #28 Ola B2): reproduces the gamas the web
-// hardcoded before the dashboard exposed `picoyplaca_exempt`. Used ONLY when a
-// category arrives without the column (null/undefined) — i.e. before the
-// migration is applied/backfilled in the Supabase the web reads. Removed in
-// Ola D once the column is the sole source of truth.
-const EXEMPT_FALLBACK: readonly CategoryType[] = ['FU', 'FL', 'GL', 'LY', 'LP', 'LU']
-
 /**
  * Decides whether a category is exempt from pico y placa (`true` → the web
- * renders the "sin pico y placa" badge), derived from the dashboard column
- * with a transitional fallback to the legacy hardcoded list.
+ * renders the "sin pico y placa" badge), derived solely from the dashboard
+ * column `picoyplaca_exempt` (issue #28).
  *
- * The column is authoritative: an explicit `true`/`false` always wins over the
- * fallback, so operations can both grant and revoke exemption from the
- * dashboard. Only a missing value (`null`/`undefined`, before the column is
- * backfilled) falls back to the hardcoded gamas, preserving today's behavior.
+ * The column is the single source of truth: operations grant or revoke exemption
+ * from the dashboard. An absent value (`null`/`undefined` — a stale cache or a
+ * not-yet-saved category) means not exempt; there is no hardcoded fallback list.
  */
 export function resolvePicoyPlacaExempt(
   picoyplacaExempt: boolean | null | undefined,
-  categoryCode: CategoryType | null | undefined,
 ): boolean {
-  if (picoyplacaExempt != null) return picoyplacaExempt
-  return categoryCode ? EXEMPT_FALLBACK.includes(categoryCode) : false
+  return picoyplacaExempt ?? false
 }

--- a/packages/logic/src/utils/types/data/CategoryAvailabilityData.ts
+++ b/packages/logic/src/utils/types/data/CategoryAvailabilityData.ts
@@ -26,8 +26,8 @@ export default interface CategoryAvailabilityData {
   extraHoursTotalAmount?: number;
   referenceToken: string;
   rateQualifier: string;
-  // Issue #28 Ola B2: pico y placa exemption from the dashboard column (null
-  // when absent → resolvePicoyPlacaExempt falls back to the hardcoded list).
+  // Issue #28: pico y placa exemption from the dashboard column (sole source of
+  // truth; null/absent → not exempt). See resolvePicoyPlacaExempt.
   picoyplacaExempt?: boolean | null;
   // Issue #28 Ola C: geographic visibility from the dashboard (visibility_mode +
   // whitelisted city slugs). See isCategoryVisibleInCity.

--- a/packages/logic/src/utils/types/data/CategoryData.ts
+++ b/packages/logic/src/utils/types/data/CategoryData.ts
@@ -14,9 +14,8 @@ export default interface CategoryData {
   month_prices: CategoryMonthPriceData[];
   total_coverage_unit_charge: number;
   extra_km_charge: number;
-  // Issue #28 Ola B2: pico y placa exemption from the dashboard column. null/
-  // absent when the column is missing (pre-backfill) → consumers fall back to
-  // the transitional hardcoded list. See resolvePicoyPlacaExempt.
+  // Issue #28: pico y placa exemption from the dashboard column (sole source of
+  // truth). null/absent → not exempt. See resolvePicoyPlacaExempt.
   picoyplaca_exempt?: boolean | null;
   // Issue #28 Ola C: geographic visibility from the dashboard. visibility_mode
   // is 'all' | 'restricted' (NOT NULL DEFAULT 'all'); allowed_cities are the


### PR DESCRIPTION
Última ola del issue #28. El dashboard (Supabase) ya es la única fuente de verdad para la exención de pico y placa y la visibilidad geográfica de categorías. Esta ola borra los fallbacks hardcodeados que sostenían la transición.

## Precondición cumplida (verificada en prod)
- Migraciones `053` (`picoyplaca_exempt`) y `054` (backfill `category_city_visibility`) **aplicadas en prod** Supabase y verificadas: datos coinciden exacto con las listas hardcodeadas que se eliminan.
- Render validado en prod (alquilatucarro.com) sobre datos reales: FU/FL/GL presentes en Bogotá, **ausentes** en Medellín; CX/GY en ambas; badges "sin pico y placa" desde la columna. Cero errores de consola.

## Qué cambia
Elimina código muerto (ya dormante porque la columna manda):
- `EXEMPT_FALLBACK` (lista de gamas) en `isPicoyPlacaExempt.ts`
- `BOGOTA_BRANCHES`/`BOGOTA_ONLY`/`CX_CITIES`/`GY_CITIES` + `legacyGeoAllows` en `isCategoryVisibleInCity.ts`
- Los parámetros huérfanos (`categoryCode`, `pickupBranchCode`) y sus argumentos en `useCategory.ts` y `useStoreSearchData.ts`

Firmas resultantes:
- `resolvePicoyPlacaExempt(flag) → flag ?? false` (ausente = no exenta).
- `isCategoryVisibleInCity(mode, cities, pickupCity)`: `restricted` → solo ciudades whitelisteadas; **fail-open** cuando el whitelist está vacío (guarda de ingresos permanente: una restricción a medio configurar nunca delista una categoría vendible).

Net **−124 líneas**.

## Verificación
- Escenarios `docs/specs/issue-28-ola-d-remove-fallbacks` (SCEN-D01..D07) — 7/7 satisfechos.
- `pnpm --filter @rentacar-main/logic test --run` → 301 passed, 0 failed.
- Typecheck delta 0 (268 = baseline alquilatucarro; 0 errores en archivos tocados).
- Review 4-agentes (code-reviewer/edge-case/simplifier/performance): APPROVE. Findings del edge-detector cerrados por evidencia: CHECK enum en `visibility_mode`, slugs de ciudad normalizados, HIGH mitigado por backfill+validación prod.

Closes #28