### PR TITLE
docs(schedule): ADR + contrato cross-repo para restricciones de horario (issue #47)

### DIFF
--- a/docs/specs/2026-06-03-issue-47-schedule-d-waves/implementation/plan.md
+++ b/docs/specs/2026-06-03-issue-47-schedule-d-waves/implementation/plan.md
@@ -1,0 +1,117 @@
+# Plan de implementación — Issue #47 olas D (lado de escritura, `rentacar-dashboard`)
+
+**Fecha**: 2026-06-03
+**Design source**: [`../../2026-06-03-issue-47-schedule-restrictions-design.md`](../../2026-06-03-issue-47-schedule-restrictions-design.md) (ADR + contrato).
+**Alcance**: solo **D1–D3** (dashboard, lado de escritura). Las olas W (web, lectura + reglas + UI) se planean cuando D1–D3 estén en producción. No hay ola "D4 exponer en payload": la web lee `locations.schedule` de Supabase directamente (ver Nota de arquitectura del ADR).
+**Repo objetivo**: `amaw-sas/rentacar-dashboard` (Next.js App Router + zod + Supabase). Este plan vive en `rentacar-web` como artefacto de coordinación; cada ola D genera su propio `docs/specs/<name>/` con scenarios **en el dashboard**.
+
+Clarificación y research no se repiten aquí: las cinco preguntas abiertas del issue se resolvieron en el ADR (forma del contrato, festivos vía Ley Emiliani, sin buffer, fallback permisivo) y la auditoría de ambos repos ya está hecha (validación servidor existe, slots de 30 min existen, datos reales inspeccionados en Supabase).
+
+---
+
+## Mapa de archivos (`rentacar-dashboard`)
+
+| Archivo | Responsabilidad | Ola |
+|---|---|---|
+| `lib/schemas/location.ts` | Reemplazar `schedule: z.record(z.string(), z.string())` por el schema v2 (`LocationSchedule`). Única fuente de validación del shape. | D1 |
+| `scripts/migration/parse-schedule.ts` | Parser puro `display: string → LocationSchedule`. Unidad testeable (Vitest). Es el corazón de D2. | D2 |
+| `scripts/migration/migrate-location-schedule.ts` (o `supabase/migrations/0NN_*.sql` que invoque el resultado) | Aplica el parser a las ~30 filas de `locations.schedule`, conservando `display`. Idempotente, con dump previo. | D2 |
+| `components/forms/location-form.tsx` | Editor de horario por día + festivo, inputs restringidos a múltiplos de 30 min, estados cerrado/24 h. | D3 |
+| `lib/actions/locations.ts`, `lib/queries/locations.ts` | Ajustar solo si el shape de lectura/escritura cambia (probablemente pass-through). | D1/D3 |
+
+**Decisión de decomposición**: una ola por responsabilidad (contrato → datos → UI), no por capa técnica. Cada una es un PR independiente con su spec+scenarios propios en el dashboard. D1 fija el contrato del que dependen D2 y D3, así que va primero y sin dependencias.
+
+---
+
+## Pasos
+
+### D1 — Schema v2 del contrato `schedule` | Size: M | Deps: ninguna
+
+Reemplaza el genérico `z.record(z.string(), z.string())` por el schema estructurado. Un operador guarda el horario de una sucursal y el sistema solo acepta la forma v2 válida; un horario con borde fuera de la grilla de 30 min o un rango invertido es rechazado.
+
+- `LocationSchedule` = objeto con claves opcionales `mon|tue|wed|thu|fri|sat|sun|hol`, cada una un array de rangos. Regex de cada rango (literal a copiar tal cual; la asimetría de hora inicio vs fin es **deliberada**, no un typo):
+  ```
+  /^([01]\d|2[0-3]):(00|30)-([01]\d|2[0-4]):(00|30)$/
+  ```
+  Inicio `00`–`23`; fin `00`–`24` (el `24` habilita el sentinel `24:00`); minutos `(00|30)` en ambos. Ejemplos: `"08:00-18:00"` matchea; `"08:15-18:00"` no (borde fuera de 30 min); `"23:30-24:30"` no (fin `24:30` no existe).
+- Además del regex, validar `inicio < fin` por rango. **Comparar en minutos-desde-medianoche**, mapeando el borde `24:00 → 1440` (no es hora de reloj parseable; un comparador ingenuo de `Date`/string lo rompe). Así `"00:00-24:00"` cumple `0 < 1440` y pasa.
+- Clave ausente o `[]` = cerrado. `["00:00-24:00"]` = 24 h.
+- Conservar `display: z.string().optional()` en el objeto para no romper la lectura actual de la web (que lee `schedule.display`) antes de la ola W1.
+- Exportar el tipo `LocationSchedule` derivado.
+
+**Acceptance criteria**
+- AC-D1.1 — `locationSchema.parse({ schedule: { mon: ["08:00-18:00"], sat: ["08:00-13:00"], hol: [] } })` pasa.
+- AC-D1.2 — `schedule.mon = ["08:15-18:00"]` falla (borde fuera de 30 min).
+- AC-D1.3 — `schedule.mon = ["18:00-08:00"]` falla (rango invertido, `1080 < 480` falso).
+- AC-D1.4 — `schedule = {}` pasa (permisivo; sin horario).
+- AC-D1.5 — `schedule = { display: "texto", mon: ["08:00-18:00"] }` pasa (coexistencia display + estructurado).
+- AC-D1.6 — `schedule.mon = ["00:00-24:00"]` pasa (sentinel 24 h; `0 < 1440`). **Es la forma que D2 produce — si D1 la rechazara, D2 generaría datos inválidos.**
+- AC-D1.7 — `schedule.mon = ["24:00-24:00"]` y `["23:30-24:30"]` fallan (inicio no puede ser fin-de-día; minuto `24:30` no existe). Documenta que la asimetría `2[0-3]`/`2[0-4]` es intencional.
+
+---
+
+### D2 — Migración de datos `{display}` → estructurado | Size: M | Deps: D1
+
+Transforma las ~30 sucursales de texto libre a la forma v2, **conservando** `display`. Tras la migración, la columna tiene ambas formas; la web sigue leyendo `display` hasta W1. Implementa los escenarios SCEN-01/02/03 del ADR.
+
+- Parser determinista de los patrones reales presentes en los datos: bloques de días `Lun-Vie`, `Lun-Sáb`, `Lun-Dom`; días sueltos `Sáb`, `Dom`; grupos con coma `Sáb, Dom y fest`, `Dom y fest`; `Todos los días`; literales `24 horas`, `Cerrado`; y `Festivos HH:MM-HH:MM`. (La forma coma-grupo `"Sáb, Dom y fest 08:00-16:00"` aparece en AARME/AABAN — no omitirla.)
+- Las ~5 sucursales con `{}` quedan `{}` (no se inventa horario — permisivo). Una columna `schedule` en `NULL`/ausente se trata igual que `{}` (permisivo), no se rompe.
+- Migración idempotente y con dump previo de `locations(code, schedule)` para rollback.
+- **Revisión humana fila por fila** del resultado contra el horario operativo real (open question O3) — el texto es heterogéneo y el parser puede malinterpretar casos límite. **Esta revisión está en el camino crítico de D2: definir el validador humano antes de la corrida prod (no es solo un riesgo).**
+
+**Acceptance criteria**
+- AC-D2.1 (SCEN-01) — `"Lun-Vie 08:00-18:00 | Sáb 08:00-13:00 | Dom y fest Cerrado"` → `{mon..fri:["08:00-18:00"], sat:["08:00-13:00"], sun:[], hol:[]}`.
+- AC-D2.2 (SCEN-02) — `"Lun-Dom 24 horas | Festivos 06:00-21:00"` → `{mon..sun:["00:00-24:00"], hol:["06:00-21:00"]}`.
+- AC-D2.3 (SCEN-03) — `{}` permanece `{}`; `NULL`/ausente → `{}` (permisivo).
+- AC-D2.3b — `"Sáb, Dom y fest 08:00-16:00"` (coma-grupo) → `{sat:["08:00-16:00"], sun:["08:00-16:00"], hol:["08:00-16:00"]}`.
+- AC-D2.4 — toda fila migrada conserva su `display` original (D3 lo regenerará desde el estructurado; ver O2 resuelto).
+- AC-D2.5 — re-ejecutar la migración no cambia el resultado (idempotente).
+- AC-D2.6 — existe dump de rollback y un runbook de reversión (patrón `docs/migration-runs/` del dashboard).
+- AC-D2.7 — toda salida del parser pasa `locationSchema` de D1 (el parser no produce nada que el schema rechace).
+
+---
+
+### D3 — UI de edición del horario | Size: M | Deps: D1 (datos de D2 para mostrar lo migrado)
+
+Editor en el formulario de sucursal. Un operador abre una sucursal, ve/edita el horario por día + festivo con selección en bloques de 30 min, marca un día como cerrado o 24 h, y al guardar solo se persiste un `schedule` válido v2.
+
+- Por cada día (`mon`…`sun`) + `hol`: toggle abierto/cerrado, toggle 24 h, y selección de rango con inputs limitados a múltiplos de 30 min (preserva la invariante del contrato).
+- Validación con el schema D1 antes de enviar; errores inline.
+- **O2 resuelto: el dashboard deriva `display` al guardar.** Al persistir, genera un `display` legible desde el estructurado (p. ej. `"Lun-Vie 08:00-18:00 | Sáb 08:00-13:00 | Dom y fest Cerrado"`). Así la web sigue leyendo `schedule.display` sin cambios y no se necesita una ola W para el texto; el estructurado es canónico y el `display` es siempre derivado. (Se descartó derivar en web porque dejaría `display` desincronizado durante D1–D3.)
+
+**Acceptance criteria**
+- AC-D3.1 — el selector de hora solo ofrece `:00` y `:30` (no `08:15`).
+- AC-D3.2 — marcar un día "Cerrado" persiste `[]` (o clave ausente) para ese día.
+- AC-D3.3 — marcar "24 h" persiste `["00:00-24:00"]`.
+- AC-D3.4 — intentar guardar un horario inválido (rango invertido) muestra error y no persiste.
+- AC-D3.5 — editar una sucursal ya migrada precarga sus rangos correctamente.
+- AC-D3.6 — al guardar, `display` se regenera desde el estructurado y queda coherente con los rangos persistidos (un cambio de `sat` a "Cerrado" se refleja en el texto).
+
+---
+
+## Prerequisites
+
+- Acceso de escritura al proyecto Supabase `rentacar-dashboard` (`ilhdholjrnbycyvejsub`) para D2.
+- Confirmar zona horaria única `America/Bogota` (open question O1) antes de cualquier cómputo de fecha — no afecta D1–D3 (escritura), pero sí W3.
+
+## Testing strategy
+
+Tooling confirmado en la raíz del repo dashboard: `vitest.config.ts`, `playwright.config.ts`, `e2e/` (verificado en el árbol de `amaw-sas/rentacar-dashboard@main`).
+- **D1**: unit (Vitest) sobre `locationSchema` — los AC-D1.* como casos.
+- **D2**: unit (Vitest) sobre el parser puro `parse-schedule.ts` (AC-D2.1–3b, AC-D2.7), más verificación de la corrida (dry-run + diff revisado, patrón `docs/migration-runs/dry-run-*.md`). Nota: el parser es código TS justamente para ser unit-testeable; una migración SQL pura no lo permitiría.
+- **D3**: component/e2e (Playwright) — AC-D3.* sobre el formulario.
+- Cada ola arranca con su `*.scenarios.md` como holdout (SDD) en el dashboard.
+
+## Rollout
+
+1. D1 (schema) — sin efecto en datos; despliega solo y permite que D3 valide.
+2. D2 (migración) — dry-run → revisión humana → corrida prod con dump de rollback. La web sigue leyendo `display` (intacto).
+3. D3 (UI) — despliega tras D2 para que los operadores editen sobre datos ya estructurados.
+4. Señal de desbloqueo de #47: D1–D3 en prod con datos revisados → planear olas W (empezando por W1, la lectura estructurada en la web).
+
+## Riesgos
+
+- **Parser de D2 malinterpreta texto** → mitigado por revisión humana fila por fila (O3, en el camino crítico) + dump de rollback.
+- **Drift display vs estructurado** → resuelto: `display` se deriva del estructurado en cada save (D3, AC-D3.6); el estructurado es la única fuente canónica.
+- **Cambio de shape rompe lectura web antes de W1** → mitigado conservando `display` en D1/D2 (la web no lee las claves nuevas hasta W1).
+- **Comparador `inicio<fin` no maneja el sentinel `24:00`** → mitigado mapeando `24:00→1440` minutos en D1 (AC-D1.6).

--- a/docs/specs/2026-06-03-issue-47-schedule-restrictions-design.md
+++ b/docs/specs/2026-06-03-issue-47-schedule-restrictions-design.md
@@ -1,0 +1,164 @@
+# Restricción de fechas/horas por horario de sucursal — ADR + contrato cross-repo
+
+**Fecha**: 2026-06-03
+**Issue**: [#47](https://github.com/amaw-sas/rentacar-web/issues/47)
+**Tipo**: ADR (decisión de arquitectura) + contrato de datos + plan de migración por olas. No incluye código — el alcance acordado es decisión + contrato + secuencia. La implementación de cada ola se autoriza por separado.
+**Repos involucrados**: `rentacar-web` (consumer), `rentacar-dashboard` (admin / fuente de verdad del catálogo y de las sucursales).
+**Referente de patrón**: `docs/specs/2026-06-02-issue-28-category-restrictions-source-of-truth-design.md` (mismo patrón: la web va detrás del dashboard, el dashboard es la fuente de verdad).
+
+---
+
+## TL;DR
+
+El issue pide que el formulario restrinja fechas y horas válidas según el `schedule` de la sucursal, y lista cinco "preguntas abiertas" más una dependencia upstream. Al auditar ambos repos antes de planear aparecieron tres datos que reescriben el alcance:
+
+1. **La validación de servidor que pide el punto 5 ya existe.** El admin API (Localiza) rechaza combinaciones fuera de horario y devuelve errores estructurados — `out_of_schedule_pickup_date_error`, `out_of_schedule_pickup_hour_error`, `out_of_schedule_return_date_error`, `out_of_schedule_return_hour_error`, más las variantes de festivo `holiday_pickup_date_error`, `holiday_out_of_schedule_pickup_date_error` y simétricas de devolución (`utils/types/data/LocalizaErrorResponse.ts:7-16`). La web ya las superficie vía la spec `2026-05-04-availability-error-feedback`. La defensa en profundidad del servidor no hay que construirla.
+
+2. **La granularidad de 30 min que el issue marca como "decisión tomada" ya está implementada.** `useSearch.ts:29` (`generateHourOptions`) genera los slots de media hora alineados a 30 min. Solo falta poder *restringirlos* por sucursal; los slots mismos ya existen. (Ojo: el rango efectivo es `00:00`–`23:00` por la condición `< 23:30` del loop, son 47 slots; el comentario del código que dice "48" está mal y conviene corregirlo al implementar W4.)
+
+3. **El `schedule` NO es estructurado.** En producción es un único string de texto libre en español bajo una clave `display`, con formatos heterogéneos y **~5 sucursales con `{}` vacío**. El dashboard **no tiene UI para editarlo** (el campo solo aparece en `lib/schemas/location.ts` como `z.record(z.string(), z.string()).default({})`, un genérico que nadie escribe estructuradamente).
+
+**Consecuencia:** el núcleo del issue — restringir el calendario y el selector de hora **proactivamente en el cliente** — está **bloqueado upstream**. La web no puede derivar reglas por sucursal de un string libre. El trabajo real, en orden, es: definir un contrato estructurado, migrar los datos en el dashboard, exponerlo en el payload, y solo entonces consumirlo en la web. Este ADR fija ese contrato y la secuencia.
+
+### Muestra de los datos reales (producción, tabla `locations`)
+
+```
+AARME Armenia Aeropuerto   {"display":"Lun-Vie 06:00-19:00 | Sáb, Dom y fest 08:00-16:00"}
+AABAN Barranquilla Aerop.  {"display":"Todos los días 07:00-20:00"}
+AABOT Bogotá Aeropuerto    {"display":"Lun-Dom 24 horas | Festivos 06:00-21:00"}
+ACKAL Cali Sur Camino Real {"display":"Lun-Vie 08:00-17:00 | Sáb 08:00-14:00 | Dom y fest Cerrado"}
+ACMCL Medellín Éxito Col.  {"display":"Lun-Vie 08:00-15:00 | Sáb 08:00-13:00 | Dom y fest Cerrado"}
+ACBED Bogotá Fontibón      {}
+AAMDL Medellín Aeropuerto  {}
+```
+
+Patrones observados: agrupación por bloques de días (`Lun-Vie`, `Sáb`, `Dom`), festivos casi siempre tratados aparte (`Dom y fest`, `Festivos 06:00-21:00`), literales `24 horas` y `Cerrado`. **Ningún horario parte el día** (no hay cierres de mediodía tipo `08:00-12:00 | 14:00-18:00`).
+
+---
+
+## Decisión (el ADR)
+
+> El horario de una sucursal es un **dato operacional del catálogo**, no una invariante de UI. Su dueño es operaciones y su sistema de registro ya es el dashboard sobre Supabase. Por tanto el `schedule` estructurado se define y administra en `rentacar-dashboard`, y la web pasa a **leerlo del payload `/api/rentacar-data`** para construir las restricciones de fecha/hora. La web no hardcodea horarios ni los infiere parseando el texto libre.
+
+**Estado**: propuesta. Implementación pendiente de autorización por ola.
+
+**Por qué consumir del dashboard y no parsear el `display` en la web:** el `display` es prosa libre, con seis o más formas distintas y varios huecos. Un parser sobre ese texto sería frágil y no cubriría los `{}`. Peor: dejaría la regla de negocio escondida en una expresión regular sin dueño, el mismo anti-patrón que el filtro mensual roto que documenta el ADR de #28. El horario es un dato; merece ser editable y observable, no un efecto secundario de un string.
+
+**Por qué la web no puede entregar el issue hoy:** sin el dato estructurado no hay de dónde sacar qué días deshabilitar ni qué horas ofrecer. El fallback permisivo (decisión 4) mantiene el comportamiento actual mientras el dashboard se pone al día, y el servidor sigue validando de respaldo. La web hoy no hace ninguna promesa proactiva, así que no rompe ninguna.
+
+---
+
+## Estado real (verificado en código, ambos repos)
+
+| Pieza | Web hoy | Dashboard hoy | Brecha real |
+|---|---|---|---|
+| Validación servidor fuera de horario | superficie errores `out_of_schedule_*`/`holiday_*` vía `extractStructuredError` | Localiza valida y devuelve los errores | **Ya hecho.** No es trabajo de este issue. |
+| Slots de 30 min | `generateHourOptions()` genera los slots de 30 min, `00:00`–`23:00` (`useSearch.ts:29`) | n/a | **Ya hecho.** Falta filtrarlos por sucursal. |
+| Dato `schedule` | transformer lee `row.schedule?.display \|\| ''` (`transformers.ts:123`), tipado `{ display?: string }` | texto libre `{display}`; ~5 vacíos; sin UI de edición | **El trabajo.** Definir contrato estructurado + migrar + UI + exponer. |
+| Uso del `schedule` en la web | solo se muestra como texto en `CityPage.vue:197` | n/a | El `display` pasa a derivarse del estructurado (decisión 1). |
+| Restricción proactiva calendario/hora | inexistente (calendario solo aplica `min/max`; horas = los 48 slots) | n/a | A construir en la web tras exponer el dato (olas W). |
+
+---
+
+## Contrato `schedule` v2 (la decisión de datos)
+
+Forma estructurada que el dashboard persiste y expone en `/api/rentacar-data`:
+
+```jsonc
+{
+  "mon": ["06:00-19:00"],
+  "tue": ["06:00-19:00"],
+  "wed": ["06:00-19:00"],
+  "thu": ["06:00-19:00"],
+  "fri": ["06:00-19:00"],
+  "sat": ["08:00-16:00"],
+  "sun": ["08:00-16:00"],
+  "hol": ["08:00-16:00"]
+}
+```
+
+**Reglas del contrato:**
+
+- **Claves**: `mon`, `tue`, `wed`, `thu`, `fri`, `sat`, `sun`, `hol`. `hol` = horario aplicable en festivos colombianos (ver decisión 2).
+- **Valor**: array de rangos `"HH:MM-HH:MM"`. Cada borde alineado a múltiplos de 30 min (invariante que la UI de edición del dashboard debe forzar; bajo esta invariante los bordes siempre coinciden con un slot del selector y no se requiere redondeo).
+- **Cerrado**: array vacío `[]` o clave ausente. Equivalentes.
+- **Abierto 24 h**: `["00:00-24:00"]`. El borde superior `24:00` denota fin-de-día inclusivo.
+- **Array, no string** (decisión 1): aunque hoy ningún horario parte el día, el array soporta un futuro cierre de mediodía (`["08:00-12:00","14:00-18:00"]`) sin una segunda migración. El costo en JSON es nulo; el costo de re-migrar ~30 filas no lo es.
+- **`display` derivado**: el string humano de `CityPage` se genera a partir del estructurado (en el transformer o en el dashboard), no se edita aparte. Elimina el riesgo de drift entre el texto mostrado y el horario aplicado.
+
+### Decisiones puntuales
+
+1. **Forma**: array de rangos por día + clave `hol`. *(Alternativas descartadas: string de un solo rango — calza con los datos de hoy pero exige re-migración si aparece un cierre de mediodía; estructura rica con excepciones por fecha — YAGNI, no existen datos de excepción y los festivos se cubren con el calendario.)*
+
+2. **Festivos**: las **fechas** de festivo las computa un util determinista en `packages/logic` que implementa el calendario colombiano **incluyendo la Ley Emiliani** (festivos trasladables al lunes). En una fecha festiva, la disponibilidad aplica el rango `hol`. El servidor (`holiday_*`) queda de respaldo. *(Alternativas descartadas: solo respaldo del servidor — rompe la promesa "ves disponibilidad real" justo en festivos; tabla de festivos en Supabase — agrega otra pieza de datos + UI sin necesidad, los festivos colombianos son computables.)*
+
+3. **Buffer operativo**: ninguno. El último slot seleccionable es la hora de cierre (cierra 18:00 → 18:00 es válido). Se podrá agregar un buffer (cierre − N min) más adelante si operaciones lo pide; no se asume hoy.
+
+4. **Sucursal sin horario (`{}`/ausente)**: **permisivo** — la web no restringe (todos los slots abiertos, comportamiento actual) y el servidor valida como respaldo. No se pierden reservas por una sucursal sin configurar. La promesa proactiva no aplica en esas sucursales hasta que se les cargue horario. *(Alternativas descartadas: restrictivo/bloquear — riesgo alto de perder reservas por mala configuración; default 24/7 explícito — igual de permisivo pero mete un horario falso al modelo.)*
+
+---
+
+## Secuencia cross-repo (olas)
+
+Las olas **D** son del dashboard y **bloquean** a las **W**. Cada ola es un PR independiente con su propio holdout de escenarios.
+
+### Dashboard (`rentacar-dashboard`) — upstream, bloqueante
+
+- **D1 — Contrato + schema.** Reemplazar `schedule: z.record(z.string(), z.string())` por el schema v2 (claves día/`hol`, arrays de rangos validados a 30 min). Tipo derivado `LocationSchedule`.
+- **D2 — Migración de datos.** Parsear los ~30 strings `display` existentes a la forma estructurada (script puntual, revisión manual del resultado dado lo heterogéneo del texto). Las ~5 sucursales con `{}` quedan `{}` (permisivo). Conservar/derivar `display` para retrocompatibilidad de lectura.
+- **D3 — UI de edición.** Formulario de sucursal con inputs por día + festivo, restringidos a múltiplos de 30 min (preserva la invariante del contrato). Estados cerrado/24 h explícitos.
+- **D4 — Exponer en payload.** Incluir `schedule` estructurado en `/api/rentacar-data`. Recordar la cache Nitro de 1 h: los cambios tardan hasta `maxAge` en propagarse (ver `rentacar-data.get.ts:55`).
+
+### Web (`rentacar-web`) — tras D4
+
+- **W1 — Lectura.** `transformBranches` lee el `schedule` estructurado a `BranchData`; `display` derivado para `CityPage`. Actualizar el tipo `BranchData.schedule`.
+- **W2 — Reglas en logic.** Util puro en `packages/logic` (testeable en aislamiento), sin dependencia de Vue:
+  - `openRangesForDate(schedule, date)` → los rangos abiertos para esa fecha (resuelve festivo vs día de semana vía W3).
+  - `isDayOpen(schedule, date)` → `true` si `openRangesForDate` no está vacío para la clave efectiva de esa fecha.
+  - `bookableSlotsForDate(schedule, date)` → intersección de los slots de 30 min con los rangos abiertos.
+- **W3 — Festivos.** Util de calendario colombiano (Ley Emiliani) en `packages/logic`, consumido por W2 para elegir `hol`.
+- **W4 — Integración Searcher.** El calendario deshabilita días cerrados (`isDateDisabled`/`disabledDates`) y el selector de hora ofrece solo los slots válidos, **por sucursal e independientes** entre recogida (`location_recogida`) y devolución (`location_devolucion`).
+- **W5 — Invalidación al cambiar sucursal.** Si la fecha/hora ya elegida cae fuera del nuevo `schedule`, limpiar el valor y pedir reselección con feedback visible; nunca enviar el form con un valor inválido.
+
+**Nota de acoplamiento (memoria de equipo):** una ola que cambie el shape de la respuesta de `/api/rentacar-data` interactúa con el deploy-scope de la cache (`docs/specs/2026-05-26-rentacar-data-cache-deploy-scope-design.md`): una entrada de cache vieja con el shape anterior no debe servirse a código nuevo. D4/W1 deben verificar que el `getKey` por `buildId` cubre el cambio de schema.
+
+---
+
+## Escenarios observables (puente a SDD)
+
+Derivados de los escenarios del issue + las decisiones de este ADR. Cada uno es un holdout para la ola que lo implementa. Sucursal de referencia **A**: `mon–fri 08:00–18:00`, `sat 08:00–13:00`, `sun []`, `hol []`.
+
+**Contrato y migración (D1–D2)**
+- **SCEN-01** — Dado el string `"Lun-Vie 08:00-18:00 | Sáb 08:00-13:00 | Dom y fest Cerrado"`, cuando se migra, entonces `{mon..fri:["08:00-18:00"], sat:["08:00-13:00"], sun:[], hol:[]}`.
+- **SCEN-02** — Dado `"Lun-Dom 24 horas | Festivos 06:00-21:00"`, cuando se migra, entonces `mon..sun:["00:00-24:00"]` y `hol:["06:00-21:00"]`.
+- **SCEN-03** — Dado `{}`, cuando se migra, entonces queda `{}` (no se inventa horario).
+
+**Reglas en logic (W2–W3)**
+- **SCEN-04** — Dado el `schedule` de A y un domingo, cuando se pide `bookableSlotsForDate`, entonces `[]` (cerrado).
+- **SCEN-05** — Dado A y un sábado, cuando se piden slots, entonces incluye `13:00` y excluye `13:30` y `15:00`.
+- **SCEN-06** — Dado A y un lunes, cuando se piden slots, entonces excluye `07:30` e incluye `08:00`.
+- **SCEN-06b** (buffer = 0, decisión 3) — Dado A un sábado (cierra 13:00), cuando se piden slots, entonces `13:00` es el último slot incluido. Este escenario es el holdout de "sin buffer": el último slot es exactamente la hora de cierre, no cierre − N.
+- **SCEN-07** — Dado A y una fecha festiva (Ley Emiliani, p. ej. festivo trasladado a lunes), cuando se piden slots, entonces aplica `hol` (`[]` → cerrado), no el horario de lunes.
+- **SCEN-08** — Dado `schedule = {}`, cuando se piden slots para cualquier fecha, entonces todos los slots de 30 min disponibles (permisivo, comportamiento actual).
+
+**Integración Searcher (W4–W5)**
+- **SCEN-09** — Dado recogida en A (cerrada domingo), cuando se abre el calendario de recogida, entonces el domingo está deshabilitado.
+- **SCEN-10** — Dado recogida en A y devolución en B (abierta domingo), cuando se abren ambos calendarios, entonces recogida bloquea domingo y devolución lo permite (independientes).
+- **SCEN-11** — Dado recogida lunes 16:00 ya elegida, cuando se cambia la sucursal a una que cierra 14:00, entonces el campo recogida se invalida y pide reselección; el form no se puede enviar con 16:00.
+- **SCEN-12** — Dado el selector de hora de cualquier sucursal, cuando se listan opciones, entonces solo bloques de 30 min (no `08:15` ni `10:37`).
+
+---
+
+## Consecuencias
+
+- **Hasta D4**, la web queda como está: sin restricción proactiva, con validación de servidor como única barrera. El fallback permisivo (decisión 4) garantiza que esto no es una regresión.
+- **El issue #47 en `rentacar-web` está bloqueado** por D1–D4 en `rentacar-dashboard`. Conviene abrir los issues D1–D4 en ese repo y enlazarlos como dependencia de #47.
+- **No se escribe código en esta entrega.** El alcance acordado es ADR + contrato + secuencia, espejo de #28.
+
+---
+
+## Preguntas abiertas (no bloquean el ADR; se resuelven al planear las olas)
+
+- **O1 — Zona horaria.** Toda Colombia es `America/Bogota` (UTC−5, sin DST), así que los cómputos de festivo/slot se hacen en hora local sin conversión. Confirmar que no hay sucursal fuera de esa zona antes de W3.
+- **O2 — Derivación de `display`.** ¿El `display` se genera en el transformer de la web (una sola implementación, formato controlado por la web) o en el dashboard (editable/override manual)? Recomendación: derivarlo en la web para una sola fuente de formato; decidir en W1.
+- **O3 — Revisión de la migración D2.** Dado lo heterogéneo del texto, el script de migración necesita revisión humana fila por fila. ¿Quién valida el resultado contra el horario operativo real de cada sucursal?

--- a/docs/specs/2026-06-03-issue-47-schedule-restrictions-design.md
+++ b/docs/specs/2026-06-03-issue-47-schedule-restrictions-design.md
@@ -163,5 +163,5 @@ Derivados de los escenarios del issue + las decisiones de este ADR. Cada uno es 
 ## Preguntas abiertas (no bloquean el ADR; se resuelven al planear las olas)
 
 - **O1 — Zona horaria.** Toda Colombia es `America/Bogota` (UTC−5, sin DST), así que los cómputos de festivo/slot se hacen en hora local sin conversión. Confirmar que no hay sucursal fuera de esa zona antes de W3.
-- **O2 — Derivación de `display`.** ¿El `display` se genera en el transformer de la web (una sola implementación, formato controlado por la web) o en el dashboard (editable/override manual)? Recomendación: derivarlo en la web para una sola fuente de formato; decidir en W1.
+- **O2 — Derivación de `display`. RESUELTO**: el dashboard deriva `display` desde el estructurado al guardar (ola D3, AC-D3.6). Así la web sigue leyendo `schedule.display` sin cambios y no hace falta una ola W para el texto; el estructurado es canónico. Se descartó derivar en web porque dejaría `display` desincronizado durante D1–D3.
 - **O3 — Revisión de la migración D2.** Dado lo heterogéneo del texto, el script de migración necesita revisión humana fila por fila. ¿Quién valida el resultado contra el horario operativo real de cada sucursal?

--- a/docs/specs/2026-06-03-issue-47-schedule-restrictions-design.md
+++ b/docs/specs/2026-06-03-issue-47-schedule-restrictions-design.md
@@ -18,7 +18,9 @@ El issue pide que el formulario restrinja fechas y horas válidas según el `sch
 
 3. **El `schedule` NO es estructurado.** En producción es un único string de texto libre en español bajo una clave `display`, con formatos heterogéneos y **~5 sucursales con `{}` vacío**. El dashboard **no tiene UI para editarlo** (el campo solo aparece en `lib/schemas/location.ts` como `z.record(z.string(), z.string()).default({})`, un genérico que nadie escribe estructuradamente).
 
-**Consecuencia:** el núcleo del issue — restringir el calendario y el selector de hora **proactivamente en el cliente** — está **bloqueado upstream**. La web no puede derivar reglas por sucursal de un string libre. El trabajo real, en orden, es: definir un contrato estructurado, migrar los datos en el dashboard, exponerlo en el payload, y solo entonces consumirlo en la web. Este ADR fija ese contrato y la secuencia.
+**Consecuencia:** el núcleo del issue — restringir el calendario y el selector de hora **proactivamente en el cliente** — está **bloqueado upstream**. La web no puede derivar reglas por sucursal de un string libre. El trabajo real, en orden, es: definir un contrato estructurado y migrar los datos en el dashboard (lado de escritura), y solo entonces consumirlos en la web. Este ADR fija ese contrato y la secuencia.
+
+**Nota de arquitectura (verificado).** La web **lee la tabla `locations` de Supabase directamente** — su endpoint `/api/rentacar-data` consulta Supabase vía `rentacarDataFetch.ts:40` (`.from('locations')`), no una API del dashboard. El dashboard y la web comparten el mismo proyecto Supabase: el dashboard **escribe** `locations.schedule`, la web lo **lee**. No existe un paso intermedio de "el dashboard expone el dato en un payload"; en cuanto la columna está estructurada, quien la consume es el transformer de la web (ola W1). Por eso las olas del dashboard son solo de escritura (**D1–D3**), y la lectura estructurada vive en web (**W1**).
 
 ### Muestra de los datos reales (producción, tabla `locations`)
 
@@ -38,7 +40,7 @@ Patrones observados: agrupación por bloques de días (`Lun-Vie`, `Sáb`, `Dom`)
 
 ## Decisión (el ADR)
 
-> El horario de una sucursal es un **dato operacional del catálogo**, no una invariante de UI. Su dueño es operaciones y su sistema de registro ya es el dashboard sobre Supabase. Por tanto el `schedule` estructurado se define y administra en `rentacar-dashboard`, y la web pasa a **leerlo del payload `/api/rentacar-data`** para construir las restricciones de fecha/hora. La web no hardcodea horarios ni los infiere parseando el texto libre.
+> El horario de una sucursal es un **dato operacional del catálogo**, no una invariante de UI. Su dueño es operaciones y su sistema de registro ya es el dashboard sobre Supabase. Por tanto el `schedule` estructurado se define y administra en `rentacar-dashboard` (schema + UI), y la web lo **lee de la tabla `locations`** (vía su endpoint `/api/rentacar-data`, que consulta Supabase directamente) para construir las restricciones de fecha/hora. La web no hardcodea horarios ni los infiere parseando el texto libre.
 
 **Estado**: propuesta. Implementación pendiente de autorización por ola.
 
@@ -62,7 +64,7 @@ Patrones observados: agrupación por bloques de días (`Lun-Vie`, `Sáb`, `Dom`)
 
 ## Contrato `schedule` v2 (la decisión de datos)
 
-Forma estructurada que el dashboard persiste y expone en `/api/rentacar-data`:
+Forma estructurada que el dashboard persiste en la columna `locations.schedule` (Supabase); la web la lee directamente:
 
 ```jsonc
 {
@@ -102,14 +104,15 @@ Forma estructurada que el dashboard persiste y expone en `/api/rentacar-data`:
 
 Las olas **D** son del dashboard y **bloquean** a las **W**. Cada ola es un PR independiente con su propio holdout de escenarios.
 
-### Dashboard (`rentacar-dashboard`) — upstream, bloqueante
+### Dashboard (`rentacar-dashboard`) — upstream, bloqueante (solo lado de escritura)
 
-- **D1 — Contrato + schema.** Reemplazar `schedule: z.record(z.string(), z.string())` por el schema v2 (claves día/`hol`, arrays de rangos validados a 30 min). Tipo derivado `LocationSchedule`.
-- **D2 — Migración de datos.** Parsear los ~30 strings `display` existentes a la forma estructurada (script puntual, revisión manual del resultado dado lo heterogéneo del texto). Las ~5 sucursales con `{}` quedan `{}` (permisivo). Conservar/derivar `display` para retrocompatibilidad de lectura.
+- **D1 — Contrato + schema.** Reemplazar `schedule: z.record(z.string(), z.string())` por el schema v2 (claves día/`hol`, arrays de rangos validados a 30 min). Conservar `display` como campo derivado/legacy para no romper la lectura actual de la web antes de W1. Tipo derivado `LocationSchedule`.
+- **D2 — Migración de datos.** Parsear los ~30 strings `display` existentes a la forma estructurada (script/migración puntual, revisión manual del resultado dado lo heterogéneo del texto). Las ~5 sucursales con `{}` quedan `{}` (permisivo). Conservar `display` junto a las claves nuevas para retrocompatibilidad de lectura.
 - **D3 — UI de edición.** Formulario de sucursal con inputs por día + festivo, restringidos a múltiplos de 30 min (preserva la invariante del contrato). Estados cerrado/24 h explícitos.
-- **D4 — Exponer en payload.** Incluir `schedule` estructurado en `/api/rentacar-data`. Recordar la cache Nitro de 1 h: los cambios tardan hasta `maxAge` en propagarse (ver `rentacar-data.get.ts:55`).
 
-### Web (`rentacar-web`) — tras D4
+No hay ola "D4 — exponer en payload": la web lee `locations.schedule` directamente de Supabase (ver Nota de arquitectura), así que la lectura del dato estructurado es la ola **W1**, no una tarea del dashboard.
+
+### Web (`rentacar-web`) — tras D3
 
 - **W1 — Lectura.** `transformBranches` lee el `schedule` estructurado a `BranchData`; `display` derivado para `CityPage`. Actualizar el tipo `BranchData.schedule`.
 - **W2 — Reglas en logic.** Util puro en `packages/logic` (testeable en aislamiento), sin dependencia de Vue:
@@ -120,7 +123,7 @@ Las olas **D** son del dashboard y **bloquean** a las **W**. Cada ola es un PR i
 - **W4 — Integración Searcher.** El calendario deshabilita días cerrados (`isDateDisabled`/`disabledDates`) y el selector de hora ofrece solo los slots válidos, **por sucursal e independientes** entre recogida (`location_recogida`) y devolución (`location_devolucion`).
 - **W5 — Invalidación al cambiar sucursal.** Si la fecha/hora ya elegida cae fuera del nuevo `schedule`, limpiar el valor y pedir reselección con feedback visible; nunca enviar el form con un valor inválido.
 
-**Nota de acoplamiento (memoria de equipo):** una ola que cambie el shape de la respuesta de `/api/rentacar-data` interactúa con el deploy-scope de la cache (`docs/specs/2026-05-26-rentacar-data-cache-deploy-scope-design.md`): una entrada de cache vieja con el shape anterior no debe servirse a código nuevo. D4/W1 deben verificar que el `getKey` por `buildId` cubre el cambio de schema.
+**Nota de acoplamiento (memoria de equipo):** la ola **W1** cambia el shape de la respuesta de `/api/rentacar-data` (el transformer pasa a emitir el `schedule` estructurado), y eso interactúa con el deploy-scope de la cache (`docs/specs/2026-05-26-rentacar-data-cache-deploy-scope-design.md`): una entrada de cache vieja con el shape anterior no debe servirse a código nuevo. W1 debe verificar que el `getKey` por `buildId` cubre el cambio de schema. Las olas D no tocan el payload (solo escriben la columna), así que no interactúan con la cache.
 
 ---
 
@@ -151,8 +154,8 @@ Derivados de los escenarios del issue + las decisiones de este ADR. Cada uno es 
 
 ## Consecuencias
 
-- **Hasta D4**, la web queda como está: sin restricción proactiva, con validación de servidor como única barrera. El fallback permisivo (decisión 4) garantiza que esto no es una regresión.
-- **El issue #47 en `rentacar-web` está bloqueado** por D1–D4 en `rentacar-dashboard`. Conviene abrir los issues D1–D4 en ese repo y enlazarlos como dependencia de #47.
+- **Hasta que llegue W1**, la web queda como está: sin restricción proactiva, con validación de servidor como única barrera. El fallback permisivo (decisión 4) garantiza que esto no es una regresión.
+- **El issue #47 en `rentacar-web` está bloqueado** por D1–D3 en `rentacar-dashboard` (lado de escritura). Conviene abrir los issues D1–D3 en ese repo y enlazarlos como dependencia de #47; las olas W (incluida W1, la lectura) se planifican una vez D1–D3 estén en producción.
 - **No se escribe código en esta entrega.** El alcance acordado es ADR + contrato + secuencia, espejo de #28.
 
 ---


### PR DESCRIPTION
## Qué

ADR + contrato de datos + plan de olas para [#47](https://github.com/amaw-sas/rentacar-web/issues/47) (restringir fechas/horas del buscador según el `schedule` de la sucursal). **Solo docs — no toca código.** Refs #47 (no lo cierra: la issue queda bloqueada upstream).

## Por qué docs y no implementación

Auditoría de ambos repos antes de planear → tres hallazgos reescriben el alcance:

1. **Validación servidor (punto 5 del issue) ya existe** — Localiza devuelve `out_of_schedule_*`/`holiday_*` (`LocalizaErrorResponse.ts:7-16`), ya superficiados vía `availability-error-feedback`.
2. **Slots de 30 min ya existen** — `useSearch.ts` `generateHourOptions` (47 slots `00:00–23:00`; el comentario que dice 48 está mal).
3. **`schedule` es texto libre** `{display}` en prod (~5 sucursales `{}`), sin UI de edición en el dashboard.

El núcleo de #47 (restricción proactiva en cliente) está **bloqueado upstream**. La web lee `locations.schedule` de Supabase **directo** (`rentacarDataFetch.ts:40`), así que no hay paso "exponer en payload" del dashboard: el trabajo accionable es el lado de escritura → **3 olas D**, no 4.

## Decisiones (contrato `schedule` v2)

- Array de rangos por día (`mon..sun`) + clave `hol`; `[]`/ausente=cerrado, `["00:00-24:00"]`=24h.
- Festivos vía util Ley Emiliani en logic (web W3); sin buffer; `{}`→permisivo (servidor de respaldo).
- `display` derivado del estructurado al guardar (dashboard).

## Secuencia cross-repo

Bloqueado por (dashboard, lado de escritura): `amaw-sas/rentacar-dashboard#95` (D1 schema), `#96` (D2 migración), `#97` (D3 UI). Luego web W1–W5.

## Archivos

- `docs/specs/2026-06-03-issue-47-schedule-restrictions-design.md` — ADR + contrato + 12 escenarios observables.
- `docs/specs/2026-06-03-issue-47-schedule-d-waves/implementation/plan.md` — plan D1–D3 con criterios de aceptación.

## Calidad

ADR y plan revisados por subagentes (Approved). Humanizer aplicado. Patrón espejo de la ADR de #28.