### PR TITLE
fix(alquilame): franchise.name alquilame.com → alquilame.co

### DIFF
--- a/packages/ui-alquilame/app/app.config.ts
+++ b/packages/ui-alquilame/app/app.config.ts
@@ -32,7 +32,7 @@ export default defineAppConfig({
 
   // Brand-specific franchise information
   franchise: {
-    name: "alquilame.com",
+    name: "alquilame.co",
     shortname: "alquilame",
     website: "https://alquilame.co",
     title: "Alquiler de Carros en Colombia desde $32/día",


### PR DESCRIPTION
## Qué
Una línea en `packages/ui-alquilame/app/app.config.ts`: `franchise.name` pasa de `"alquilame.com"` a `"alquilame.co"`.

## Por qué
El dominio real del brand es **alquilame.co** (el campo `website` del mismo bloque ya usa `.co`). `franchise.name` quedó en `.com` desde el commit inicial (`d27315e`) y nunca se corrigió — `origin/main` aún lo tenía mal. Es una corrección de dato de config, consistente con `website`.

## Alcance / blast radius
- Solo `franchise.name` del brand alquilame. No toca lógica.
- La otra ocurrencia `alquilame.com` en el archivo (línea 50, `instagram.com/alquilame.com`) es el **handle de Instagram**, una cuenta distinta — se deja intacta a propósito.

## Verificación
- Diff = exactamente 1 línea; `franchise.name` ahora coincide con `website: https://alquilame.co`.
- Sin tests que cubran `franchise.*` en el brand (no existe dir de tests en ui-alquilame); es constante de presentación.

> Nota de procedencia: este cambio estaba sin commitear y varado en una rama obsoleta (`docs/issue-28-...`, 25 commits detrás de main). Rescatado a esta rama limpia desde `origin/main`.