### PR TITLE
fix(reservations): a11y del flujo de reserva — slideover único + autocomplete (#65)

### DIFF
--- a/docs/specs/issue-65-a11y-reservation-slideover/design.md
+++ b/docs/specs/issue-65-a11y-reservation-slideover/design.md
@@ -1,0 +1,116 @@
+---
+name: issue-65-a11y-reservation-slideover
+created_by: claude
+created_at: 2026-06-04T00:00:00Z
+issue: 65
+epic: 63
+ola: 0
+---
+
+# A11y del flujo de reserva: un solo slideover modal + autocomplete
+
+Issue #65 (épico #63, Ola 0). Dos defectos de accesibilidad en el flujo de
+reserva de las tres marcas. Comparten archivos, se arreglan juntos.
+
+## Diagnóstico (corrige a la auditoría)
+
+La auditoría de caja negra reportó "dos `role=dialog` sin `aria-modal`". El
+código dice otra cosa.
+
+- `@nuxt/ui` 4.2.1: el prop `modal` de `Slideover` es `true` por defecto. Con
+  `modal` activo, reka-ui ya pone `aria-modal="true"`, focus-trap y
+  `pointer-events:none` en el `<body>` (esto último es la cicatriz de #25). Los
+  slideovers usan `:overlay="false"` pero **no** tocan `modal` → siguen siendo
+  modales.
+- El defecto real no es "falta `aria-modal`" sino **dos diálogos modales
+  abiertos a la vez**: el slideover "Datos para reservas" está anidado en el
+  `#footer` del slideover "Resumen de la reserva"
+  (`CategorySelectionSection.vue:127`), y el watch de apertura directa
+  (`:374-390`) abre ambos en cascada sin cerrar el primero.
+
+Por eso el fix es estructural (garantizar un único modal activo), no añadir un
+atributo.
+
+## Problema A — des-anidar + mutuamente excluyentes
+
+Sacar el slideover "Datos" del `#footer` de "Resumen": ambos pasan a ser
+hermanos top-level controlados por `slideoverReservationResume` y
+`slideoverReservationForm`, con la invariante **a lo sumo uno abierto**. El
+botón "Siguiente" deja de ser un trigger anidado y pasa a un handler explícito.
+
+Transiciones (cada una deja un único modal o ninguno):
+
+| Acción de usuario / sistema | `resume` | `form` |
+|---|---|---|
+| Click en tarjeta (`setSelectedCategory`) | `true` | `false` |
+| "Siguiente" en Resumen (`goToForm`) | `false` | `true` |
+| "Volver" en Datos (`backToResume`) | `true` | `false` |
+| "Volver" en Resumen | `false` | `false` |
+| Deep-link `?reservar=X` | `false` | `true` |
+| Deep-link `/categoria/X` o `?resumen=X` | `true` | `false` |
+
+### Integración con los watchers de URL (cicatriz de #25)
+
+Los watchers que sincronizan la URL (`:332-354`) están probados y no se
+reescriben. Solo se añade un guard de una línea al watcher de
+`slideoverReservationResume`:
+
+```
+if (!isOpen && !slideoverReservationForm.value) updateCategoriaUrl(undefined)
+```
+
+Razón: en la transición Resumen→Datos, `resume` pasa a `false` mientras `form`
+ya es `true`. Sin el guard, el watcher borraría el `?reservar=X` que el watcher
+de `form` acaba de poner. Con el guard, la URL solo se limpia cuando se cierran
+ambos. El watcher de cierre de `form` ya está condicionado a `resume`, así que
+no necesita cambios.
+
+`onBeforeRouteLeave` (`:401-409`) sigue cerrando ambos refs antes del unmount
+para no reintroducir el `pointer-events:none` colgado de #25.
+
+### aria-modal
+
+Con `modal` por defecto `true` y un único slideover abierto, reka-ui renderiza
+exactamente un `[role=dialog][aria-modal=true]`. No se asume: se verifica en
+runtime con Playwright (`/agent-browser`).
+
+## Problema B — autocomplete + nombre accesible del teléfono
+
+- `ReservationForm.vue`: `autocomplete` en los campos con token HTML estándar —
+  `given-name` (nombres), `family-name` (apellidos), `email` (correo). Tipo y
+  número de identificación **no tienen token estándar**; no se fabrica uno
+  (sería ruido para el agente de autocompletado). La auditoría misma solo
+  enumera cuatro tokens.
+- `usePhoneField.ts` (logic, archivo único compartido): añadir
+  `autocomplete: "tel"` a `phoneInputOptions`. Ya expone `id`, `name` y
+  `aria-label` ("Número de teléfono") → el input de teléfono **ya tiene nombre
+  accesible**.
+- Asociar `VueTelInput` a su `UFormField label="Teléfono"`: hoy el `for` del
+  label (id generado por `UFormField`) no coincide con el `id="telefono"`
+  hardcodeado del input. Se alinea el id del input con el del field, o se usa
+  `aria-labelledby`. La API exacta del slot/id de `UFormField` se confirma con
+  Context7 al implementar.
+
+## Blast radius
+
+- `packages/ui-{alquilatucarro,alquilame,alquicarros}/app/components/CategorySelectionSection.vue`
+  — **byte-idénticos** (md5 `3ff360b3…`). Mantener idénticos tras el cambio.
+- `packages/ui-{…}/app/components/ReservationForm.vue` — byte-idénticos
+  (md5 `16adb618…`). Mantener idénticos.
+- `packages/logic/src/composables/usePhoneField.ts` — único, propaga a las 3
+  marcas vía el layer.
+- Sin consumidores fuera de presentación. Flujo crítico de conversión.
+- ⚠️ Riesgos: deep-link `?reservar=X`; regresión `pointer-events:none` de #25.
+  Ambos cubiertos por escenarios + verificación runtime.
+
+## Fuera de alcance
+
+- Deduplicar los componentes de UI al layer (refactor mayor, no es de este
+  issue). Las copias siguen byte-idénticas.
+- Tokens `autocomplete` inventados para tipo/número de identificación.
+- Tocar el prop `modal`/`overlay` (la modalidad ya es correcta).
+
+## Escenarios observables
+
+Ver `scenarios/a11y-reservation-slideover.scenarios.md`. Son el holdout para
+`/scenario-driven-development`.

--- a/docs/specs/issue-65-a11y-reservation-slideover/design.md
+++ b/docs/specs/issue-65-a11y-reservation-slideover/design.md
@@ -38,6 +38,13 @@ hermanos top-level controlados por `slideoverReservationResume` y
 `slideoverReservationForm`, con la invariante **a lo sumo uno abierto**. El
 botón "Siguiente" deja de ser un trigger anidado y pasa a un handler explícito.
 
+Dos handlers nuevos, `goToForm` y `backToResume`, mutan **ambos refs en el
+mismo tick, de forma síncrona** (sin `nextTick` entre las dos asignaciones).
+Esto es precondición de correctitud: los watchers usan `flush: 'pre'` (default),
+así que leen el estado ya consolidado al disparar. Si se metiera un `nextTick`
+entre las asignaciones, el watcher de URL vería un estado intermedio y borraría
+el `?reservar=X` (rompe SCEN-004).
+
 Transiciones (cada una deja un único modal o ninguno):
 
 | Acción de usuario / sistema | `resume` | `form` |
@@ -49,10 +56,21 @@ Transiciones (cada una deja un único modal o ninguno):
 | Deep-link `?reservar=X` | `false` | `true` |
 | Deep-link `/categoria/X` o `?resumen=X` | `true` | `false` |
 
-### Integración con los watchers de URL (cicatriz de #25)
+### Watchers: qué cambia y qué no
 
-Los watchers que sincronizan la URL (`:332-354`) están probados y no se
-reescriben. Solo se añade un guard de una línea al watcher de
+Hay tres bloques de watchers. Solo dos se tocan, y de forma quirúrgica.
+
+**1. Watcher de auto-apertura por deep-link (`:357-393`) — SÍ cambia.** Hoy,
+cuando `abrirFormularioDirecto` es `true`, abre `resume` y luego `form` en
+cascada (deja los dos abiertos). Con slideovers hermanos eso renderiza dos
+`[role=dialog]` a la vez y rompe la invariante (SCEN-001). Cambio: para
+`?reservar=X` abre **solo** `form` (`resume=false`); para `/categoria/X` o
+`?resumen=X` abre **solo** `resume`. La cascada anidada de `nextTick`
+desaparece. Nota: `abrirFormularioDirecto` se deriva solo de `reservarParam`;
+`?resumen=X` cae en la rama "solo resume", igual que el path `/categoria/X`.
+
+**2. Watchers de sincronización de URL (`:332-354`) — NO se reescriben.** Están
+probados (cicatriz de #25). Solo se añade un guard de una línea al watcher de
 `slideoverReservationResume`:
 
 ```
@@ -60,13 +78,22 @@ if (!isOpen && !slideoverReservationForm.value) updateCategoriaUrl(undefined)
 ```
 
 Razón: en la transición Resumen→Datos, `resume` pasa a `false` mientras `form`
-ya es `true`. Sin el guard, el watcher borraría el `?reservar=X` que el watcher
-de `form` acaba de poner. Con el guard, la URL solo se limpia cuando se cierran
-ambos. El watcher de cierre de `form` ya está condicionado a `resume`, así que
-no necesita cambios.
+ya es `true` (mismo tick). Sin el guard, este watcher borraría el `?reservar=X`
+que el watcher de `form` acaba de poner. Con el guard, la URL solo se limpia
+cuando se cierran ambos.
 
-`onBeforeRouteLeave` (`:401-409`) sigue cerrando ambos refs antes del unmount
-para no reintroducir el `pointer-events:none` colgado de #25.
+El watcher de cierre de `form` (`:341-354`) ya está condicionado a `resume` y no
+cambia, pero su correctitud es load-bearing en la transición Datos→Resumen.
+Traza de `backToResume` (reemplaza el handler de línea 163, que hoy solo hace
+`form=false`): setea `resume=true; form=false` síncrono → el watcher de `form`
+ve `resume=true` y llama `updateCategoriaUrl(codigo, false)` (quita `?reservar`,
+deja `/categoria/X`); el watcher de `resume` ve `isOpen=true` y no entra a la
+rama de limpieza. URL neta: `/categoria/X`. Coincide con SCEN-003.
+
+**3. `onBeforeRouteLeave` (`:401-409`) — NO cambia.** Sigue cerrando ambos refs
+antes del unmount para no reintroducir el `pointer-events:none` colgado de #25.
+El guard `isUpdatingFromUrl` hace que el watcher de `resume` (incluida la línea
+nueva) salga temprano durante el teardown, así que no dispara `replaceState`.
 
 ### aria-modal
 
@@ -82,14 +109,20 @@ runtime con Playwright (`/agent-browser`).
   (sería ruido para el agente de autocompletado). La auditoría misma solo
   enumera cuatro tokens.
 - `usePhoneField.ts` (logic, archivo único compartido): añadir
-  `autocomplete: "tel"` a `phoneInputOptions`. Ya expone `id`, `name` y
-  `aria-label` ("Número de teléfono") → el input de teléfono **ya tiene nombre
-  accesible**.
-- Asociar `VueTelInput` a su `UFormField label="Teléfono"`: hoy el `for` del
-  label (id generado por `UFormField`) no coincide con el `id="telefono"`
-  hardcodeado del input. Se alinea el id del input con el del field, o se usa
-  `aria-labelledby`. La API exacta del slot/id de `UFormField` se confirma con
-  Context7 al implementar.
+  `autocomplete: "tel"` a `phoneInputOptions`.
+- Asociar `VueTelInput` a su `UFormField label="Teléfono"` y **quitar el
+  `aria-label="Número de teléfono"`** de `phoneInputOptions`. Razón (resuelta
+  ahora, no en implementación): el `aria-label` y el label visible "Teléfono"
+  compiten por el nombre accesible. Por precedencia ARIA, `aria-label` gana →
+  el nombre accesible sería "Número de teléfono" mientras el label visible dice
+  "Teléfono", lo que **viola WCAG 2.5.3 Label in Name** (el texto visible debe
+  estar contenido en el nombre accesible). Decisión: el nombre accesible es
+  "Teléfono", provisto por el `UFormField` vía `aria-labelledby` apuntando al id
+  del label del field (o alineando el `for`/`id`). Se elimina el `aria-label`
+  redundante. `usePhoneField` solo lo consume este formulario, así que quitarlo
+  es seguro. La API exacta del slot/id de `UFormField` se confirma con Context7
+  al implementar; la decisión de cuál string es el nombre accesible ya está
+  tomada.
 
 ## Blast radius
 
@@ -109,6 +142,21 @@ runtime con Playwright (`/agent-browser`).
   issue). Las copias siguen byte-idénticas.
 - Tokens `autocomplete` inventados para tipo/número de identificación.
 - Tocar el prop `modal`/`overlay` (la modalidad ya es correcta).
+
+## Nota para el implementador
+
+`PhoneInputOptionsType` (`packages/logic/src/utils/types/type/PhoneInputOptionsType.ts`)
+ya está desincronizado: declara `showDialCode/id/name/placeholder` pero omite el
+`aria-label` actual. Al añadir `autocomplete` y quitar `aria-label`, actualizar
+el tipo (`autocomplete: string`, sin `aria-label`) por higiene. No rompe el
+typecheck (TS no aplica excess-property check al retorno de un
+`computed<T>(() => ({...}))`), pero el tipo debe reflejar la realidad.
+
+La aserción de SCEN-008 ("nombre accesible == 'Teléfono'") se valida con el
+accessibility tree en runtime, no solo por presencia de atributos. Si
+`VueTelInput` renderiza su `<input>` dentro de su propia estructura, puede que
+`for`/`id` no baste y haya que usar `aria-labelledby`; el árbol de
+accesibilidad es el árbitro.
 
 ## Escenarios observables
 

--- a/docs/specs/issue-65-a11y-reservation-slideover/implementation/plan.md
+++ b/docs/specs/issue-65-a11y-reservation-slideover/implementation/plan.md
@@ -1,0 +1,119 @@
+---
+name: issue-65-a11y-reservation-slideover-plan
+created_by: claude
+created_at: 2026-06-04T00:00:00Z
+issue: 65
+spec: ../design.md
+scenarios: ../scenarios/a11y-reservation-slideover.scenarios.md
+---
+
+# Plan de implementación — Issue #65
+
+Diseño y escenarios ya aprobados (ver `spec`/`scenarios`). Este plan solo aporta
+el mapa de archivos y los pasos ordenados con escenarios embebidos. No repite
+clarificación ni research: el spec pasó spec-review.
+
+## Chunk 1: Form a11y + slideover restructure
+
+### Mapa de archivos
+
+| Archivo | Responsabilidad | Cambio |
+|---|---|---|
+| `packages/logic/src/composables/usePhoneField.ts` | Opciones del input de teléfono (compartido) | `+autocomplete:'tel'`, **quitar** `aria-label` |
+| `packages/logic/src/utils/types/type/PhoneInputOptionsType.ts` | Tipo de esas opciones | `+autocomplete: string`, quitar `aria-label` (higiene, no rompe tsc) |
+| `packages/ui-{atc,alquilame,alquicarros}/app/components/ReservationForm.vue` | Formulario de datos (×3 byte-idénticos) | `autocomplete` en nombres/apellidos/email; asociar `VueTelInput` al `UFormField` |
+| `packages/ui-{atc,alquilame,alquicarros}/app/components/CategorySelectionSection.vue` | Grid + slideovers Resumen/Datos (×3 byte-idénticos) | des-anidar slideovers; `goToForm`/`backToResume`; reescribir watcher de auto-apertura; guard de 1 línea en watcher de URL |
+
+Invariante de paridad: tras cada paso, los 3 archivos de cada componente quedan
+**byte-idénticos** (mismo md5). Estrategia: editar `alquilatucarro`, luego copiar
+el archivo a las otras dos marcas.
+
+### Prerrequisitos
+
+- Dev server por marca: `pnpm dev:alquilatucarro` (`:3000`).
+- Backend admin en `:3000` para tarjetas reales; si no, stub de availability vía
+  Playwright `page.route` (NO via agent-browser network route — no intercepta el
+  POST; ver memoria de validación local).
+- Confirmar API de `UFormField` (slot/id para asociar label) con Context7 antes
+  del paso 2.
+
+### Pasos
+
+Orden: primero Problema B (independiente, bajo riesgo), luego Problema A
+(reestructura, mayor riesgo). SDD: escenario → código → satisfacer → refactor.
+
+**Paso 1 — autocomplete en campos de texto** · Size: S · Dep: ninguna
+El formulario expone `autocomplete="given-name"` (nombres), `family-name`
+(apellidos), `email` (correo); tipo y número de identificación NO exponen
+`autocomplete` (no se fabrica token ni `"off"`).
+- Archivos: `ReservationForm.vue` ×3.
+- Escenario: SCEN-007 (atributos presentes en 3, ausentes en 2 de id).
+- Aceptación: DOM renderizado muestra los 3 tokens; los 2 de id sin atributo;
+  3 archivos byte-idénticos.
+
+**Paso 2 — teléfono: autocomplete + nombre accesible "Teléfono"** · Size: M · Dep: Paso 1
+El input de teléfono expone `autocomplete="tel"`, su nombre accesible computado
+es "Teléfono" (vía `UFormField`), y ya no tiene `aria-label="Número de
+teléfono"`.
+- Archivos: `usePhoneField.ts`, `PhoneInputOptionsType.ts`, `ReservationForm.vue` ×3.
+- Confirmar con Context7 si la asociación va por `for`/`id` o `aria-labelledby`
+  (depende de cómo `VueTelInput` renderiza su `<input>`).
+- Escenario: SCEN-008 (accessible name == "Teléfono", `aria-label` ausente,
+  `autocomplete="tel"`).
+- Aceptación: accessibility tree en runtime confirma el nombre; tsc verde;
+  archivos byte-idénticos.
+
+**Paso 3 — reestructura completa del slideover (un cambio atómico)** · Size: L · Dep: ninguna (independiente de 1-2, mismo archivo)
+> Fusiona des-anidar + handlers + watcher de auto-apertura + guard de URL en
+> **un solo paso**. Razón (spec-review): des-anidar sin reescribir la cascada
+> deja un estado intermedio roto — un deep-link `?reservar=X` renderizaría dos
+> `[role=dialog]` hermanos. El des-anidar no es demoable verde sin la reescritura
+> de la cascada, así que van juntos.
+
+Cambios en `CategorySelectionSection.vue` ×3:
+1. "Datos" sale del `#footer` de "Resumen" → ambos hermanos top-level.
+2. "Siguiente" → `goToForm` (`form=true; resume=false`, síncrono).
+3. "Volver" en Datos → `backToResume` (`resume=true; form=false`, síncrono;
+   reemplaza el handler de línea 163).
+4. Watcher de auto-apertura (`:357-393`): `?reservar=X` abre **solo** `form`;
+   `/categoria/X` o `?resumen=X` abre **solo** `resume` (elimina la cascada).
+5. Guard de 1 línea en el watcher de `slideoverReservationResume` (`:332-338`):
+   `if (!isOpen && !slideoverReservationForm.value) updateCategoriaUrl(undefined)`.
+
+Invariante en todo momento y por toda ruta de entrada: a lo sumo un
+`[role=dialog]`, con `aria-modal="true"`.
+- Escenarios: SCEN-002a (click tarjeta → solo Resumen), SCEN-002 (Siguiente →
+  solo Datos), SCEN-003 (Volver → reabre Resumen, URL `/categoria/X`), SCEN-001
+  (deep-link `?reservar` → solo Datos), SCEN-001b (cold-load `/categoria/X` →
+  solo Resumen), SCEN-004 (transición no borra `?reservar=X`), SCEN-005 (Volver
+  en Resumen → cierra todo + limpia URL).
+- Aceptación: los 7 escenarios pasan en runtime; conteo de `[role=dialog]` == 1
+  en cada transición **y en cada deep-link**; archivos byte-idénticos.
+
+**Paso 4 — regresión #25 + verificación integral** · Size: S · Dep: Paso 3
+Confirmar que `onBeforeRouteLeave` sigue cerrando ambos refs y que Back no deja
+`pointer-events:none` colgado en `<body>`. Correr los 11 escenarios en
+Playwright sobre las 3 marcas (o al menos atc + un smoke en las otras dos por la
+paridad byte-idéntica).
+- Escenarios: SCEN-006 (regresión #25), SCEN-009 (paridad md5).
+- Aceptación: Searcher responde tras Back; `<body>` sin `pointer-events:none`;
+  md5 de los 6 archivos coincide por componente; `pnpm typecheck` + `pnpm lint`
+  sin delta nuevo vs baseline.
+
+## Testing Strategy
+
+- **Runtime (principal)**: Playwright/`agent-browser` sobre preview de
+  alquilatucarro — snapshots del accessibility tree, conteo de `[role=dialog]`,
+  inspección de `window.location` y de `<body>` inline style. Stub de
+  availability vía `page.route` si no hay backend en `:3000`.
+- **Paridad**: `md5sum` de los 6 archivos UI tras cada paso (SCEN-009).
+- **Estático**: `pnpm typecheck` y `pnpm lint` — delta-vs-baseline, no "verde"
+  absoluto (baseline rojo conocido).
+- Sin unit tests nuevos: el comportamiento es de DOM/a11y, se valida en runtime.
+
+## Rollout
+
+- Worktree `fix/issue-65-a11y-slideover-autocomplete` → PR contra `main`.
+- Verificación en preview de Vercel (3 marcas). alquilatucarro es la única en
+  dominio público; alquicarros/alquilame se validan vía alias `-git-main-`.
+- Rollback: revertir el PR; cambios aislados a 4 archivos lógicos, reversibles.

--- a/docs/specs/issue-65-a11y-reservation-slideover/scenarios/a11y-reservation-slideover.scenarios.md
+++ b/docs/specs/issue-65-a11y-reservation-slideover/scenarios/a11y-reservation-slideover.scenarios.md
@@ -8,10 +8,17 @@ epic: 63
 
 # A11y del flujo de reserva: un solo slideover modal + autocomplete
 
-Flujo de reserva de las tres marcas (componentes byte-idénticos). Dos slideovers
+Flujo de reserva de las tres marcas (componentes byte-idénticos). Dos pasos
 secuenciales — "Resumen de la reserva" → "Datos para reservas" — deben respetar
 la invariante **a lo sumo un diálogo modal abierto**. El formulario debe exponer
 `autocomplete` estándar y nombre accesible.
+
+> Nota de implementación (post SCEN-011): los dos "pasos" son `slideoverStep`
+> dentro de **un único `<u-slideover>`**, no dos slideovers. SCEN-001…010 son
+> contratos **observables** (título/conteo de `[role=dialog]`/URL) y se cumplen
+> igual: el contenido se intercambia dentro del mismo diálogo. Redacciones como
+> "Resumen se cierra" (SCEN-002) describen el efecto observable (el `[role=dialog]`
+> pasa a titularse "Datos"), no dos elementos.
 
 Invariante central: en todo momento hay **0 o 1** `[role=dialog]` visible; si hay
 uno, tiene `aria-modal="true"`.
@@ -102,3 +109,21 @@ autocomplete inspecciona el DOM renderizado. SCEN-006 es regresión de #25.
 > Origen: edge-case review del PR #65 (Escape es ruta primaria de cierre a11y).
 > El watcher de form, en su rama `else` cuando Resumen tampoco está abierto,
 > llama `updateCategoriaUrl(undefined)`.
+
+## SCEN-011: tras Resumen→Datos→cerrar, la grilla sigue interactiva (regresión #65)
+**Given**: la grilla de resultados; el usuario abre "Resumen" desde una tarjeta, pasa a "Datos" con "Siguiente", y luego cierra todo **en la misma página** (por el botón X, por Escape, o por "Volver"→"Volver"), sin cambiar de ruta
+**When**: el usuario hace click en "Solicitar este vehículo" de cualquier tarjeta para reseleccionar
+**Then**: la tarjeta responde y reaparece "Resumen" como único `[role=dialog]`; con 0 diálogos abiertos, el `<body>` **no** conserva `pointer-events:none` inline (la grilla es clickeable; el `<html>` no intercepta el puntero)
+**Evidence**: `document.body.style.pointerEvents` (≠ `none`, vacío) con conteo de `[role=dialog]` = 0 tras cerrar; y `[role=dialog]` "Resumen" visible tras el click de reselección
+
+> Origen: bug reportado por el usuario (2026-06-05) y reproducido. Causa raíz
+> (systematic-debugging): el diseño de **dos slideovers hermanos** hacía que
+> `goToForm`/`backToResume` mutaran ambos refs en el mismo tick (cerrar uno +
+> abrir otro), corrompiendo el conteo de capas de reka-ui y dejando
+> `pointer-events:none` pegado en `<body>` con 0 diálogos. **Verificado como
+> regresión**: `main` (anidado) limpia bien incluso con dos modales abiertos.
+> Fix (Option C): colapsar a **un solo `<u-slideover>` con un `step` interno**
+> (`resumen`|`datos`) — el diálogo se abre y cierra **una vez** por flujo, sin
+> swap ni stacking. El invariante "0 o 1 `[role=dialog]`" pasa a ser estructural
+> (un único `DialogContent`); SCEN-001…010 mantienen su contrato observable (el
+> contenido se intercambia dentro del mismo diálogo).

--- a/docs/specs/issue-65-a11y-reservation-slideover/scenarios/a11y-reservation-slideover.scenarios.md
+++ b/docs/specs/issue-65-a11y-reservation-slideover/scenarios/a11y-reservation-slideover.scenarios.md
@@ -71,8 +71,15 @@ autocomplete inspecciona el DOM renderizado. SCEN-006 es regresión de #25.
 ## SCEN-007: campos del formulario exponen autocomplete estándar
 **Given**: el slideover "Datos" abierto con el formulario renderizado
 **When**: se inspecciona el DOM de los inputs
-**Then**: nombres → `autocomplete="given-name"`, apellidos → `family-name`, correo → `email`; y los campos de identificación (tipo y número) **no** exponen ningún atributo `autocomplete` (no se fabrica token; tampoco `"off"`)
-**Evidence**: atributo `autocomplete` de cada `<input>` en el snapshot (presente en los 3, ausente en los 2 de identificación)
+**Then**: nombres → `autocomplete="given-name"`, apellidos → `family-name`, correo → `email`; y los campos de identificación **no fabrican un token de datos personales**: exponen el `autocomplete="off"` por defecto de `@nuxt/ui` UInput (señal correcta de no-autocompletar para un documento de identidad)
+**Evidence**: atributo `autocomplete` de cada `<input>` en el snapshot (tokens personales en los 3; `"off"` en el de identificación)
+
+> Amend (2026-06-04, aprobado por el usuario): la versión previa exigía que
+> identificación **no** expusiera `autocomplete` "tampoco off". Premisa falsa,
+> verificada en el DOM: `@nuxt/ui` UInput pone `autocomplete="off"` por defecto
+> y no es removible sin degradar la a11y. `"off"` cumple la intención original
+> (no fabricar un token de datos personales engañoso) y es el valor correcto
+> para un campo de cédula/ID.
 
 ## SCEN-008: el teléfono expone autocomplete y su nombre accesible es "Teléfono"
 **Given**: el formulario renderizado

--- a/docs/specs/issue-65-a11y-reservation-slideover/scenarios/a11y-reservation-slideover.scenarios.md
+++ b/docs/specs/issue-65-a11y-reservation-slideover/scenarios/a11y-reservation-slideover.scenarios.md
@@ -1,0 +1,75 @@
+---
+name: a11y-reservation-slideover
+created_by: claude
+created_at: 2026-06-04T00:00:00Z
+issue: 65
+epic: 63
+---
+
+# A11y del flujo de reserva: un solo slideover modal + autocomplete
+
+Flujo de reserva de las tres marcas (componentes byte-idénticos). Dos slideovers
+secuenciales — "Resumen de la reserva" → "Datos para reservas" — deben respetar
+la invariante **a lo sumo un diálogo modal abierto**. El formulario debe exponer
+`autocomplete` estándar y nombre accesible.
+
+Invariante central: en todo momento hay **0 o 1** `[role=dialog]` visible; si hay
+uno, tiene `aria-modal="true"`.
+
+Verificación: runtime con Playwright (`/agent-browser`) sobre preview de
+alquilatucarro; los escenarios de URL inspeccionan `window.location`; el de
+autocomplete inspecciona el DOM renderizado. SCEN-006 es regresión de #25.
+
+## SCEN-001: apertura directa por deep-link expone un único modal
+**Given**: la página de resultados abierta con `?reservar=ECAR` (categoría válida y disponible)
+**When**: las categorías cargan y el slideover de datos se auto-abre
+**Then**: existe exactamente un `[role=dialog][aria-modal="true"]` en el DOM y es el de "Datos para reservas" (no el de "Resumen")
+**Evidence**: conteo de `[role=dialog]` visibles y su `aria-modal`/título en el snapshot de Playwright
+
+## SCEN-002: Resumen → Datos cierra el Resumen
+**Given**: el slideover "Resumen de la reserva" abierto (tras click en una tarjeta)
+**When**: el usuario hace click en "Siguiente"
+**Then**: "Resumen" se cierra y queda exactamente un `[role=dialog]` visible, el de "Datos"
+**Evidence**: conteo de `[role=dialog]` visibles antes/después en el snapshot
+
+## SCEN-003: Datos → Volver reabre el Resumen y restaura la URL
+**Given**: el slideover "Datos" abierto, URL en `/.../categoria/ecar?reservar=ECAR`
+**When**: el usuario hace click en "Volver" dentro de "Datos"
+**Then**: reaparece "Resumen" como único `[role=dialog]` y la URL es `/.../categoria/ecar` (sin `?reservar`)
+**Evidence**: título del dialog activo + `window.location.pathname`+`search`
+
+## SCEN-004: la transición Resumen→Datos no borra el deep-link
+**Given**: el slideover "Resumen" abierto en `/.../categoria/ecar`
+**When**: el usuario hace click en "Siguiente" (abre "Datos")
+**Then**: la URL pasa a `/.../categoria/ecar?reservar=ECAR` y permanece así (la apertura de Datos no la limpia)
+**Evidence**: `window.location.search` tras la transición
+
+## SCEN-005: "Volver" en Resumen cierra todo y limpia la URL
+**Given**: el slideover "Resumen" abierto en `/.../categoria/ecar`
+**When**: el usuario hace click en "Volver" dentro de "Resumen"
+**Then**: no queda ningún `[role=dialog]` visible y la URL vuelve a la base (sin `/categoria/...` ni `?reservar`)
+**Evidence**: conteo de `[role=dialog]` (= 0) + `window.location.pathname`
+
+## SCEN-006: regresión #25 — Back no deja el Searcher bloqueado
+**Given**: cualquier slideover abierto, luego navegación a otra ruta y regreso vía Back del navegador
+**When**: el usuario interactúa con el Searcher
+**Then**: el Searcher responde; el `<body>` no conserva `pointer-events:none` inline
+**Evidence**: estilo inline de `<body>` + click efectivo en un control del Searcher
+
+## SCEN-007: campos del formulario exponen autocomplete estándar
+**Given**: el slideover "Datos" abierto con el formulario renderizado
+**When**: se inspecciona el DOM de los inputs
+**Then**: nombres → `autocomplete="given-name"`, apellidos → `family-name`, correo → `email`
+**Evidence**: atributo `autocomplete` de cada `<input>` en el snapshot
+
+## SCEN-008: el teléfono expone autocomplete y nombre accesible asociado
+**Given**: el formulario renderizado
+**When**: se inspecciona el input de teléfono (`VueTelInput`)
+**Then**: expone `autocomplete="tel"` y tiene nombre accesible asociado a su `UFormField` (label "Teléfono" vía `for`/`id` o `aria-labelledby`, sin romper el `aria-label` existente)
+**Evidence**: atributos `autocomplete` y `aria-labelledby`/`id` del input de teléfono; nombre accesible computado
+
+## SCEN-009: paridad entre marcas
+**Given**: los componentes de las tres marcas
+**When**: se comparan tras el cambio
+**Then**: `CategorySelectionSection.vue` y `ReservationForm.vue` siguen byte-idénticos entre alquilatucarro, alquilame y alquicarros
+**Evidence**: md5 de los 6 archivos (3 + 3) coincide por componente

--- a/docs/specs/issue-65-a11y-reservation-slideover/scenarios/a11y-reservation-slideover.scenarios.md
+++ b/docs/specs/issue-65-a11y-reservation-slideover/scenarios/a11y-reservation-slideover.scenarios.md
@@ -26,6 +26,18 @@ autocomplete inspecciona el DOM renderizado. SCEN-006 es regresión de #25.
 **Then**: existe exactamente un `[role=dialog][aria-modal="true"]` en el DOM y es el de "Datos para reservas" (no el de "Resumen")
 **Evidence**: conteo de `[role=dialog]` visibles y su `aria-modal`/título en el snapshot de Playwright
 
+## SCEN-001b: cold-load /categoria/X (sin reservar) abre solo el Resumen
+**Given**: navegación en frío a `/.../categoria/ecar` sin `?reservar` (o `?resumen=ECAR`)
+**When**: las categorías cargan y el slideover se auto-abre
+**Then**: existe exactamente un `[role=dialog]` visible y es el de "Resumen" (no el de "Datos")
+**Evidence**: conteo de `[role=dialog]` visibles + título en el snapshot (otra rama del watcher de auto-apertura)
+
+## SCEN-002a: click en tarjeta abre solo el Resumen
+**Given**: la página de resultados sin slideover abierto
+**When**: el usuario hace click en una tarjeta de categoría (`setSelectedCategory`)
+**Then**: aparece exactamente un `[role=dialog]` visible y es el de "Resumen de la reserva" (no el de "Datos")
+**Evidence**: conteo de `[role=dialog]` visibles + título en el snapshot
+
 ## SCEN-002: Resumen → Datos cierra el Resumen
 **Given**: el slideover "Resumen de la reserva" abierto (tras click en una tarjeta)
 **When**: el usuario hace click en "Siguiente"
@@ -59,14 +71,14 @@ autocomplete inspecciona el DOM renderizado. SCEN-006 es regresión de #25.
 ## SCEN-007: campos del formulario exponen autocomplete estándar
 **Given**: el slideover "Datos" abierto con el formulario renderizado
 **When**: se inspecciona el DOM de los inputs
-**Then**: nombres → `autocomplete="given-name"`, apellidos → `family-name`, correo → `email`
-**Evidence**: atributo `autocomplete` de cada `<input>` en el snapshot
+**Then**: nombres → `autocomplete="given-name"`, apellidos → `family-name`, correo → `email`; y los campos de identificación (tipo y número) **no** exponen ningún atributo `autocomplete` (no se fabrica token; tampoco `"off"`)
+**Evidence**: atributo `autocomplete` de cada `<input>` en el snapshot (presente en los 3, ausente en los 2 de identificación)
 
-## SCEN-008: el teléfono expone autocomplete y nombre accesible asociado
+## SCEN-008: el teléfono expone autocomplete y su nombre accesible es "Teléfono"
 **Given**: el formulario renderizado
 **When**: se inspecciona el input de teléfono (`VueTelInput`)
-**Then**: expone `autocomplete="tel"` y tiene nombre accesible asociado a su `UFormField` (label "Teléfono" vía `for`/`id` o `aria-labelledby`, sin romper el `aria-label` existente)
-**Evidence**: atributos `autocomplete` y `aria-labelledby`/`id` del input de teléfono; nombre accesible computado
+**Then**: expone `autocomplete="tel"`; su nombre accesible computado es exactamente "Teléfono" (provisto por el `UFormField` vía `aria-labelledby`/`for`-`id`); y **no** conserva `aria-label="Número de teléfono"` (se eliminó para no violar Label in Name)
+**Evidence**: atributos `autocomplete`, `aria-labelledby`/`id` y `aria-label` del input; nombre accesible computado (Accessibility tree / `accessibleName`)
 
 ## SCEN-009: paridad entre marcas
 **Given**: los componentes de las tres marcas

--- a/docs/specs/issue-65-a11y-reservation-slideover/scenarios/a11y-reservation-slideover.scenarios.md
+++ b/docs/specs/issue-65-a11y-reservation-slideover/scenarios/a11y-reservation-slideover.scenarios.md
@@ -84,7 +84,7 @@ autocomplete inspecciona el DOM renderizado. SCEN-006 es regresión de #25.
 ## SCEN-008: el teléfono expone autocomplete y su nombre accesible es "Teléfono"
 **Given**: el formulario renderizado
 **When**: se inspecciona el input de teléfono (`VueTelInput`)
-**Then**: expone `autocomplete="tel"`; su nombre accesible computado es exactamente "Teléfono" (provisto por el `UFormField` vía `aria-labelledby`/`for`-`id`); y **no** conserva `aria-label="Número de teléfono"` (se eliminó para no violar Label in Name)
+**Then**: expone `autocomplete="tel"`; su nombre accesible computado es exactamente "Teléfono" (provisto por un `<label for="telefono">` propio dentro del `UFormField` — `VueTelInput` no usa `useFormField`, así que el `for` autogenerado del field no asocia su `<input>`; se controla el `id`/`for` a mano); y **no** conserva `aria-label="Número de teléfono"` (se eliminó para no violar Label in Name)
 **Evidence**: atributos `autocomplete`, `aria-labelledby`/`id` y `aria-label` del input; nombre accesible computado (Accessibility tree / `accessibleName`)
 
 ## SCEN-009: paridad entre marcas
@@ -92,3 +92,13 @@ autocomplete inspecciona el DOM renderizado. SCEN-006 es regresión de #25.
 **When**: se comparan tras el cambio
 **Then**: `CategorySelectionSection.vue` y `ReservationForm.vue` siguen byte-idénticos entre alquilatucarro, alquilame y alquicarros
 **Evidence**: md5 de los 6 archivos (3 + 3) coincide por componente
+
+## SCEN-010: Escape/cerrar "Datos" sin reabrir Resumen limpia la URL
+**Given**: el slideover "Datos" abierto vía deep-link `?reservar=X`
+**When**: el usuario lo cierra con Escape (o el botón X / click fuera), sin pasar por "Volver"
+**Then**: no queda ningún `[role=dialog]` visible y la URL pierde `?reservar` (vuelve a la base, sin `/categoria/...`); un reload no re-abre el slideover descartado
+**Evidence**: conteo de `[role=dialog]:visible` (= 0) + `window.location` tras Escape
+
+> Origen: edge-case review del PR #65 (Escape es ruta primaria de cierre a11y).
+> El watcher de form, en su rama `else` cuando Resumen tampoco está abierto,
+> llama `updateCategoriaUrl(undefined)`.

--- a/docs/specs/issue-65-a11y-reservation-slideover/summary.md
+++ b/docs/specs/issue-65-a11y-reservation-slideover/summary.md
@@ -20,10 +20,13 @@ modal activo + `autocomplete`/nombre accesible en el formulario) en las 3 marcas
 ## Decisiones clave
 1. **Des-anidar + mutuamente excluyentes** (no `inert`): un solo `[role=dialog]`
    por construcción, no por parche de atributo.
-2. **El diagnóstico de la auditoría era erróneo**: no falta `aria-modal` (reka-ui
-   ya lo pone con `modal=true`), el defecto es dos modales simultáneos.
+2. **El diagnóstico de la auditoría era erróneo**: el defecto NO es falta de
+   `aria-modal` sino **dos modales simultáneos**. reka-ui NO emite `aria-modal`
+   en ningún caso (verificado: 0 ocurrencias en su dist), así que se inyecta
+   explícitamente vía la prop `content`.
 3. **Quitar `aria-label="Número de teléfono"`**: violaba WCAG 2.5.3 Label in Name;
-   el nombre accesible pasa a "Teléfono" vía `UFormField`.
+   el nombre accesible pasa a "Teléfono" vía un `<label for="telefono">` propio
+   dentro del `UFormField` (no por `useFormField`, que `VueTelInput` no usa).
 4. **Reestructura atómica** (Paso 3): un-nest + watcher + guard en un commit
    indivisible — evita el estado intermedio de dos diálogos en deep-link.
 

--- a/docs/specs/issue-65-a11y-reservation-slideover/summary.md
+++ b/docs/specs/issue-65-a11y-reservation-slideover/summary.md
@@ -1,0 +1,41 @@
+---
+name: issue-65-a11y-reservation-slideover-summary
+created_by: claude
+created_at: 2026-06-04T00:00:00Z
+issue: 65
+epic: 63
+ola: 0
+---
+
+# Planning Summary — Issue #65
+
+**Goal**: arreglar dos defectos de a11y del flujo de reserva (un solo slideover
+modal activo + `autocomplete`/nombre accesible en el formulario) en las 3 marcas.
+
+## Artefactos
+- `design.md` — diseño (spec-reviewed, approved)
+- `scenarios/a11y-reservation-slideover.scenarios.md` — 11 escenarios (holdout SDD)
+- `implementation/plan.md` — plan de 4 pasos (plan-reviewed, approved)
+
+## Decisiones clave
+1. **Des-anidar + mutuamente excluyentes** (no `inert`): un solo `[role=dialog]`
+   por construcción, no por parche de atributo.
+2. **El diagnóstico de la auditoría era erróneo**: no falta `aria-modal` (reka-ui
+   ya lo pone con `modal=true`), el defecto es dos modales simultáneos.
+3. **Quitar `aria-label="Número de teléfono"`**: violaba WCAG 2.5.3 Label in Name;
+   el nombre accesible pasa a "Teléfono" vía `UFormField`.
+4. **Reestructura atómica** (Paso 3): un-nest + watcher + guard en un commit
+   indivisible — evita el estado intermedio de dos diálogos en deep-link.
+
+## Complejidad
+- **Overall**: M · **Riesgo**: Medio (flujo de conversión + cicatriz #25)
+- Paso 3 (L) es el de mayor riesgo de presupuesto.
+
+## Próximos pasos
+1. `/scenario-driven-development` con los 11 escenarios como holdout.
+2. Verificación runtime Playwright sobre las 3 marcas.
+3. `/verification-before-completion` antes de PR.
+
+## Open questions
+- API exacta `UFormField`→`VueTelInput` (Context7 al implementar; fallback
+  `aria-labelledby`).

--- a/e2e/reservation-a11y-single-dialog.spec.ts
+++ b/e2e/reservation-a11y-single-dialog.spec.ts
@@ -1,0 +1,280 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Holdout: docs/specs/issue-65-a11y-reservation-slideover/scenarios/
+ *          a11y-reservation-slideover.scenarios.md
+ * Issue:   https://github.com/amaw-sas/rentacar-web/issues/65 (épico #63, Ola 0)
+ *
+ * Invariante central: en el flujo de reserva (Resumen → Datos) hay en todo
+ * momento 0 o 1 [role=dialog] visible; si hay uno, tiene aria-modal="true".
+ * Antes del fix, "Datos" estaba anidado en el #footer de "Resumen" y se abrían
+ * dos diálogos modales simultáneos. Tras des-anidar a hermanos mutuamente
+ * excluyentes, solo uno está activo por ruta de entrada.
+ *
+ * Backend: requiere categorías reales (admin availability). Sin ellas, los
+ * tests dependientes hacen test.skip — misma convención que
+ * e2e/reservation-back-url-cleanup.spec.ts. Fechas futuras para maximizar
+ * disponibilidad real.
+ */
+
+const searchPath =
+  '/bogota/buscar-vehiculos' +
+  '/lugar-recogida/bogota-aeropuerto' +
+  '/lugar-devolucion/bogota-aeropuerto' +
+  '/fecha-recogida/2026-07-10' +
+  '/fecha-devolucion/2026-07-12' +
+  '/hora-recogida/10:00am' +
+  '/hora-devolucion/10:00am';
+
+// Availability is fetched CLIENT-SIDE (useFetchCategoriesAvailabilityData),
+// so page.route intercepts it. The admin backend (NUXT_RENTACAR_ADMIN_URL)
+// points at a local :3000 that isn't running in this env, so we stub. The
+// categoryCode MUST be a real vehicleCategories key (loaded via SSR from
+// Supabase) or renderableCategories drops it and no card renders — 'C' is real
+// (see /api/rentacar-data). estimatedTotalAmount != 999999999 → real card,
+// not a "No disponible" placeholder.
+const STUB_CODE = 'C';
+const AVAILABILITY_STUB = [
+  {
+    categoryCode: STUB_CODE,
+    categoryDescription: 'Económico Mecánico',
+    categoryModels: [],
+    categoryMonthPrices: [],
+    totalAmount: 500000,
+    estimatedTotalAmount: 500000,
+    vehicleDayCharge: 250000,
+    numberDays: 2,
+    taxFeeAmount: 0,
+    taxFeePercentage: 0,
+    IVAFeeAmount: 95000,
+    coverageUnitCharge: 0,
+    coverageQuantity: 0,
+    coverageTotalAmount: 0,
+    totalCoverageUnitCharge: 0,
+    referenceToken: 'STUB-TOKEN-65',
+    rateQualifier: 'STUB',
+  },
+];
+
+async function stubAvailability(page: Page) {
+  await page.route('**/api/reservations/availability', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(AVAILABILITY_STUB),
+    }),
+  );
+}
+
+async function firstAvailableCategoryCode(page: Page): Promise<string | null> {
+  return await page.evaluate(() => {
+    const buttons = Array.from(document.querySelectorAll('button')).map(
+      (b) => b.textContent ?? '',
+    );
+    for (const text of buttons) {
+      const m = text.match(/Grupo\s+([A-Z0-9]+)\s*\(/);
+      if (m) return m[1];
+    }
+    return null;
+  });
+}
+
+/** Navigate to the search page and return the first rendered category code, or
+ * null (caller skips). Avoids networkidle: dev server may retry admin calls. */
+async function gotoSearchAndGetCode(page: Page): Promise<string | null> {
+  await stubAvailability(page);
+  await page.goto(searchPath);
+  await page.waitForLoadState('domcontentloaded');
+  return await Promise.race([
+    page
+      .waitForFunction(
+        () =>
+          Array.from(document.querySelectorAll('button')).some((b) =>
+            /Grupo\s+[A-Z0-9]+\s*\(/.test(b.textContent ?? ''),
+          ),
+        { timeout: 20_000 },
+      )
+      .then(() => firstAvailableCategoryCode(page))
+      .catch(() => null),
+    page.waitForTimeout(20_000).then(() => null),
+  ]);
+}
+
+const visibleDialogs = (page: Page) => page.locator('[role="dialog"]:visible');
+const visibleModalDialogs = (page: Page) =>
+  page.locator('[role="dialog"][aria-modal="true"]:visible');
+
+test.describe('Reserva a11y — un solo slideover modal activo (issue #65) — desktop', () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test('SCEN-001: deep-link ?reservar=X abre exactamente un diálogo modal y es "Datos"', async ({
+    page,
+  }) => {
+    const code = await gotoSearchAndGetCode(page);
+    test.skip(!code, 'Sin categorías renderizadas (admin availability no disponible)');
+
+    await page.goto(`${searchPath}/categoria/${code}?reservar=${code}`);
+    await page.waitForLoadState('domcontentloaded');
+
+    await expect(visibleDialogs(page)).toHaveCount(1, { timeout: 15_000 });
+    await expect(visibleModalDialogs(page)).toHaveCount(1);
+    await expect(
+      page.getByRole('dialog').filter({ hasText: 'Datos para reservas' }),
+    ).toBeVisible();
+    // El de "Resumen" NO debe estar visible.
+    await expect(
+      page.locator('[role="dialog"]:visible', { hasText: 'Resumen de la reserva' }),
+    ).toHaveCount(0);
+  });
+
+  test('SCEN-001b: cold-load /categoria/X (sin reservar) abre solo "Resumen"', async ({
+    page,
+  }) => {
+    const code = await gotoSearchAndGetCode(page);
+    test.skip(!code, 'Sin categorías renderizadas');
+
+    await page.goto(`${searchPath}/categoria/${code}`);
+    await page.waitForLoadState('domcontentloaded');
+
+    await expect(visibleDialogs(page)).toHaveCount(1, { timeout: 15_000 });
+    await expect(visibleModalDialogs(page)).toHaveCount(1);
+    await expect(
+      page.getByRole('dialog').filter({ hasText: 'Resumen de la reserva' }),
+    ).toBeVisible();
+  });
+
+  test('SCEN-002a/002/003/004/005: flujo click — un diálogo por paso + URL', async ({
+    page,
+  }) => {
+    const code = await gotoSearchAndGetCode(page);
+    test.skip(!code, 'Sin categorías renderizadas');
+
+    // SCEN-002a: click en el CTA de la tarjeta → solo "Resumen".
+    // El CTA que dispara setSelectedCategory es "Solicitar este vehículo"
+    // (CategoryCard.vue goNextStep), no el título "Grupo X".
+    await page.getByRole('button', { name: 'Solicitar este vehículo' }).first().click();
+    await expect(visibleDialogs(page)).toHaveCount(1, { timeout: 10_000 });
+    await expect(
+      page.getByRole('dialog').filter({ hasText: 'Resumen de la reserva' }),
+    ).toBeVisible();
+    await expect(page).toHaveURL(new RegExp(`/categoria/${code.toLowerCase()}$`));
+
+    // SCEN-002 + SCEN-004: "Siguiente" → solo "Datos" + URL gana ?reservar=X.
+    // Selector estable por data-testid: hay otros role=button con nombre
+    // accesible "Siguiente"/"Volver" en la página (convención del proyecto).
+    await page.getByTestId('reservation-next-test').click();
+    await expect(visibleDialogs(page)).toHaveCount(1, { timeout: 10_000 });
+    const formDialog = page.getByRole('dialog').filter({ hasText: 'Datos para reservas' });
+    await expect(formDialog).toBeVisible();
+    await expect(page).toHaveURL(new RegExp(`reservar=${code}`));
+
+    // SCEN-003: "Volver" en Datos → reabre "Resumen" + URL pierde ?reservar.
+    await page.getByTestId('reservation-form-back-test').click();
+    await expect(visibleDialogs(page)).toHaveCount(1, { timeout: 10_000 });
+    await expect(
+      page.getByRole('dialog').filter({ hasText: 'Resumen de la reserva' }),
+    ).toBeVisible();
+    await expect(page).toHaveURL(new RegExp(`/categoria/${code.toLowerCase()}$`));
+    await expect(page).not.toHaveURL(/reservar=/);
+
+    // SCEN-005: "Volver" en Resumen → cierra todo + URL base (sin /categoria).
+    await page.getByTestId('reservation-resume-back-test').click();
+    await expect(visibleDialogs(page)).toHaveCount(0, { timeout: 10_000 });
+    await expect(page).not.toHaveURL(/\/categoria\//);
+    await expect(page).not.toHaveURL(/reservar=/);
+  });
+
+  test('SCEN-007: campos de texto exponen autocomplete estándar; identificación no', async ({
+    page,
+  }) => {
+    const code = await gotoSearchAndGetCode(page);
+    test.skip(!code, 'Sin categorías renderizadas');
+
+    await page.goto(`${searchPath}/categoria/${code}?reservar=${code}`);
+    await page.waitForLoadState('domcontentloaded');
+    await expect(
+      page.getByRole('dialog').filter({ hasText: 'Datos para reservas' }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const dialog = page.getByRole('dialog').filter({ hasText: 'Datos para reservas' });
+    await expect(dialog.locator('input[autocomplete="given-name"]')).toHaveCount(1);
+    await expect(dialog.locator('input[autocomplete="family-name"]')).toHaveCount(1);
+    await expect(dialog.locator('input[autocomplete="email"]')).toHaveCount(1);
+    // Identificación (número): no fabrica un token de datos personales. El
+    // default de @nuxt/ui UInput es autocomplete="off" (señal correcta de
+    // no-autocompletar para un documento de identidad). Amend SCEN-007
+    // (aprobado 2026-06-04): la premisa "tampoco off" era falsa — UInput
+    // siempre pone "off" y no es removible sin degradar la a11y.
+    const idInput = dialog.getByRole('textbox', { name: 'Número de identificación' });
+    await expect(idInput).toBeVisible();
+    await expect(idInput).toHaveAttribute('autocomplete', 'off');
+    // Solo el campo de identificación lleva "off": no se fabricó un token
+    // personal (given-name/family-name/email/tel) sobre un campo de documento.
+    await expect(dialog.locator('input[autocomplete="off"]')).toHaveCount(1);
+  });
+
+  test('SCEN-006: regresión #25 — Back tras el flujo no deja el body bloqueado', async ({
+    page,
+  }) => {
+    const code = await gotoSearchAndGetCode(page);
+    test.skip(!code, 'Sin categorías renderizadas');
+
+    // Abrir "Datos" por deep-link: diálogo modal (aria-modal="true"). Nota: en
+    // esta versión de reka-ui con overlay=false el <body> NO recibe
+    // pointer-events:none — la modalidad es por focus-trap + aria-modal, no por
+    // lock de puntero. El guard de #25 que importa es post-Back, abajo.
+    await page.goto(`${searchPath}/categoria/${code}?reservar=${code}`);
+    await page.waitForLoadState('domcontentloaded');
+    const datosDialog = page.getByRole('dialog').filter({ hasText: 'Datos para reservas' });
+    await expect(datosDialog).toBeVisible({ timeout: 15_000 });
+    expect(await datosDialog.getAttribute('aria-modal')).toBe('true');
+
+    // Simular navegación post-submit (los refs de slideover siguen true hasta el
+    // unmount; onBeforeRouteLeave debe cerrarlos). Mismo patrón que
+    // reservation-submit-back-unlocks-searcher.spec.ts.
+    await page.evaluate(() => {
+      const clean = window.location.pathname.replace(/\/categoria\/[^/]+$/, '');
+      window.history.replaceState(window.history.state, '', clean);
+      const app = (window as unknown as {
+        useNuxtApp(): { $router: { push: (p: string) => Promise<unknown> } };
+      }).useNuxtApp();
+      return app.$router.push('/reservado/TEST65');
+    });
+    await page.waitForURL(/\/reservado\/TEST65$/, { timeout: 10_000 });
+
+    // SPA Back.
+    await page.goBack();
+    await page.waitForURL(/buscar-vehiculos/, { timeout: 10_000 });
+
+    // Body interactivo + sin diálogo residual.
+    await expect
+      .poll(() => page.evaluate(() => getComputedStyle(document.body).pointerEvents), {
+        timeout: 10_000,
+      })
+      .not.toBe('none');
+    await expect(visibleDialogs(page)).toHaveCount(0);
+  });
+
+  test('SCEN-008: teléfono — nombre accesible "Teléfono" + autocomplete tel, sin aria-label viejo', async ({
+    page,
+  }) => {
+    const code = await gotoSearchAndGetCode(page);
+    test.skip(!code, 'Sin categorías renderizadas');
+
+    await page.goto(`${searchPath}/categoria/${code}?reservar=${code}`);
+    await page.waitForLoadState('domcontentloaded');
+    const dialog = page.getByRole('dialog').filter({ hasText: 'Datos para reservas' });
+    await expect(dialog).toBeVisible({ timeout: 15_000 });
+
+    // Nombre accesible computado == "Teléfono" (vía <label for="telefono">).
+    await expect(
+      dialog.getByRole('textbox', { name: 'Teléfono', exact: true }),
+    ).toBeVisible();
+    // El input de teléfono expone autocomplete="tel".
+    await expect(dialog.locator('input#telefono[autocomplete="tel"]')).toHaveCount(1);
+    // Ya NO existe el aria-label viejo "Número de teléfono".
+    await expect(
+      dialog.getByRole('textbox', { name: 'Número de teléfono' }),
+    ).toHaveCount(0);
+  });
+});

--- a/e2e/reservation-a11y-single-dialog.spec.ts
+++ b/e2e/reservation-a11y-single-dialog.spec.ts
@@ -255,6 +255,27 @@ test.describe('Reserva a11y — un solo slideover modal activo (issue #65) — d
     await expect(visibleDialogs(page)).toHaveCount(0);
   });
 
+  test('SCEN-010: Escape en "Datos" (sin Volver) cierra y limpia ?reservar de la URL', async ({
+    page,
+  }) => {
+    const code = await gotoSearchAndGetCode(page);
+    test.skip(!code, 'Sin categorías renderizadas');
+
+    await page.goto(`${searchPath}/categoria/${code}?reservar=${code}`);
+    await page.waitForLoadState('domcontentloaded');
+    await expect(
+      page.getByRole('dialog').filter({ hasText: 'Datos para reservas' }),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(page).toHaveURL(new RegExp(`reservar=${code}`));
+
+    // Cierre por Escape (ruta a11y primaria), NO por "Volver".
+    await page.keyboard.press('Escape');
+
+    await expect(visibleDialogs(page)).toHaveCount(0, { timeout: 10_000 });
+    await expect(page).not.toHaveURL(/reservar=/);
+    await expect(page).not.toHaveURL(/\/categoria\//);
+  });
+
   test('SCEN-008: teléfono — nombre accesible "Teléfono" + autocomplete tel, sin aria-label viejo', async ({
     page,
   }) => {

--- a/e2e/reservation-a11y-single-dialog.spec.ts
+++ b/e2e/reservation-a11y-single-dialog.spec.ts
@@ -276,6 +276,48 @@ test.describe('Reserva a11y — un solo slideover modal activo (issue #65) — d
     await expect(page).not.toHaveURL(/\/categoria\//);
   });
 
+  test('SCEN-011: tras Resumen→Datos→cerrar, la grilla sigue interactiva (regresión #65)', async ({
+    page,
+  }) => {
+    const code = await gotoSearchAndGetCode(page);
+    test.skip(!code, 'Sin categorías renderizadas');
+
+    // Flujo completo en la MISMA página (sin cambio de ruta): Resumen → Datos.
+    await page.getByRole('button', { name: 'Solicitar este vehículo' }).first().click();
+    await expect(
+      page.getByRole('dialog').filter({ hasText: 'Resumen de la reserva' }),
+    ).toBeVisible({ timeout: 10_000 });
+    await page.getByTestId('reservation-next-test').click();
+    await expect(
+      page.getByRole('dialog').filter({ hasText: 'Datos para reservas' }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Cerrar "Datos" con el botón X (ruta de cierre primaria, sin navegar).
+    await page
+      .getByRole('dialog')
+      .filter({ hasText: 'Datos para reservas' })
+      .getByRole('button', { name: /close|cerrar/i })
+      .first()
+      .click();
+    await expect(visibleDialogs(page)).toHaveCount(0, { timeout: 10_000 });
+
+    // Con 0 diálogos abiertos, el <body> NO debe quedar con pointer-events:none
+    // pegado (el hand-off de dos modales hermanos lo dejaba bloqueado → la
+    // grilla quedaba muerta porque el <html> interceptaba el puntero).
+    await expect
+      .poll(() => page.evaluate(() => document.body.style.pointerEvents || ''), {
+        timeout: 5_000,
+      })
+      .not.toBe('none');
+
+    // Satisfacción del usuario: reseleccionar cualquier vehículo vuelve a abrir
+    // "Resumen". Antes del fix el click no llegaba (puntero interceptado).
+    await page.getByRole('button', { name: 'Solicitar este vehículo' }).first().click();
+    await expect(
+      page.getByRole('dialog').filter({ hasText: 'Resumen de la reserva' }),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
   test('SCEN-008: teléfono — nombre accesible "Teléfono" + autocomplete tel, sin aria-label viejo', async ({
     page,
   }) => {

--- a/packages/logic/src/composables/__tests__/usePhoneField.test.ts
+++ b/packages/logic/src/composables/__tests__/usePhoneField.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+// Scenario captured (issue #65 SCEN-008, unit-level slice): the phone field
+// must expose autocomplete="tel" and must NOT carry the stale
+// aria-label="Número de teléfono" — that aria-label overrode the visible
+// "Teléfono" label as the accessible name, violating WCAG 2.5.3 Label in Name.
+// The accessible name is provided by the UFormField label instead (asserted in
+// the runtime DOM scenario; this test guards the composable config that feeds
+// VueTelInput's inputOptions).
+//
+// Source-level test (codebase convention) avoids mocking Nuxt auto-imports
+// (computed) — same approach as useCategory.getTotalPrice.test.ts.
+
+const source = readFileSync(
+  fileURLToPath(new URL('../usePhoneField.ts', import.meta.url)),
+  'utf8',
+)
+
+describe('usePhoneField — phone input accessibility config (issue #65)', () => {
+  it('exposes autocomplete="tel" so browsers/agents can autofill the phone', () => {
+    expect(source).toMatch(/autocomplete:\s*['"]tel['"]/)
+  })
+
+  it('drops the stale aria-label so it cannot override the "Teléfono" label', () => {
+    expect(source).not.toContain('aria-label')
+    expect(source).not.toContain('Número de teléfono')
+  })
+
+  it('keeps id and name "telefono" for the form control', () => {
+    expect(source).toMatch(/id:\s*['"]telefono['"]/)
+    expect(source).toMatch(/name:\s*['"]telefono['"]/)
+  })
+})

--- a/packages/logic/src/composables/usePhoneField.ts
+++ b/packages/logic/src/composables/usePhoneField.ts
@@ -10,7 +10,7 @@ export default function usePhoneField() {
       id: "telefono",
       name: "telefono",
       placeholder: "Whatsapp o Teléfono Móvil*",
-      'aria-label': "Número de teléfono",
+      autocomplete: "tel",
     }));
 
     const phoneDropdownOptions = {

--- a/packages/logic/src/utils/types/type/PhoneInputOptionsType.ts
+++ b/packages/logic/src/utils/types/type/PhoneInputOptionsType.ts
@@ -3,4 +3,5 @@ export default interface PhoneInputOptionsType {
   id: string;
   name: string;
   placeholder: string;
+  autocomplete: string;
 }

--- a/packages/ui-alquicarros/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquicarros/app/components/CategorySelectionSection.vue
@@ -64,6 +64,7 @@
       title="Resumen de la reserva"
       description="Antes de continuar revisa la información"
       :overlay="false"
+      :content="modalContentProps"
       :close="{ color: 'neutral', variant: 'outline', class: 'text-gray-700 border-gray-300 hover:bg-gray-100' }"
       :ui="{
         content: 'bg-white',
@@ -122,62 +123,76 @@
               variant="solid"
               size="xl"
               class="flex-1 py-4 justify-center bg-gray-200 !text-black hover:bg-gray-300"
+              data-testid="reservation-resume-back-test"
               @click="slideoverReservationResume = false"
             />
-            <u-slideover
-          v-model:open="slideoverReservationForm"
-          title="Datos para reservas"
-          description="Completa tus datos y solicita la reserva"
-          :overlay="false"
-          :close="{ color: 'neutral', variant: 'outline', class: 'text-gray-700 border-gray-300 hover:bg-gray-100' }"
-          :ui="{
-            content: 'bg-white',
-            header: 'bg-white',
-            title: 'text-gray-900 text-2xl font-bold',
-            description: 'text-gray-600',
-            body: 'bg-white text-gray-900',
-            footer: 'bg-white gap-2 border-t-0',
-            close: 'absolute top-4 end-4 z-10',
-          }"
-        >
-          <u-button label="Siguiente" color="neutral" size="xl" class="flex-1 py-4 justify-center bg-green-700 hover:bg-green-800 text-white">
-            <template #trailing>
-              <ChevronRightIcon cls="size-5" />
-            </template>
-          </u-button>
-
-          <template #body>
-            <reservation-form
-              ref="reservationFormComponent"
-              @submit="submitForm"
-            />
-          </template>
-
-          <template #footer>
+            <!-- "Siguiente" ya NO es trigger anidado: handler explícito que
+                 abre Datos y cierra Resumen (issue #65, un solo modal). -->
             <u-button
-              label="Volver"
-              color="neutral"
-              variant="solid"
-              size="xl"
-              class="flex-1 py-4 justify-center bg-gray-200 !text-black hover:bg-gray-300"
-              @click="slideoverReservationForm = false"
-            />
-            <u-button
+              label="Siguiente"
               color="neutral"
               size="xl"
-              class="flex-1 py-4 justify-center bg-green-700 hover:bg-green-800 disabled:bg-green-700 aria-disabled:bg-green-700 disabled:opacity-80 aria-disabled:opacity-80 text-white"
-              :loading="isSubmittingForm"
-              :disabled="isSubmittingForm"
-              @click="reservationFormComponent.submit()"
-              >Solicitar reserva
+              class="flex-1 py-4 justify-center bg-green-700 hover:bg-green-800 text-white"
+              data-testid="reservation-next-test"
+              @click="goToForm"
+            >
               <template #trailing>
-                <ChevronRightIcon v-if="!isSubmittingForm" cls="size-5" />
+                <ChevronRightIcon cls="size-5" />
               </template>
             </u-button>
-          </template>
-        </u-slideover>
           </div>
         </div>
+      </template>
+    </u-slideover>
+    <!-- "Datos" es HERMANO de "Resumen" (issue #65): mutuamente excluyentes,
+         a lo sumo un [role=dialog][aria-modal] activo. Antes estaba anidado en
+         el #footer de "Resumen", dejando dos diálogos modales simultáneos. -->
+    <u-slideover
+      v-model:open="slideoverReservationForm"
+      title="Datos para reservas"
+      description="Completa tus datos y solicita la reserva"
+      :overlay="false"
+      :content="modalContentProps"
+      :close="{ color: 'neutral', variant: 'outline', class: 'text-gray-700 border-gray-300 hover:bg-gray-100' }"
+      :ui="{
+        content: 'bg-white',
+        header: 'bg-white',
+        title: 'text-gray-900 text-2xl font-bold',
+        description: 'text-gray-600',
+        body: 'bg-white text-gray-900',
+        footer: 'bg-white gap-2 border-t-0',
+        close: 'absolute top-4 end-4 z-10',
+      }"
+    >
+      <template #body>
+        <reservation-form
+          ref="reservationFormComponent"
+          @submit="submitForm"
+        />
+      </template>
+
+      <template #footer>
+        <u-button
+          label="Volver"
+          color="neutral"
+          variant="solid"
+          size="xl"
+          class="flex-1 py-4 justify-center bg-gray-200 !text-black hover:bg-gray-300"
+          data-testid="reservation-form-back-test"
+          @click="backToResume"
+        />
+        <u-button
+          color="neutral"
+          size="xl"
+          class="flex-1 py-4 justify-center bg-green-700 hover:bg-green-800 disabled:bg-green-700 aria-disabled:bg-green-700 disabled:opacity-80 aria-disabled:opacity-80 text-white"
+          :loading="isSubmittingForm"
+          :disabled="isSubmittingForm"
+          @click="reservationFormComponent.submit()"
+          >Solicitar reserva
+          <template #trailing>
+            <ChevronRightIcon v-if="!isSubmittingForm" cls="size-5" />
+          </template>
+        </u-button>
       </template>
     </u-slideover>
   </template>
@@ -246,6 +261,12 @@ const slideoverReservationResume = ref<boolean>(false);
 const slideoverReservationForm = ref<boolean>(false);
 const reservationFormComponent = ref(null);
 const linkCopied = ref(false);
+
+// Issue #65: reka-ui Dialog (vía @nuxt/ui Slideover) no setea aria-modal y su
+// tipo `content` (DialogContentProps) no expone el atributo, aunque el elemento
+// sí lo acepta. Lo inyectamos por la prop `content`; el cast cubre el hueco de
+// tipos de la dependencia para un atributo ARIA estándar.
+const modalContentProps = { 'aria-modal': 'true' } as Record<string, string>;
 
 /** Share functions */
 function getReservationShareUrl() {
@@ -328,11 +349,15 @@ function updateCategoriaUrl(codigoCategoria?: string, reservar?: boolean) {
   }
 }
 
-// Limpiar URL cuando se cierra el slideover de resumen
+// Limpiar URL cuando se cierra el slideover de resumen.
+// Guard (issue #65): en la transición Resumen→Datos, `resume` pasa a false
+// mientras `form` ya es true (mismo tick). Sin `!slideoverReservationForm`,
+// esto borraría el ?reservar=X que el watcher de form acaba de poner. La URL
+// solo se limpia cuando se cierran AMBOS.
 watch(slideoverReservationResume, (isOpen) => {
   if (isUpdatingFromUrl.value) return;
 
-  if (!isOpen) {
+  if (!isOpen && !slideoverReservationForm.value) {
     updateCategoriaUrl(undefined);
   }
 });
@@ -370,23 +395,20 @@ watch(
     vehiculo.value = category.categoryCode.value;
     selectedCategory.value = category;
 
-    // Abrir slideover correspondiente
+    // Abrir UN solo slideover (issue #65): ?reservar=X → Datos directo;
+    // /categoria/X o ?resumen=X → Resumen. Antes abría ambos en cascada,
+    // dejando dos diálogos modales al des-anidar. `abrirFormularioDirecto`
+    // deriva solo de reservarParam, así que ?resumen=X cae en la rama Resumen.
     nextTick(() => {
-      slideoverReservationResume.value = true;
       if (abrirFormularioDirecto.value) {
-        nextTick(() => {
-          slideoverReservationForm.value = true;
-          // Resetear flag después de que todo esté abierto
-          nextTick(() => {
-            isUpdatingFromUrl.value = false;
-          });
-        });
+        slideoverReservationForm.value = true;
       } else {
-        // Resetear flag
-        nextTick(() => {
-          isUpdatingFromUrl.value = false;
-        });
+        slideoverReservationResume.value = true;
       }
+      // Resetear flag después de abrir
+      nextTick(() => {
+        isUpdatingFromUrl.value = false;
+      });
     });
   },
   { immediate: true }
@@ -415,6 +437,19 @@ function setSelectedCategory(category: ReturnType<typeof useCategory>) {
   slideoverReservationResume.value = true;
   // Actualizar URL con el código de la categoría
   updateCategoriaUrl(category.categoryCode.value, false);
+}
+
+// Transiciones Resumen↔Datos (issue #65): mutan AMBOS refs de forma síncrona
+// en el mismo tick (sin nextTick entre asignaciones). Con flush:'pre', los
+// watchers de URL leen el estado ya consolidado, así el guard de Resumen
+// preserva el ?reservar=X. Invariante: a lo sumo un slideover abierto.
+function goToForm() {
+  slideoverReservationForm.value = true;
+  slideoverReservationResume.value = false;
+}
+function backToResume() {
+  slideoverReservationResume.value = true;
+  slideoverReservationForm.value = false;
 }
 
 const { submitForm } = storeForm;

--- a/packages/ui-alquicarros/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquicarros/app/components/CategorySelectionSection.vue
@@ -327,8 +327,14 @@ const reservarParam = computed(() => route.query.reservar as string | undefined)
 const codigoCategoria = computed(() => categoriaParam.value || resumenParam.value || reservarParam.value);
 const abrirFormularioDirecto = computed(() => !!reservarParam.value);
 
-// Flag para evitar loops cuando actualizamos la URL programáticamente
-const isUpdatingFromUrl = ref(false);
+// Profundidad de sincronización URL→estado (contador, no booleano): enmascara
+// los watchers de URL mientras abrimos slideovers desde la URL. Es un CONTADOR
+// para ser reentrante — si el watcher de auto-apertura se dispara otra vez
+// antes de que el reset diferido corra (p.ej. filteredCategories emite dos
+// veces, o navegación rápida entre /categoria), un booleano lo desenmascararía
+// a mitad de transición (edge-case #65 HIGH). Con el contador, el reset de la
+// primera invocación no abre la ventana mientras la segunda sigue en vuelo.
+const urlSyncDepth = ref(0);
 
 // Actualizar URL con categoría sin disparar navegación Vue Router.
 // Usa history.replaceState para evitar que Nuxt desmonte/remonte la página
@@ -355,7 +361,7 @@ function updateCategoriaUrl(codigoCategoria?: string, reservar?: boolean) {
 // esto borraría el ?reservar=X que el watcher de form acaba de poner. La URL
 // solo se limpia cuando se cierran AMBOS.
 watch(slideoverReservationResume, (isOpen) => {
-  if (isUpdatingFromUrl.value) return;
+  if (urlSyncDepth.value > 0) return;
 
   if (!isOpen && !slideoverReservationForm.value) {
     updateCategoriaUrl(undefined);
@@ -364,17 +370,20 @@ watch(slideoverReservationResume, (isOpen) => {
 
 // Sincronizar URL con estado del slideover de formulario
 watch(slideoverReservationForm, (isOpen) => {
-  if (isUpdatingFromUrl.value) return;
+  if (urlSyncDepth.value > 0) return;
   if (!vehiculo.value) return;
 
   const codigo = vehiculo.value;
   if (isOpen) {
     updateCategoriaUrl(codigo, true);
+  } else if (slideoverReservationResume.value) {
+    // Datos→Resumen (backToResume): mantener /categoria sin ?reservar.
+    updateCategoriaUrl(codigo, false);
   } else {
-    // Volver a mostrar solo categoría sin query param reservar
-    if (slideoverReservationResume.value) {
-      updateCategoriaUrl(codigo, false);
-    }
+    // Datos cerrado SIN reabrir Resumen (Escape, botón X, dismiss-outside):
+    // limpiar ?reservar para que un reload no re-abra el slideover descartado
+    // (issue #65 edge-case). Escape es ruta de cierre primaria de a11y.
+    updateCategoriaUrl(undefined);
   }
 });
 
@@ -387,8 +396,8 @@ watch(
     const categoryData = categories.find(c => c.categoryCode === codigo);
     if (!categoryData || !vehicleCategories[codigo]) return;
 
-    // Marcar que estamos actualizando desde la URL
-    isUpdatingFromUrl.value = true;
+    // Marcar que estamos actualizando desde la URL (contador reentrante)
+    urlSyncDepth.value++;
 
     // Seleccionar categoría
     const category = useCategory(categoryData, vehicleCategories[codigo]);
@@ -405,9 +414,11 @@ watch(
       } else {
         slideoverReservationResume.value = true;
       }
-      // Resetear flag después de abrir
+      // Reset diferido (nextTick anidado): los watchers de URL (flush:'pre')
+      // disparan tras abrir el slideover y ANTES de este reset, así quedan
+      // enmascarados. Decremento (no =0) por reentrancia.
       nextTick(() => {
-        isUpdatingFromUrl.value = false;
+        urlSyncDepth.value--;
       });
     });
   },
@@ -417,16 +428,16 @@ watch(
 // Issue #25: cerrar slideovers (reka-ui Dialog modal:true) ANTES del unmount
 // por route change. Sin esto, el cleanup interno de Reka UI no corre y
 // `pointer-events: none` queda inline en <body> — DOM compartido en SPA —
-// bloqueando el Searcher cuando el usuario regresa via Back. El guard
-// `isUpdatingFromUrl` evita que los watchers de URL disparen replaceState
+// bloqueando el Searcher cuando el usuario regresa via Back. El contador
+// `urlSyncDepth` evita que los watchers de URL disparen replaceState
 // redundante mientras navegamos a otra ruta.
 onBeforeRouteLeave(async () => {
   if (slideoverReservationForm.value || slideoverReservationResume.value) {
-    isUpdatingFromUrl.value = true;
+    urlSyncDepth.value++;
     slideoverReservationForm.value = false;
     slideoverReservationResume.value = false;
     await nextTick();
-    isUpdatingFromUrl.value = false;
+    urlSyncDepth.value--;
   }
 });
 

--- a/packages/ui-alquicarros/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquicarros/app/components/CategorySelectionSection.vue
@@ -59,10 +59,18 @@
         />
       </template>
     </div>
+    <!-- UN SOLO slideover con `slideoverStep` interno (issue #65). El diálogo se
+         abre y cierra UNA vez por flujo; "Resumen" y "Datos" son pasos que
+         intercambian su contenido dentro del mismo [role=dialog]. Antes eran dos
+         slideovers (anidados en main, hermanos en el primer fix de #65); en
+         ambos, el hand-off entre dos capas modales corrompía el conteo de reka-ui
+         y dejaba `pointer-events:none` pegado en <body> con 0 diálogos, matando
+         la grilla (regresión SCEN-011). Con un único DialogContent el invariante
+         "0 o 1 [role=dialog]" es estructural y no hay swap de capas. -->
     <u-slideover
-      v-model:open="slideoverReservationResume"
-      title="Resumen de la reserva"
-      description="Antes de continuar revisa la información"
+      v-model:open="slideoverOpen"
+      :title="slideoverStep === 'datos' ? 'Datos para reservas' : 'Resumen de la reserva'"
+      :description="slideoverStep === 'datos' ? 'Completa tus datos y solicita la reserva' : 'Antes de continuar revisa la información'"
       :overlay="false"
       :content="modalContentProps"
       :close="{ color: 'neutral', variant: 'outline', class: 'text-gray-700 border-gray-300 hover:bg-gray-100' }"
@@ -77,10 +85,16 @@
       }"
     >
       <template #body>
-        <reservation-resume :category="selectedCategory"></reservation-resume>
+        <reservation-resume v-if="slideoverStep === 'resumen'" :category="selectedCategory"></reservation-resume>
+        <reservation-form
+          v-else
+          ref="reservationFormComponent"
+          @submit="submitForm"
+        />
       </template>
       <template #footer>
-        <div class="w-full flex flex-col gap-3">
+        <!-- Paso "Resumen": cápsula de compartir + Volver/Siguiente. -->
+        <div v-if="slideoverStep === 'resumen'" class="w-full flex flex-col gap-3">
           <!-- Share Capsule -->
           <div class="flex justify-center">
             <div class="flex items-center gap-2 bg-gray-100 rounded-full px-4 py-2">
@@ -124,10 +138,10 @@
               size="xl"
               class="flex-1 py-4 justify-center bg-gray-200 !text-black hover:bg-gray-300"
               data-testid="reservation-resume-back-test"
-              @click="slideoverReservationResume = false"
+              @click="slideoverOpen = false"
             />
-            <!-- "Siguiente" ya NO es trigger anidado: handler explícito que
-                 abre Datos y cierra Resumen (issue #65, un solo modal). -->
+            <!-- "Siguiente" cambia el paso a "datos" SIN cerrar/reabrir el
+                 diálogo (issue #65): no hay swap de capas modales. -->
             <u-button
               label="Siguiente"
               color="neutral"
@@ -142,57 +156,30 @@
             </u-button>
           </div>
         </div>
-      </template>
-    </u-slideover>
-    <!-- "Datos" es HERMANO de "Resumen" (issue #65): mutuamente excluyentes,
-         a lo sumo un [role=dialog][aria-modal] activo. Antes estaba anidado en
-         el #footer de "Resumen", dejando dos diálogos modales simultáneos. -->
-    <u-slideover
-      v-model:open="slideoverReservationForm"
-      title="Datos para reservas"
-      description="Completa tus datos y solicita la reserva"
-      :overlay="false"
-      :content="modalContentProps"
-      :close="{ color: 'neutral', variant: 'outline', class: 'text-gray-700 border-gray-300 hover:bg-gray-100' }"
-      :ui="{
-        content: 'bg-white',
-        header: 'bg-white',
-        title: 'text-gray-900 text-2xl font-bold',
-        description: 'text-gray-600',
-        body: 'bg-white text-gray-900',
-        footer: 'bg-white gap-2 border-t-0',
-        close: 'absolute top-4 end-4 z-10',
-      }"
-    >
-      <template #body>
-        <reservation-form
-          ref="reservationFormComponent"
-          @submit="submitForm"
-        />
-      </template>
-
-      <template #footer>
-        <u-button
-          label="Volver"
-          color="neutral"
-          variant="solid"
-          size="xl"
-          class="flex-1 py-4 justify-center bg-gray-200 !text-black hover:bg-gray-300"
-          data-testid="reservation-form-back-test"
-          @click="backToResume"
-        />
-        <u-button
-          color="neutral"
-          size="xl"
-          class="flex-1 py-4 justify-center bg-green-700 hover:bg-green-800 disabled:bg-green-700 aria-disabled:bg-green-700 disabled:opacity-80 aria-disabled:opacity-80 text-white"
-          :loading="isSubmittingForm"
-          :disabled="isSubmittingForm"
-          @click="reservationFormComponent.submit()"
-          >Solicitar reserva
-          <template #trailing>
-            <ChevronRightIcon v-if="!isSubmittingForm" cls="size-5" />
-          </template>
-        </u-button>
+        <!-- Paso "Datos": Volver (al resumen) + Solicitar reserva. -->
+        <template v-else>
+          <u-button
+            label="Volver"
+            color="neutral"
+            variant="solid"
+            size="xl"
+            class="flex-1 py-4 justify-center bg-gray-200 !text-black hover:bg-gray-300"
+            data-testid="reservation-form-back-test"
+            @click="backToResume"
+          />
+          <u-button
+            color="neutral"
+            size="xl"
+            class="flex-1 py-4 justify-center bg-green-700 hover:bg-green-800 disabled:bg-green-700 aria-disabled:bg-green-700 disabled:opacity-80 aria-disabled:opacity-80 text-white"
+            :loading="isSubmittingForm"
+            :disabled="isSubmittingForm"
+            @click="reservationFormComponent?.submit()"
+            >Solicitar reserva
+            <template #trailing>
+              <ChevronRightIcon v-if="!isSubmittingForm" cls="size-5" />
+            </template>
+          </u-button>
+        </template>
       </template>
     </u-slideover>
   </template>
@@ -257,8 +244,13 @@ const renderableCategories = computed(() =>
 const hasRenderableAvailable = computed(() =>
   renderableCategories.value.some((c: { estimatedTotalAmount: number }) => c.estimatedTotalAmount !== 999999999),
 );
-const slideoverReservationResume = ref<boolean>(false);
-const slideoverReservationForm = ref<boolean>(false);
+// Un solo slideover modal con dos pasos (issue #65). `slideoverStep` decide
+// título/descripción/body/footer; `slideoverOpen` gobierna la única capa modal.
+// El flujo Resumen↔Datos solo cambia `slideoverStep` (el diálogo permanece
+// abierto), evitando el swap de dos capas que dejaba `pointer-events:none`
+// pegado en <body> (regresión SCEN-011).
+const slideoverOpen = ref<boolean>(false);
+const slideoverStep = ref<'resumen' | 'datos'>('resumen');
 const reservationFormComponent = ref(null);
 const linkCopied = ref(false);
 
@@ -328,7 +320,7 @@ const codigoCategoria = computed(() => categoriaParam.value || resumenParam.valu
 const abrirFormularioDirecto = computed(() => !!reservarParam.value);
 
 // Profundidad de sincronización URL→estado (contador, no booleano): enmascara
-// los watchers de URL mientras abrimos slideovers desde la URL. Es un CONTADOR
+// el watcher de URL mientras abrimos el slideover desde la URL. Es un CONTADOR
 // para ser reentrante — si el watcher de auto-apertura se dispara otra vez
 // antes de que el reset diferido corra (p.ej. filteredCategories emite dos
 // veces, o navegación rápida entre /categoria), un booleano lo desenmascararía
@@ -355,39 +347,30 @@ function updateCategoriaUrl(codigoCategoria?: string, reservar?: boolean) {
   }
 }
 
-// Limpiar URL cuando se cierra el slideover de resumen.
-// Guard (issue #65): en la transición Resumen→Datos, `resume` pasa a false
-// mientras `form` ya es true (mismo tick). Sin `!slideoverReservationForm`,
-// esto borraría el ?reservar=X que el watcher de form acaba de poner. La URL
-// solo se limpia cuando se cierran AMBOS.
-watch(slideoverReservationResume, (isOpen) => {
+// Sincronizar URL con (apertura, paso) del único slideover.
+// - cerrado            → URL base (sin /categoria ni ?reservar)
+// - abierto + resumen  → /categoria/X
+// - abierto + datos    → /categoria/X?reservar=X
+// Con un solo slideover NO hay transición Resumen→Datos que cierre una capa y
+// abra otra, así que no hace falta el guard que antes preservaba ?reservar
+// durante el swap: el cambio de paso solo reescribe la query (issue #65).
+watch([slideoverOpen, slideoverStep], ([open, step]) => {
   if (urlSyncDepth.value > 0) return;
 
-  if (!isOpen && !slideoverReservationForm.value) {
+  // Cerrado → limpiar la URL SIEMPRE, sin gatear por `vehiculo`: si el form se
+  // reseteó (submit fallido, rehidratación) `vehiculo` puede quedar vacío con el
+  // slideover aún abierto, y el `/categoria/X(?reservar)` NO debe sobrevivir al
+  // cierre (si no, un reload reabriría un slideover ya descartado).
+  if (!open) {
     updateCategoriaUrl(undefined);
+    return;
   }
-});
-
-// Sincronizar URL con estado del slideover de formulario
-watch(slideoverReservationForm, (isOpen) => {
-  if (urlSyncDepth.value > 0) return;
+  // Abierto → se necesita la categoría para construir /categoria/X.
   if (!vehiculo.value) return;
-
-  const codigo = vehiculo.value;
-  if (isOpen) {
-    updateCategoriaUrl(codigo, true);
-  } else if (slideoverReservationResume.value) {
-    // Datos→Resumen (backToResume): mantener /categoria sin ?reservar.
-    updateCategoriaUrl(codigo, false);
-  } else {
-    // Datos cerrado SIN reabrir Resumen (Escape, botón X, dismiss-outside):
-    // limpiar ?reservar para que un reload no re-abra el slideover descartado
-    // (issue #65 edge-case). Escape es ruta de cierre primaria de a11y.
-    updateCategoriaUrl(undefined);
-  }
+  updateCategoriaUrl(vehiculo.value, step === 'datos');
 });
 
-// Auto-abrir slideover cuando se carguen las categorías y exista el param
+// Auto-abrir el slideover cuando carguen las categorías y exista el param.
 watch(
   [filteredCategories, codigoCategoria],
   ([categories, codigo]) => {
@@ -404,19 +387,15 @@ watch(
     vehiculo.value = category.categoryCode.value;
     selectedCategory.value = category;
 
-    // Abrir UN solo slideover (issue #65): ?reservar=X → Datos directo;
-    // /categoria/X o ?resumen=X → Resumen. Antes abría ambos en cascada,
-    // dejando dos diálogos modales al des-anidar. `abrirFormularioDirecto`
-    // deriva solo de reservarParam, así que ?resumen=X cae en la rama Resumen.
+    // Abrir el slideover en el paso correcto (issue #65): ?reservar=X → "datos";
+    // /categoria/X o ?resumen=X → "resumen". `abrirFormularioDirecto` deriva
+    // solo de reservarParam, así que ?resumen=X cae en la rama "resumen".
     nextTick(() => {
-      if (abrirFormularioDirecto.value) {
-        slideoverReservationForm.value = true;
-      } else {
-        slideoverReservationResume.value = true;
-      }
-      // Reset diferido (nextTick anidado): los watchers de URL (flush:'pre')
-      // disparan tras abrir el slideover y ANTES de este reset, así quedan
-      // enmascarados. Decremento (no =0) por reentrancia.
+      slideoverStep.value = abrirFormularioDirecto.value ? 'datos' : 'resumen';
+      slideoverOpen.value = true;
+      // Reset diferido (nextTick anidado): el watcher de URL (flush:'pre')
+      // dispara tras abrir el slideover y ANTES de este reset, así queda
+      // enmascarado. Decremento (no =0) por reentrancia.
       nextTick(() => {
         urlSyncDepth.value--;
       });
@@ -425,17 +404,16 @@ watch(
   { immediate: true }
 );
 
-// Issue #25: cerrar slideovers (reka-ui Dialog modal:true) ANTES del unmount
+// Issue #25: cerrar el slideover (reka-ui Dialog modal:true) ANTES del unmount
 // por route change. Sin esto, el cleanup interno de Reka UI no corre y
 // `pointer-events: none` queda inline en <body> — DOM compartido en SPA —
 // bloqueando el Searcher cuando el usuario regresa via Back. El contador
-// `urlSyncDepth` evita que los watchers de URL disparen replaceState
-// redundante mientras navegamos a otra ruta.
+// `urlSyncDepth` evita que el watcher de URL dispare replaceState redundante
+// mientras navegamos a otra ruta.
 onBeforeRouteLeave(async () => {
-  if (slideoverReservationForm.value || slideoverReservationResume.value) {
+  if (slideoverOpen.value) {
     urlSyncDepth.value++;
-    slideoverReservationForm.value = false;
-    slideoverReservationResume.value = false;
+    slideoverOpen.value = false;
     await nextTick();
     urlSyncDepth.value--;
   }
@@ -445,22 +423,22 @@ onBeforeRouteLeave(async () => {
 function setSelectedCategory(category: ReturnType<typeof useCategory>) {
   vehiculo.value = category.categoryCode.value;
   selectedCategory.value = category;
-  slideoverReservationResume.value = true;
-  // Actualizar URL con el código de la categoría
-  updateCategoriaUrl(category.categoryCode.value, false);
+  // Abrir en el paso "resumen"; el watcher [slideoverOpen, slideoverStep]
+  // sincroniza la URL a /categoria/X.
+  slideoverStep.value = 'resumen';
+  slideoverOpen.value = true;
 }
 
-// Transiciones Resumen↔Datos (issue #65): mutan AMBOS refs de forma síncrona
-// en el mismo tick (sin nextTick entre asignaciones). Con flush:'pre', los
-// watchers de URL leen el estado ya consolidado, así el guard de Resumen
-// preserva el ?reservar=X. Invariante: a lo sumo un slideover abierto.
+// Transiciones Resumen↔Datos (issue #65): solo cambian `slideoverStep`. El
+// diálogo permanece abierto (una sola capa modal de reka-ui), el contenido del
+// body y el footer se intercambian. Sin cerrar/reabrir → sin corromper el
+// manejo de pointer-events de reka (regresión SCEN-011). Invariante: a lo sumo
+// un [role=dialog], garantizado estructuralmente por el único DialogContent.
 function goToForm() {
-  slideoverReservationForm.value = true;
-  slideoverReservationResume.value = false;
+  slideoverStep.value = 'datos';
 }
 function backToResume() {
-  slideoverReservationResume.value = true;
-  slideoverReservationForm.value = false;
+  slideoverStep.value = 'resumen';
 }
 
 const { submitForm } = storeForm;

--- a/packages/ui-alquicarros/app/components/ReservationForm.vue
+++ b/packages/ui-alquicarros/app/components/ReservationForm.vue
@@ -13,6 +13,7 @@
             class="w-full"
             placeholder="Nombres*"
             aria-label="Nombres"
+            autocomplete="given-name"
             :ui="inputUi"
           ></u-input>
         </u-form-field>
@@ -22,6 +23,7 @@
             class="w-full"
             placeholder="Apellidos*"
             aria-label="Apellidos"
+            autocomplete="family-name"
             :ui="inputUi"
           ></u-input>
         </u-form-field>
@@ -50,10 +52,16 @@
             class="w-full"
             placeholder="Email*"
             aria-label="Correo electrónico"
+            autocomplete="email"
             :ui="inputUi"
           ></u-input>
         </u-form-field>
-        <u-form-field class="col-span-2" name="telefono" label="Teléfono">
+        <u-form-field class="col-span-2" name="telefono">
+          <!-- VueTelInput no usa useFormField, así que el label autogenerado de
+               UFormField (for=useId()) no asocia su <input>. Label propio con
+               for="telefono" ↔ inputOptions.id="telefono" → nombre accesible
+               "Teléfono" determinista (issue #65 SCEN-008). -->
+          <label for="telefono" class="block font-medium text-sm text-gray-900 mb-1.5">Teléfono</label>
           <VueTelInput
             v-model="formState.telefono"
             mode="international"

--- a/packages/ui-alquilame/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquilame/app/components/CategorySelectionSection.vue
@@ -64,6 +64,7 @@
       title="Resumen de la reserva"
       description="Antes de continuar revisa la información"
       :overlay="false"
+      :content="modalContentProps"
       :close="{ color: 'neutral', variant: 'outline', class: 'text-gray-700 border-gray-300 hover:bg-gray-100' }"
       :ui="{
         content: 'bg-white',
@@ -122,62 +123,76 @@
               variant="solid"
               size="xl"
               class="flex-1 py-4 justify-center bg-gray-200 !text-black hover:bg-gray-300"
+              data-testid="reservation-resume-back-test"
               @click="slideoverReservationResume = false"
             />
-            <u-slideover
-          v-model:open="slideoverReservationForm"
-          title="Datos para reservas"
-          description="Completa tus datos y solicita la reserva"
-          :overlay="false"
-          :close="{ color: 'neutral', variant: 'outline', class: 'text-gray-700 border-gray-300 hover:bg-gray-100' }"
-          :ui="{
-            content: 'bg-white',
-            header: 'bg-white',
-            title: 'text-gray-900 text-2xl font-bold',
-            description: 'text-gray-600',
-            body: 'bg-white text-gray-900',
-            footer: 'bg-white gap-2 border-t-0',
-            close: 'absolute top-4 end-4 z-10',
-          }"
-        >
-          <u-button label="Siguiente" color="neutral" size="xl" class="flex-1 py-4 justify-center bg-green-700 hover:bg-green-800 text-white">
-            <template #trailing>
-              <ChevronRightIcon cls="size-5" />
-            </template>
-          </u-button>
-
-          <template #body>
-            <reservation-form
-              ref="reservationFormComponent"
-              @submit="submitForm"
-            />
-          </template>
-
-          <template #footer>
+            <!-- "Siguiente" ya NO es trigger anidado: handler explícito que
+                 abre Datos y cierra Resumen (issue #65, un solo modal). -->
             <u-button
-              label="Volver"
-              color="neutral"
-              variant="solid"
-              size="xl"
-              class="flex-1 py-4 justify-center bg-gray-200 !text-black hover:bg-gray-300"
-              @click="slideoverReservationForm = false"
-            />
-            <u-button
+              label="Siguiente"
               color="neutral"
               size="xl"
-              class="flex-1 py-4 justify-center bg-green-700 hover:bg-green-800 disabled:bg-green-700 aria-disabled:bg-green-700 disabled:opacity-80 aria-disabled:opacity-80 text-white"
-              :loading="isSubmittingForm"
-              :disabled="isSubmittingForm"
-              @click="reservationFormComponent.submit()"
-              >Solicitar reserva
+              class="flex-1 py-4 justify-center bg-green-700 hover:bg-green-800 text-white"
+              data-testid="reservation-next-test"
+              @click="goToForm"
+            >
               <template #trailing>
-                <ChevronRightIcon v-if="!isSubmittingForm" cls="size-5" />
+                <ChevronRightIcon cls="size-5" />
               </template>
             </u-button>
-          </template>
-        </u-slideover>
           </div>
         </div>
+      </template>
+    </u-slideover>
+    <!-- "Datos" es HERMANO de "Resumen" (issue #65): mutuamente excluyentes,
+         a lo sumo un [role=dialog][aria-modal] activo. Antes estaba anidado en
+         el #footer de "Resumen", dejando dos diálogos modales simultáneos. -->
+    <u-slideover
+      v-model:open="slideoverReservationForm"
+      title="Datos para reservas"
+      description="Completa tus datos y solicita la reserva"
+      :overlay="false"
+      :content="modalContentProps"
+      :close="{ color: 'neutral', variant: 'outline', class: 'text-gray-700 border-gray-300 hover:bg-gray-100' }"
+      :ui="{
+        content: 'bg-white',
+        header: 'bg-white',
+        title: 'text-gray-900 text-2xl font-bold',
+        description: 'text-gray-600',
+        body: 'bg-white text-gray-900',
+        footer: 'bg-white gap-2 border-t-0',
+        close: 'absolute top-4 end-4 z-10',
+      }"
+    >
+      <template #body>
+        <reservation-form
+          ref="reservationFormComponent"
+          @submit="submitForm"
+        />
+      </template>
+
+      <template #footer>
+        <u-button
+          label="Volver"
+          color="neutral"
+          variant="solid"
+          size="xl"
+          class="flex-1 py-4 justify-center bg-gray-200 !text-black hover:bg-gray-300"
+          data-testid="reservation-form-back-test"
+          @click="backToResume"
+        />
+        <u-button
+          color="neutral"
+          size="xl"
+          class="flex-1 py-4 justify-center bg-green-700 hover:bg-green-800 disabled:bg-green-700 aria-disabled:bg-green-700 disabled:opacity-80 aria-disabled:opacity-80 text-white"
+          :loading="isSubmittingForm"
+          :disabled="isSubmittingForm"
+          @click="reservationFormComponent.submit()"
+          >Solicitar reserva
+          <template #trailing>
+            <ChevronRightIcon v-if="!isSubmittingForm" cls="size-5" />
+          </template>
+        </u-button>
       </template>
     </u-slideover>
   </template>
@@ -246,6 +261,12 @@ const slideoverReservationResume = ref<boolean>(false);
 const slideoverReservationForm = ref<boolean>(false);
 const reservationFormComponent = ref(null);
 const linkCopied = ref(false);
+
+// Issue #65: reka-ui Dialog (vía @nuxt/ui Slideover) no setea aria-modal y su
+// tipo `content` (DialogContentProps) no expone el atributo, aunque el elemento
+// sí lo acepta. Lo inyectamos por la prop `content`; el cast cubre el hueco de
+// tipos de la dependencia para un atributo ARIA estándar.
+const modalContentProps = { 'aria-modal': 'true' } as Record<string, string>;
 
 /** Share functions */
 function getReservationShareUrl() {
@@ -328,11 +349,15 @@ function updateCategoriaUrl(codigoCategoria?: string, reservar?: boolean) {
   }
 }
 
-// Limpiar URL cuando se cierra el slideover de resumen
+// Limpiar URL cuando se cierra el slideover de resumen.
+// Guard (issue #65): en la transición Resumen→Datos, `resume` pasa a false
+// mientras `form` ya es true (mismo tick). Sin `!slideoverReservationForm`,
+// esto borraría el ?reservar=X que el watcher de form acaba de poner. La URL
+// solo se limpia cuando se cierran AMBOS.
 watch(slideoverReservationResume, (isOpen) => {
   if (isUpdatingFromUrl.value) return;
 
-  if (!isOpen) {
+  if (!isOpen && !slideoverReservationForm.value) {
     updateCategoriaUrl(undefined);
   }
 });
@@ -370,23 +395,20 @@ watch(
     vehiculo.value = category.categoryCode.value;
     selectedCategory.value = category;
 
-    // Abrir slideover correspondiente
+    // Abrir UN solo slideover (issue #65): ?reservar=X → Datos directo;
+    // /categoria/X o ?resumen=X → Resumen. Antes abría ambos en cascada,
+    // dejando dos diálogos modales al des-anidar. `abrirFormularioDirecto`
+    // deriva solo de reservarParam, así que ?resumen=X cae en la rama Resumen.
     nextTick(() => {
-      slideoverReservationResume.value = true;
       if (abrirFormularioDirecto.value) {
-        nextTick(() => {
-          slideoverReservationForm.value = true;
-          // Resetear flag después de que todo esté abierto
-          nextTick(() => {
-            isUpdatingFromUrl.value = false;
-          });
-        });
+        slideoverReservationForm.value = true;
       } else {
-        // Resetear flag
-        nextTick(() => {
-          isUpdatingFromUrl.value = false;
-        });
+        slideoverReservationResume.value = true;
       }
+      // Resetear flag después de abrir
+      nextTick(() => {
+        isUpdatingFromUrl.value = false;
+      });
     });
   },
   { immediate: true }
@@ -415,6 +437,19 @@ function setSelectedCategory(category: ReturnType<typeof useCategory>) {
   slideoverReservationResume.value = true;
   // Actualizar URL con el código de la categoría
   updateCategoriaUrl(category.categoryCode.value, false);
+}
+
+// Transiciones Resumen↔Datos (issue #65): mutan AMBOS refs de forma síncrona
+// en el mismo tick (sin nextTick entre asignaciones). Con flush:'pre', los
+// watchers de URL leen el estado ya consolidado, así el guard de Resumen
+// preserva el ?reservar=X. Invariante: a lo sumo un slideover abierto.
+function goToForm() {
+  slideoverReservationForm.value = true;
+  slideoverReservationResume.value = false;
+}
+function backToResume() {
+  slideoverReservationResume.value = true;
+  slideoverReservationForm.value = false;
 }
 
 const { submitForm } = storeForm;

--- a/packages/ui-alquilame/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquilame/app/components/CategorySelectionSection.vue
@@ -327,8 +327,14 @@ const reservarParam = computed(() => route.query.reservar as string | undefined)
 const codigoCategoria = computed(() => categoriaParam.value || resumenParam.value || reservarParam.value);
 const abrirFormularioDirecto = computed(() => !!reservarParam.value);
 
-// Flag para evitar loops cuando actualizamos la URL programáticamente
-const isUpdatingFromUrl = ref(false);
+// Profundidad de sincronización URL→estado (contador, no booleano): enmascara
+// los watchers de URL mientras abrimos slideovers desde la URL. Es un CONTADOR
+// para ser reentrante — si el watcher de auto-apertura se dispara otra vez
+// antes de que el reset diferido corra (p.ej. filteredCategories emite dos
+// veces, o navegación rápida entre /categoria), un booleano lo desenmascararía
+// a mitad de transición (edge-case #65 HIGH). Con el contador, el reset de la
+// primera invocación no abre la ventana mientras la segunda sigue en vuelo.
+const urlSyncDepth = ref(0);
 
 // Actualizar URL con categoría sin disparar navegación Vue Router.
 // Usa history.replaceState para evitar que Nuxt desmonte/remonte la página
@@ -355,7 +361,7 @@ function updateCategoriaUrl(codigoCategoria?: string, reservar?: boolean) {
 // esto borraría el ?reservar=X que el watcher de form acaba de poner. La URL
 // solo se limpia cuando se cierran AMBOS.
 watch(slideoverReservationResume, (isOpen) => {
-  if (isUpdatingFromUrl.value) return;
+  if (urlSyncDepth.value > 0) return;
 
   if (!isOpen && !slideoverReservationForm.value) {
     updateCategoriaUrl(undefined);
@@ -364,17 +370,20 @@ watch(slideoverReservationResume, (isOpen) => {
 
 // Sincronizar URL con estado del slideover de formulario
 watch(slideoverReservationForm, (isOpen) => {
-  if (isUpdatingFromUrl.value) return;
+  if (urlSyncDepth.value > 0) return;
   if (!vehiculo.value) return;
 
   const codigo = vehiculo.value;
   if (isOpen) {
     updateCategoriaUrl(codigo, true);
+  } else if (slideoverReservationResume.value) {
+    // Datos→Resumen (backToResume): mantener /categoria sin ?reservar.
+    updateCategoriaUrl(codigo, false);
   } else {
-    // Volver a mostrar solo categoría sin query param reservar
-    if (slideoverReservationResume.value) {
-      updateCategoriaUrl(codigo, false);
-    }
+    // Datos cerrado SIN reabrir Resumen (Escape, botón X, dismiss-outside):
+    // limpiar ?reservar para que un reload no re-abra el slideover descartado
+    // (issue #65 edge-case). Escape es ruta de cierre primaria de a11y.
+    updateCategoriaUrl(undefined);
   }
 });
 
@@ -387,8 +396,8 @@ watch(
     const categoryData = categories.find(c => c.categoryCode === codigo);
     if (!categoryData || !vehicleCategories[codigo]) return;
 
-    // Marcar que estamos actualizando desde la URL
-    isUpdatingFromUrl.value = true;
+    // Marcar que estamos actualizando desde la URL (contador reentrante)
+    urlSyncDepth.value++;
 
     // Seleccionar categoría
     const category = useCategory(categoryData, vehicleCategories[codigo]);
@@ -405,9 +414,11 @@ watch(
       } else {
         slideoverReservationResume.value = true;
       }
-      // Resetear flag después de abrir
+      // Reset diferido (nextTick anidado): los watchers de URL (flush:'pre')
+      // disparan tras abrir el slideover y ANTES de este reset, así quedan
+      // enmascarados. Decremento (no =0) por reentrancia.
       nextTick(() => {
-        isUpdatingFromUrl.value = false;
+        urlSyncDepth.value--;
       });
     });
   },
@@ -417,16 +428,16 @@ watch(
 // Issue #25: cerrar slideovers (reka-ui Dialog modal:true) ANTES del unmount
 // por route change. Sin esto, el cleanup interno de Reka UI no corre y
 // `pointer-events: none` queda inline en <body> — DOM compartido en SPA —
-// bloqueando el Searcher cuando el usuario regresa via Back. El guard
-// `isUpdatingFromUrl` evita que los watchers de URL disparen replaceState
+// bloqueando el Searcher cuando el usuario regresa via Back. El contador
+// `urlSyncDepth` evita que los watchers de URL disparen replaceState
 // redundante mientras navegamos a otra ruta.
 onBeforeRouteLeave(async () => {
   if (slideoverReservationForm.value || slideoverReservationResume.value) {
-    isUpdatingFromUrl.value = true;
+    urlSyncDepth.value++;
     slideoverReservationForm.value = false;
     slideoverReservationResume.value = false;
     await nextTick();
-    isUpdatingFromUrl.value = false;
+    urlSyncDepth.value--;
   }
 });
 

--- a/packages/ui-alquilame/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquilame/app/components/CategorySelectionSection.vue
@@ -59,10 +59,18 @@
         />
       </template>
     </div>
+    <!-- UN SOLO slideover con `slideoverStep` interno (issue #65). El diálogo se
+         abre y cierra UNA vez por flujo; "Resumen" y "Datos" son pasos que
+         intercambian su contenido dentro del mismo [role=dialog]. Antes eran dos
+         slideovers (anidados en main, hermanos en el primer fix de #65); en
+         ambos, el hand-off entre dos capas modales corrompía el conteo de reka-ui
+         y dejaba `pointer-events:none` pegado en <body> con 0 diálogos, matando
+         la grilla (regresión SCEN-011). Con un único DialogContent el invariante
+         "0 o 1 [role=dialog]" es estructural y no hay swap de capas. -->
     <u-slideover
-      v-model:open="slideoverReservationResume"
-      title="Resumen de la reserva"
-      description="Antes de continuar revisa la información"
+      v-model:open="slideoverOpen"
+      :title="slideoverStep === 'datos' ? 'Datos para reservas' : 'Resumen de la reserva'"
+      :description="slideoverStep === 'datos' ? 'Completa tus datos y solicita la reserva' : 'Antes de continuar revisa la información'"
       :overlay="false"
       :content="modalContentProps"
       :close="{ color: 'neutral', variant: 'outline', class: 'text-gray-700 border-gray-300 hover:bg-gray-100' }"
@@ -77,10 +85,16 @@
       }"
     >
       <template #body>
-        <reservation-resume :category="selectedCategory"></reservation-resume>
+        <reservation-resume v-if="slideoverStep === 'resumen'" :category="selectedCategory"></reservation-resume>
+        <reservation-form
+          v-else
+          ref="reservationFormComponent"
+          @submit="submitForm"
+        />
       </template>
       <template #footer>
-        <div class="w-full flex flex-col gap-3">
+        <!-- Paso "Resumen": cápsula de compartir + Volver/Siguiente. -->
+        <div v-if="slideoverStep === 'resumen'" class="w-full flex flex-col gap-3">
           <!-- Share Capsule -->
           <div class="flex justify-center">
             <div class="flex items-center gap-2 bg-gray-100 rounded-full px-4 py-2">
@@ -124,10 +138,10 @@
               size="xl"
               class="flex-1 py-4 justify-center bg-gray-200 !text-black hover:bg-gray-300"
               data-testid="reservation-resume-back-test"
-              @click="slideoverReservationResume = false"
+              @click="slideoverOpen = false"
             />
-            <!-- "Siguiente" ya NO es trigger anidado: handler explícito que
-                 abre Datos y cierra Resumen (issue #65, un solo modal). -->
+            <!-- "Siguiente" cambia el paso a "datos" SIN cerrar/reabrir el
+                 diálogo (issue #65): no hay swap de capas modales. -->
             <u-button
               label="Siguiente"
               color="neutral"
@@ -142,57 +156,30 @@
             </u-button>
           </div>
         </div>
-      </template>
-    </u-slideover>
-    <!-- "Datos" es HERMANO de "Resumen" (issue #65): mutuamente excluyentes,
-         a lo sumo un [role=dialog][aria-modal] activo. Antes estaba anidado en
-         el #footer de "Resumen", dejando dos diálogos modales simultáneos. -->
-    <u-slideover
-      v-model:open="slideoverReservationForm"
-      title="Datos para reservas"
-      description="Completa tus datos y solicita la reserva"
-      :overlay="false"
-      :content="modalContentProps"
-      :close="{ color: 'neutral', variant: 'outline', class: 'text-gray-700 border-gray-300 hover:bg-gray-100' }"
-      :ui="{
-        content: 'bg-white',
-        header: 'bg-white',
-        title: 'text-gray-900 text-2xl font-bold',
-        description: 'text-gray-600',
-        body: 'bg-white text-gray-900',
-        footer: 'bg-white gap-2 border-t-0',
-        close: 'absolute top-4 end-4 z-10',
-      }"
-    >
-      <template #body>
-        <reservation-form
-          ref="reservationFormComponent"
-          @submit="submitForm"
-        />
-      </template>
-
-      <template #footer>
-        <u-button
-          label="Volver"
-          color="neutral"
-          variant="solid"
-          size="xl"
-          class="flex-1 py-4 justify-center bg-gray-200 !text-black hover:bg-gray-300"
-          data-testid="reservation-form-back-test"
-          @click="backToResume"
-        />
-        <u-button
-          color="neutral"
-          size="xl"
-          class="flex-1 py-4 justify-center bg-green-700 hover:bg-green-800 disabled:bg-green-700 aria-disabled:bg-green-700 disabled:opacity-80 aria-disabled:opacity-80 text-white"
-          :loading="isSubmittingForm"
-          :disabled="isSubmittingForm"
-          @click="reservationFormComponent.submit()"
-          >Solicitar reserva
-          <template #trailing>
-            <ChevronRightIcon v-if="!isSubmittingForm" cls="size-5" />
-          </template>
-        </u-button>
+        <!-- Paso "Datos": Volver (al resumen) + Solicitar reserva. -->
+        <template v-else>
+          <u-button
+            label="Volver"
+            color="neutral"
+            variant="solid"
+            size="xl"
+            class="flex-1 py-4 justify-center bg-gray-200 !text-black hover:bg-gray-300"
+            data-testid="reservation-form-back-test"
+            @click="backToResume"
+          />
+          <u-button
+            color="neutral"
+            size="xl"
+            class="flex-1 py-4 justify-center bg-green-700 hover:bg-green-800 disabled:bg-green-700 aria-disabled:bg-green-700 disabled:opacity-80 aria-disabled:opacity-80 text-white"
+            :loading="isSubmittingForm"
+            :disabled="isSubmittingForm"
+            @click="reservationFormComponent?.submit()"
+            >Solicitar reserva
+            <template #trailing>
+              <ChevronRightIcon v-if="!isSubmittingForm" cls="size-5" />
+            </template>
+          </u-button>
+        </template>
       </template>
     </u-slideover>
   </template>
@@ -257,8 +244,13 @@ const renderableCategories = computed(() =>
 const hasRenderableAvailable = computed(() =>
   renderableCategories.value.some((c: { estimatedTotalAmount: number }) => c.estimatedTotalAmount !== 999999999),
 );
-const slideoverReservationResume = ref<boolean>(false);
-const slideoverReservationForm = ref<boolean>(false);
+// Un solo slideover modal con dos pasos (issue #65). `slideoverStep` decide
+// título/descripción/body/footer; `slideoverOpen` gobierna la única capa modal.
+// El flujo Resumen↔Datos solo cambia `slideoverStep` (el diálogo permanece
+// abierto), evitando el swap de dos capas que dejaba `pointer-events:none`
+// pegado en <body> (regresión SCEN-011).
+const slideoverOpen = ref<boolean>(false);
+const slideoverStep = ref<'resumen' | 'datos'>('resumen');
 const reservationFormComponent = ref(null);
 const linkCopied = ref(false);
 
@@ -328,7 +320,7 @@ const codigoCategoria = computed(() => categoriaParam.value || resumenParam.valu
 const abrirFormularioDirecto = computed(() => !!reservarParam.value);
 
 // Profundidad de sincronización URL→estado (contador, no booleano): enmascara
-// los watchers de URL mientras abrimos slideovers desde la URL. Es un CONTADOR
+// el watcher de URL mientras abrimos el slideover desde la URL. Es un CONTADOR
 // para ser reentrante — si el watcher de auto-apertura se dispara otra vez
 // antes de que el reset diferido corra (p.ej. filteredCategories emite dos
 // veces, o navegación rápida entre /categoria), un booleano lo desenmascararía
@@ -355,39 +347,30 @@ function updateCategoriaUrl(codigoCategoria?: string, reservar?: boolean) {
   }
 }
 
-// Limpiar URL cuando se cierra el slideover de resumen.
-// Guard (issue #65): en la transición Resumen→Datos, `resume` pasa a false
-// mientras `form` ya es true (mismo tick). Sin `!slideoverReservationForm`,
-// esto borraría el ?reservar=X que el watcher de form acaba de poner. La URL
-// solo se limpia cuando se cierran AMBOS.
-watch(slideoverReservationResume, (isOpen) => {
+// Sincronizar URL con (apertura, paso) del único slideover.
+// - cerrado            → URL base (sin /categoria ni ?reservar)
+// - abierto + resumen  → /categoria/X
+// - abierto + datos    → /categoria/X?reservar=X
+// Con un solo slideover NO hay transición Resumen→Datos que cierre una capa y
+// abra otra, así que no hace falta el guard que antes preservaba ?reservar
+// durante el swap: el cambio de paso solo reescribe la query (issue #65).
+watch([slideoverOpen, slideoverStep], ([open, step]) => {
   if (urlSyncDepth.value > 0) return;
 
-  if (!isOpen && !slideoverReservationForm.value) {
+  // Cerrado → limpiar la URL SIEMPRE, sin gatear por `vehiculo`: si el form se
+  // reseteó (submit fallido, rehidratación) `vehiculo` puede quedar vacío con el
+  // slideover aún abierto, y el `/categoria/X(?reservar)` NO debe sobrevivir al
+  // cierre (si no, un reload reabriría un slideover ya descartado).
+  if (!open) {
     updateCategoriaUrl(undefined);
+    return;
   }
-});
-
-// Sincronizar URL con estado del slideover de formulario
-watch(slideoverReservationForm, (isOpen) => {
-  if (urlSyncDepth.value > 0) return;
+  // Abierto → se necesita la categoría para construir /categoria/X.
   if (!vehiculo.value) return;
-
-  const codigo = vehiculo.value;
-  if (isOpen) {
-    updateCategoriaUrl(codigo, true);
-  } else if (slideoverReservationResume.value) {
-    // Datos→Resumen (backToResume): mantener /categoria sin ?reservar.
-    updateCategoriaUrl(codigo, false);
-  } else {
-    // Datos cerrado SIN reabrir Resumen (Escape, botón X, dismiss-outside):
-    // limpiar ?reservar para que un reload no re-abra el slideover descartado
-    // (issue #65 edge-case). Escape es ruta de cierre primaria de a11y.
-    updateCategoriaUrl(undefined);
-  }
+  updateCategoriaUrl(vehiculo.value, step === 'datos');
 });
 
-// Auto-abrir slideover cuando se carguen las categorías y exista el param
+// Auto-abrir el slideover cuando carguen las categorías y exista el param.
 watch(
   [filteredCategories, codigoCategoria],
   ([categories, codigo]) => {
@@ -404,19 +387,15 @@ watch(
     vehiculo.value = category.categoryCode.value;
     selectedCategory.value = category;
 
-    // Abrir UN solo slideover (issue #65): ?reservar=X → Datos directo;
-    // /categoria/X o ?resumen=X → Resumen. Antes abría ambos en cascada,
-    // dejando dos diálogos modales al des-anidar. `abrirFormularioDirecto`
-    // deriva solo de reservarParam, así que ?resumen=X cae en la rama Resumen.
+    // Abrir el slideover en el paso correcto (issue #65): ?reservar=X → "datos";
+    // /categoria/X o ?resumen=X → "resumen". `abrirFormularioDirecto` deriva
+    // solo de reservarParam, así que ?resumen=X cae en la rama "resumen".
     nextTick(() => {
-      if (abrirFormularioDirecto.value) {
-        slideoverReservationForm.value = true;
-      } else {
-        slideoverReservationResume.value = true;
-      }
-      // Reset diferido (nextTick anidado): los watchers de URL (flush:'pre')
-      // disparan tras abrir el slideover y ANTES de este reset, así quedan
-      // enmascarados. Decremento (no =0) por reentrancia.
+      slideoverStep.value = abrirFormularioDirecto.value ? 'datos' : 'resumen';
+      slideoverOpen.value = true;
+      // Reset diferido (nextTick anidado): el watcher de URL (flush:'pre')
+      // dispara tras abrir el slideover y ANTES de este reset, así queda
+      // enmascarado. Decremento (no =0) por reentrancia.
       nextTick(() => {
         urlSyncDepth.value--;
       });
@@ -425,17 +404,16 @@ watch(
   { immediate: true }
 );
 
-// Issue #25: cerrar slideovers (reka-ui Dialog modal:true) ANTES del unmount
+// Issue #25: cerrar el slideover (reka-ui Dialog modal:true) ANTES del unmount
 // por route change. Sin esto, el cleanup interno de Reka UI no corre y
 // `pointer-events: none` queda inline en <body> — DOM compartido en SPA —
 // bloqueando el Searcher cuando el usuario regresa via Back. El contador
-// `urlSyncDepth` evita que los watchers de URL disparen replaceState
-// redundante mientras navegamos a otra ruta.
+// `urlSyncDepth` evita que el watcher de URL dispare replaceState redundante
+// mientras navegamos a otra ruta.
 onBeforeRouteLeave(async () => {
-  if (slideoverReservationForm.value || slideoverReservationResume.value) {
+  if (slideoverOpen.value) {
     urlSyncDepth.value++;
-    slideoverReservationForm.value = false;
-    slideoverReservationResume.value = false;
+    slideoverOpen.value = false;
     await nextTick();
     urlSyncDepth.value--;
   }
@@ -445,22 +423,22 @@ onBeforeRouteLeave(async () => {
 function setSelectedCategory(category: ReturnType<typeof useCategory>) {
   vehiculo.value = category.categoryCode.value;
   selectedCategory.value = category;
-  slideoverReservationResume.value = true;
-  // Actualizar URL con el código de la categoría
-  updateCategoriaUrl(category.categoryCode.value, false);
+  // Abrir en el paso "resumen"; el watcher [slideoverOpen, slideoverStep]
+  // sincroniza la URL a /categoria/X.
+  slideoverStep.value = 'resumen';
+  slideoverOpen.value = true;
 }
 
-// Transiciones Resumen↔Datos (issue #65): mutan AMBOS refs de forma síncrona
-// en el mismo tick (sin nextTick entre asignaciones). Con flush:'pre', los
-// watchers de URL leen el estado ya consolidado, así el guard de Resumen
-// preserva el ?reservar=X. Invariante: a lo sumo un slideover abierto.
+// Transiciones Resumen↔Datos (issue #65): solo cambian `slideoverStep`. El
+// diálogo permanece abierto (una sola capa modal de reka-ui), el contenido del
+// body y el footer se intercambian. Sin cerrar/reabrir → sin corromper el
+// manejo de pointer-events de reka (regresión SCEN-011). Invariante: a lo sumo
+// un [role=dialog], garantizado estructuralmente por el único DialogContent.
 function goToForm() {
-  slideoverReservationForm.value = true;
-  slideoverReservationResume.value = false;
+  slideoverStep.value = 'datos';
 }
 function backToResume() {
-  slideoverReservationResume.value = true;
-  slideoverReservationForm.value = false;
+  slideoverStep.value = 'resumen';
 }
 
 const { submitForm } = storeForm;

--- a/packages/ui-alquilame/app/components/ReservationForm.vue
+++ b/packages/ui-alquilame/app/components/ReservationForm.vue
@@ -13,6 +13,7 @@
             class="w-full"
             placeholder="Nombres*"
             aria-label="Nombres"
+            autocomplete="given-name"
             :ui="inputUi"
           ></u-input>
         </u-form-field>
@@ -22,6 +23,7 @@
             class="w-full"
             placeholder="Apellidos*"
             aria-label="Apellidos"
+            autocomplete="family-name"
             :ui="inputUi"
           ></u-input>
         </u-form-field>
@@ -50,10 +52,16 @@
             class="w-full"
             placeholder="Email*"
             aria-label="Correo electrónico"
+            autocomplete="email"
             :ui="inputUi"
           ></u-input>
         </u-form-field>
-        <u-form-field class="col-span-2" name="telefono" label="Teléfono">
+        <u-form-field class="col-span-2" name="telefono">
+          <!-- VueTelInput no usa useFormField, así que el label autogenerado de
+               UFormField (for=useId()) no asocia su <input>. Label propio con
+               for="telefono" ↔ inputOptions.id="telefono" → nombre accesible
+               "Teléfono" determinista (issue #65 SCEN-008). -->
+          <label for="telefono" class="block font-medium text-sm text-gray-900 mb-1.5">Teléfono</label>
           <VueTelInput
             v-model="formState.telefono"
             mode="international"

--- a/packages/ui-alquilatucarro/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquilatucarro/app/components/CategorySelectionSection.vue
@@ -64,6 +64,7 @@
       title="Resumen de la reserva"
       description="Antes de continuar revisa la información"
       :overlay="false"
+      :content="modalContentProps"
       :close="{ color: 'neutral', variant: 'outline', class: 'text-gray-700 border-gray-300 hover:bg-gray-100' }"
       :ui="{
         content: 'bg-white',
@@ -122,62 +123,76 @@
               variant="solid"
               size="xl"
               class="flex-1 py-4 justify-center bg-gray-200 !text-black hover:bg-gray-300"
+              data-testid="reservation-resume-back-test"
               @click="slideoverReservationResume = false"
             />
-            <u-slideover
-          v-model:open="slideoverReservationForm"
-          title="Datos para reservas"
-          description="Completa tus datos y solicita la reserva"
-          :overlay="false"
-          :close="{ color: 'neutral', variant: 'outline', class: 'text-gray-700 border-gray-300 hover:bg-gray-100' }"
-          :ui="{
-            content: 'bg-white',
-            header: 'bg-white',
-            title: 'text-gray-900 text-2xl font-bold',
-            description: 'text-gray-600',
-            body: 'bg-white text-gray-900',
-            footer: 'bg-white gap-2 border-t-0',
-            close: 'absolute top-4 end-4 z-10',
-          }"
-        >
-          <u-button label="Siguiente" color="neutral" size="xl" class="flex-1 py-4 justify-center bg-green-700 hover:bg-green-800 text-white">
-            <template #trailing>
-              <ChevronRightIcon cls="size-5" />
-            </template>
-          </u-button>
-
-          <template #body>
-            <reservation-form
-              ref="reservationFormComponent"
-              @submit="submitForm"
-            />
-          </template>
-
-          <template #footer>
+            <!-- "Siguiente" ya NO es trigger anidado: handler explícito que
+                 abre Datos y cierra Resumen (issue #65, un solo modal). -->
             <u-button
-              label="Volver"
-              color="neutral"
-              variant="solid"
-              size="xl"
-              class="flex-1 py-4 justify-center bg-gray-200 !text-black hover:bg-gray-300"
-              @click="slideoverReservationForm = false"
-            />
-            <u-button
+              label="Siguiente"
               color="neutral"
               size="xl"
-              class="flex-1 py-4 justify-center bg-green-700 hover:bg-green-800 disabled:bg-green-700 aria-disabled:bg-green-700 disabled:opacity-80 aria-disabled:opacity-80 text-white"
-              :loading="isSubmittingForm"
-              :disabled="isSubmittingForm"
-              @click="reservationFormComponent.submit()"
-              >Solicitar reserva
+              class="flex-1 py-4 justify-center bg-green-700 hover:bg-green-800 text-white"
+              data-testid="reservation-next-test"
+              @click="goToForm"
+            >
               <template #trailing>
-                <ChevronRightIcon v-if="!isSubmittingForm" cls="size-5" />
+                <ChevronRightIcon cls="size-5" />
               </template>
             </u-button>
-          </template>
-        </u-slideover>
           </div>
         </div>
+      </template>
+    </u-slideover>
+    <!-- "Datos" es HERMANO de "Resumen" (issue #65): mutuamente excluyentes,
+         a lo sumo un [role=dialog][aria-modal] activo. Antes estaba anidado en
+         el #footer de "Resumen", dejando dos diálogos modales simultáneos. -->
+    <u-slideover
+      v-model:open="slideoverReservationForm"
+      title="Datos para reservas"
+      description="Completa tus datos y solicita la reserva"
+      :overlay="false"
+      :content="modalContentProps"
+      :close="{ color: 'neutral', variant: 'outline', class: 'text-gray-700 border-gray-300 hover:bg-gray-100' }"
+      :ui="{
+        content: 'bg-white',
+        header: 'bg-white',
+        title: 'text-gray-900 text-2xl font-bold',
+        description: 'text-gray-600',
+        body: 'bg-white text-gray-900',
+        footer: 'bg-white gap-2 border-t-0',
+        close: 'absolute top-4 end-4 z-10',
+      }"
+    >
+      <template #body>
+        <reservation-form
+          ref="reservationFormComponent"
+          @submit="submitForm"
+        />
+      </template>
+
+      <template #footer>
+        <u-button
+          label="Volver"
+          color="neutral"
+          variant="solid"
+          size="xl"
+          class="flex-1 py-4 justify-center bg-gray-200 !text-black hover:bg-gray-300"
+          data-testid="reservation-form-back-test"
+          @click="backToResume"
+        />
+        <u-button
+          color="neutral"
+          size="xl"
+          class="flex-1 py-4 justify-center bg-green-700 hover:bg-green-800 disabled:bg-green-700 aria-disabled:bg-green-700 disabled:opacity-80 aria-disabled:opacity-80 text-white"
+          :loading="isSubmittingForm"
+          :disabled="isSubmittingForm"
+          @click="reservationFormComponent.submit()"
+          >Solicitar reserva
+          <template #trailing>
+            <ChevronRightIcon v-if="!isSubmittingForm" cls="size-5" />
+          </template>
+        </u-button>
       </template>
     </u-slideover>
   </template>
@@ -246,6 +261,12 @@ const slideoverReservationResume = ref<boolean>(false);
 const slideoverReservationForm = ref<boolean>(false);
 const reservationFormComponent = ref(null);
 const linkCopied = ref(false);
+
+// Issue #65: reka-ui Dialog (vía @nuxt/ui Slideover) no setea aria-modal y su
+// tipo `content` (DialogContentProps) no expone el atributo, aunque el elemento
+// sí lo acepta. Lo inyectamos por la prop `content`; el cast cubre el hueco de
+// tipos de la dependencia para un atributo ARIA estándar.
+const modalContentProps = { 'aria-modal': 'true' } as Record<string, string>;
 
 /** Share functions */
 function getReservationShareUrl() {
@@ -328,11 +349,15 @@ function updateCategoriaUrl(codigoCategoria?: string, reservar?: boolean) {
   }
 }
 
-// Limpiar URL cuando se cierra el slideover de resumen
+// Limpiar URL cuando se cierra el slideover de resumen.
+// Guard (issue #65): en la transición Resumen→Datos, `resume` pasa a false
+// mientras `form` ya es true (mismo tick). Sin `!slideoverReservationForm`,
+// esto borraría el ?reservar=X que el watcher de form acaba de poner. La URL
+// solo se limpia cuando se cierran AMBOS.
 watch(slideoverReservationResume, (isOpen) => {
   if (isUpdatingFromUrl.value) return;
 
-  if (!isOpen) {
+  if (!isOpen && !slideoverReservationForm.value) {
     updateCategoriaUrl(undefined);
   }
 });
@@ -370,23 +395,20 @@ watch(
     vehiculo.value = category.categoryCode.value;
     selectedCategory.value = category;
 
-    // Abrir slideover correspondiente
+    // Abrir UN solo slideover (issue #65): ?reservar=X → Datos directo;
+    // /categoria/X o ?resumen=X → Resumen. Antes abría ambos en cascada,
+    // dejando dos diálogos modales al des-anidar. `abrirFormularioDirecto`
+    // deriva solo de reservarParam, así que ?resumen=X cae en la rama Resumen.
     nextTick(() => {
-      slideoverReservationResume.value = true;
       if (abrirFormularioDirecto.value) {
-        nextTick(() => {
-          slideoverReservationForm.value = true;
-          // Resetear flag después de que todo esté abierto
-          nextTick(() => {
-            isUpdatingFromUrl.value = false;
-          });
-        });
+        slideoverReservationForm.value = true;
       } else {
-        // Resetear flag
-        nextTick(() => {
-          isUpdatingFromUrl.value = false;
-        });
+        slideoverReservationResume.value = true;
       }
+      // Resetear flag después de abrir
+      nextTick(() => {
+        isUpdatingFromUrl.value = false;
+      });
     });
   },
   { immediate: true }
@@ -415,6 +437,19 @@ function setSelectedCategory(category: ReturnType<typeof useCategory>) {
   slideoverReservationResume.value = true;
   // Actualizar URL con el código de la categoría
   updateCategoriaUrl(category.categoryCode.value, false);
+}
+
+// Transiciones Resumen↔Datos (issue #65): mutan AMBOS refs de forma síncrona
+// en el mismo tick (sin nextTick entre asignaciones). Con flush:'pre', los
+// watchers de URL leen el estado ya consolidado, así el guard de Resumen
+// preserva el ?reservar=X. Invariante: a lo sumo un slideover abierto.
+function goToForm() {
+  slideoverReservationForm.value = true;
+  slideoverReservationResume.value = false;
+}
+function backToResume() {
+  slideoverReservationResume.value = true;
+  slideoverReservationForm.value = false;
 }
 
 const { submitForm } = storeForm;

--- a/packages/ui-alquilatucarro/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquilatucarro/app/components/CategorySelectionSection.vue
@@ -327,8 +327,14 @@ const reservarParam = computed(() => route.query.reservar as string | undefined)
 const codigoCategoria = computed(() => categoriaParam.value || resumenParam.value || reservarParam.value);
 const abrirFormularioDirecto = computed(() => !!reservarParam.value);
 
-// Flag para evitar loops cuando actualizamos la URL programáticamente
-const isUpdatingFromUrl = ref(false);
+// Profundidad de sincronización URL→estado (contador, no booleano): enmascara
+// los watchers de URL mientras abrimos slideovers desde la URL. Es un CONTADOR
+// para ser reentrante — si el watcher de auto-apertura se dispara otra vez
+// antes de que el reset diferido corra (p.ej. filteredCategories emite dos
+// veces, o navegación rápida entre /categoria), un booleano lo desenmascararía
+// a mitad de transición (edge-case #65 HIGH). Con el contador, el reset de la
+// primera invocación no abre la ventana mientras la segunda sigue en vuelo.
+const urlSyncDepth = ref(0);
 
 // Actualizar URL con categoría sin disparar navegación Vue Router.
 // Usa history.replaceState para evitar que Nuxt desmonte/remonte la página
@@ -355,7 +361,7 @@ function updateCategoriaUrl(codigoCategoria?: string, reservar?: boolean) {
 // esto borraría el ?reservar=X que el watcher de form acaba de poner. La URL
 // solo se limpia cuando se cierran AMBOS.
 watch(slideoverReservationResume, (isOpen) => {
-  if (isUpdatingFromUrl.value) return;
+  if (urlSyncDepth.value > 0) return;
 
   if (!isOpen && !slideoverReservationForm.value) {
     updateCategoriaUrl(undefined);
@@ -364,17 +370,20 @@ watch(slideoverReservationResume, (isOpen) => {
 
 // Sincronizar URL con estado del slideover de formulario
 watch(slideoverReservationForm, (isOpen) => {
-  if (isUpdatingFromUrl.value) return;
+  if (urlSyncDepth.value > 0) return;
   if (!vehiculo.value) return;
 
   const codigo = vehiculo.value;
   if (isOpen) {
     updateCategoriaUrl(codigo, true);
+  } else if (slideoverReservationResume.value) {
+    // Datos→Resumen (backToResume): mantener /categoria sin ?reservar.
+    updateCategoriaUrl(codigo, false);
   } else {
-    // Volver a mostrar solo categoría sin query param reservar
-    if (slideoverReservationResume.value) {
-      updateCategoriaUrl(codigo, false);
-    }
+    // Datos cerrado SIN reabrir Resumen (Escape, botón X, dismiss-outside):
+    // limpiar ?reservar para que un reload no re-abra el slideover descartado
+    // (issue #65 edge-case). Escape es ruta de cierre primaria de a11y.
+    updateCategoriaUrl(undefined);
   }
 });
 
@@ -387,8 +396,8 @@ watch(
     const categoryData = categories.find(c => c.categoryCode === codigo);
     if (!categoryData || !vehicleCategories[codigo]) return;
 
-    // Marcar que estamos actualizando desde la URL
-    isUpdatingFromUrl.value = true;
+    // Marcar que estamos actualizando desde la URL (contador reentrante)
+    urlSyncDepth.value++;
 
     // Seleccionar categoría
     const category = useCategory(categoryData, vehicleCategories[codigo]);
@@ -405,9 +414,11 @@ watch(
       } else {
         slideoverReservationResume.value = true;
       }
-      // Resetear flag después de abrir
+      // Reset diferido (nextTick anidado): los watchers de URL (flush:'pre')
+      // disparan tras abrir el slideover y ANTES de este reset, así quedan
+      // enmascarados. Decremento (no =0) por reentrancia.
       nextTick(() => {
-        isUpdatingFromUrl.value = false;
+        urlSyncDepth.value--;
       });
     });
   },
@@ -417,16 +428,16 @@ watch(
 // Issue #25: cerrar slideovers (reka-ui Dialog modal:true) ANTES del unmount
 // por route change. Sin esto, el cleanup interno de Reka UI no corre y
 // `pointer-events: none` queda inline en <body> — DOM compartido en SPA —
-// bloqueando el Searcher cuando el usuario regresa via Back. El guard
-// `isUpdatingFromUrl` evita que los watchers de URL disparen replaceState
+// bloqueando el Searcher cuando el usuario regresa via Back. El contador
+// `urlSyncDepth` evita que los watchers de URL disparen replaceState
 // redundante mientras navegamos a otra ruta.
 onBeforeRouteLeave(async () => {
   if (slideoverReservationForm.value || slideoverReservationResume.value) {
-    isUpdatingFromUrl.value = true;
+    urlSyncDepth.value++;
     slideoverReservationForm.value = false;
     slideoverReservationResume.value = false;
     await nextTick();
-    isUpdatingFromUrl.value = false;
+    urlSyncDepth.value--;
   }
 });
 

--- a/packages/ui-alquilatucarro/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquilatucarro/app/components/CategorySelectionSection.vue
@@ -59,10 +59,18 @@
         />
       </template>
     </div>
+    <!-- UN SOLO slideover con `slideoverStep` interno (issue #65). El diálogo se
+         abre y cierra UNA vez por flujo; "Resumen" y "Datos" son pasos que
+         intercambian su contenido dentro del mismo [role=dialog]. Antes eran dos
+         slideovers (anidados en main, hermanos en el primer fix de #65); en
+         ambos, el hand-off entre dos capas modales corrompía el conteo de reka-ui
+         y dejaba `pointer-events:none` pegado en <body> con 0 diálogos, matando
+         la grilla (regresión SCEN-011). Con un único DialogContent el invariante
+         "0 o 1 [role=dialog]" es estructural y no hay swap de capas. -->
     <u-slideover
-      v-model:open="slideoverReservationResume"
-      title="Resumen de la reserva"
-      description="Antes de continuar revisa la información"
+      v-model:open="slideoverOpen"
+      :title="slideoverStep === 'datos' ? 'Datos para reservas' : 'Resumen de la reserva'"
+      :description="slideoverStep === 'datos' ? 'Completa tus datos y solicita la reserva' : 'Antes de continuar revisa la información'"
       :overlay="false"
       :content="modalContentProps"
       :close="{ color: 'neutral', variant: 'outline', class: 'text-gray-700 border-gray-300 hover:bg-gray-100' }"
@@ -77,10 +85,16 @@
       }"
     >
       <template #body>
-        <reservation-resume :category="selectedCategory"></reservation-resume>
+        <reservation-resume v-if="slideoverStep === 'resumen'" :category="selectedCategory"></reservation-resume>
+        <reservation-form
+          v-else
+          ref="reservationFormComponent"
+          @submit="submitForm"
+        />
       </template>
       <template #footer>
-        <div class="w-full flex flex-col gap-3">
+        <!-- Paso "Resumen": cápsula de compartir + Volver/Siguiente. -->
+        <div v-if="slideoverStep === 'resumen'" class="w-full flex flex-col gap-3">
           <!-- Share Capsule -->
           <div class="flex justify-center">
             <div class="flex items-center gap-2 bg-gray-100 rounded-full px-4 py-2">
@@ -124,10 +138,10 @@
               size="xl"
               class="flex-1 py-4 justify-center bg-gray-200 !text-black hover:bg-gray-300"
               data-testid="reservation-resume-back-test"
-              @click="slideoverReservationResume = false"
+              @click="slideoverOpen = false"
             />
-            <!-- "Siguiente" ya NO es trigger anidado: handler explícito que
-                 abre Datos y cierra Resumen (issue #65, un solo modal). -->
+            <!-- "Siguiente" cambia el paso a "datos" SIN cerrar/reabrir el
+                 diálogo (issue #65): no hay swap de capas modales. -->
             <u-button
               label="Siguiente"
               color="neutral"
@@ -142,57 +156,30 @@
             </u-button>
           </div>
         </div>
-      </template>
-    </u-slideover>
-    <!-- "Datos" es HERMANO de "Resumen" (issue #65): mutuamente excluyentes,
-         a lo sumo un [role=dialog][aria-modal] activo. Antes estaba anidado en
-         el #footer de "Resumen", dejando dos diálogos modales simultáneos. -->
-    <u-slideover
-      v-model:open="slideoverReservationForm"
-      title="Datos para reservas"
-      description="Completa tus datos y solicita la reserva"
-      :overlay="false"
-      :content="modalContentProps"
-      :close="{ color: 'neutral', variant: 'outline', class: 'text-gray-700 border-gray-300 hover:bg-gray-100' }"
-      :ui="{
-        content: 'bg-white',
-        header: 'bg-white',
-        title: 'text-gray-900 text-2xl font-bold',
-        description: 'text-gray-600',
-        body: 'bg-white text-gray-900',
-        footer: 'bg-white gap-2 border-t-0',
-        close: 'absolute top-4 end-4 z-10',
-      }"
-    >
-      <template #body>
-        <reservation-form
-          ref="reservationFormComponent"
-          @submit="submitForm"
-        />
-      </template>
-
-      <template #footer>
-        <u-button
-          label="Volver"
-          color="neutral"
-          variant="solid"
-          size="xl"
-          class="flex-1 py-4 justify-center bg-gray-200 !text-black hover:bg-gray-300"
-          data-testid="reservation-form-back-test"
-          @click="backToResume"
-        />
-        <u-button
-          color="neutral"
-          size="xl"
-          class="flex-1 py-4 justify-center bg-green-700 hover:bg-green-800 disabled:bg-green-700 aria-disabled:bg-green-700 disabled:opacity-80 aria-disabled:opacity-80 text-white"
-          :loading="isSubmittingForm"
-          :disabled="isSubmittingForm"
-          @click="reservationFormComponent.submit()"
-          >Solicitar reserva
-          <template #trailing>
-            <ChevronRightIcon v-if="!isSubmittingForm" cls="size-5" />
-          </template>
-        </u-button>
+        <!-- Paso "Datos": Volver (al resumen) + Solicitar reserva. -->
+        <template v-else>
+          <u-button
+            label="Volver"
+            color="neutral"
+            variant="solid"
+            size="xl"
+            class="flex-1 py-4 justify-center bg-gray-200 !text-black hover:bg-gray-300"
+            data-testid="reservation-form-back-test"
+            @click="backToResume"
+          />
+          <u-button
+            color="neutral"
+            size="xl"
+            class="flex-1 py-4 justify-center bg-green-700 hover:bg-green-800 disabled:bg-green-700 aria-disabled:bg-green-700 disabled:opacity-80 aria-disabled:opacity-80 text-white"
+            :loading="isSubmittingForm"
+            :disabled="isSubmittingForm"
+            @click="reservationFormComponent?.submit()"
+            >Solicitar reserva
+            <template #trailing>
+              <ChevronRightIcon v-if="!isSubmittingForm" cls="size-5" />
+            </template>
+          </u-button>
+        </template>
       </template>
     </u-slideover>
   </template>
@@ -257,8 +244,13 @@ const renderableCategories = computed(() =>
 const hasRenderableAvailable = computed(() =>
   renderableCategories.value.some((c: { estimatedTotalAmount: number }) => c.estimatedTotalAmount !== 999999999),
 );
-const slideoverReservationResume = ref<boolean>(false);
-const slideoverReservationForm = ref<boolean>(false);
+// Un solo slideover modal con dos pasos (issue #65). `slideoverStep` decide
+// título/descripción/body/footer; `slideoverOpen` gobierna la única capa modal.
+// El flujo Resumen↔Datos solo cambia `slideoverStep` (el diálogo permanece
+// abierto), evitando el swap de dos capas que dejaba `pointer-events:none`
+// pegado en <body> (regresión SCEN-011).
+const slideoverOpen = ref<boolean>(false);
+const slideoverStep = ref<'resumen' | 'datos'>('resumen');
 const reservationFormComponent = ref(null);
 const linkCopied = ref(false);
 
@@ -328,7 +320,7 @@ const codigoCategoria = computed(() => categoriaParam.value || resumenParam.valu
 const abrirFormularioDirecto = computed(() => !!reservarParam.value);
 
 // Profundidad de sincronización URL→estado (contador, no booleano): enmascara
-// los watchers de URL mientras abrimos slideovers desde la URL. Es un CONTADOR
+// el watcher de URL mientras abrimos el slideover desde la URL. Es un CONTADOR
 // para ser reentrante — si el watcher de auto-apertura se dispara otra vez
 // antes de que el reset diferido corra (p.ej. filteredCategories emite dos
 // veces, o navegación rápida entre /categoria), un booleano lo desenmascararía
@@ -355,39 +347,30 @@ function updateCategoriaUrl(codigoCategoria?: string, reservar?: boolean) {
   }
 }
 
-// Limpiar URL cuando se cierra el slideover de resumen.
-// Guard (issue #65): en la transición Resumen→Datos, `resume` pasa a false
-// mientras `form` ya es true (mismo tick). Sin `!slideoverReservationForm`,
-// esto borraría el ?reservar=X que el watcher de form acaba de poner. La URL
-// solo se limpia cuando se cierran AMBOS.
-watch(slideoverReservationResume, (isOpen) => {
+// Sincronizar URL con (apertura, paso) del único slideover.
+// - cerrado            → URL base (sin /categoria ni ?reservar)
+// - abierto + resumen  → /categoria/X
+// - abierto + datos    → /categoria/X?reservar=X
+// Con un solo slideover NO hay transición Resumen→Datos que cierre una capa y
+// abra otra, así que no hace falta el guard que antes preservaba ?reservar
+// durante el swap: el cambio de paso solo reescribe la query (issue #65).
+watch([slideoverOpen, slideoverStep], ([open, step]) => {
   if (urlSyncDepth.value > 0) return;
 
-  if (!isOpen && !slideoverReservationForm.value) {
+  // Cerrado → limpiar la URL SIEMPRE, sin gatear por `vehiculo`: si el form se
+  // reseteó (submit fallido, rehidratación) `vehiculo` puede quedar vacío con el
+  // slideover aún abierto, y el `/categoria/X(?reservar)` NO debe sobrevivir al
+  // cierre (si no, un reload reabriría un slideover ya descartado).
+  if (!open) {
     updateCategoriaUrl(undefined);
+    return;
   }
-});
-
-// Sincronizar URL con estado del slideover de formulario
-watch(slideoverReservationForm, (isOpen) => {
-  if (urlSyncDepth.value > 0) return;
+  // Abierto → se necesita la categoría para construir /categoria/X.
   if (!vehiculo.value) return;
-
-  const codigo = vehiculo.value;
-  if (isOpen) {
-    updateCategoriaUrl(codigo, true);
-  } else if (slideoverReservationResume.value) {
-    // Datos→Resumen (backToResume): mantener /categoria sin ?reservar.
-    updateCategoriaUrl(codigo, false);
-  } else {
-    // Datos cerrado SIN reabrir Resumen (Escape, botón X, dismiss-outside):
-    // limpiar ?reservar para que un reload no re-abra el slideover descartado
-    // (issue #65 edge-case). Escape es ruta de cierre primaria de a11y.
-    updateCategoriaUrl(undefined);
-  }
+  updateCategoriaUrl(vehiculo.value, step === 'datos');
 });
 
-// Auto-abrir slideover cuando se carguen las categorías y exista el param
+// Auto-abrir el slideover cuando carguen las categorías y exista el param.
 watch(
   [filteredCategories, codigoCategoria],
   ([categories, codigo]) => {
@@ -404,19 +387,15 @@ watch(
     vehiculo.value = category.categoryCode.value;
     selectedCategory.value = category;
 
-    // Abrir UN solo slideover (issue #65): ?reservar=X → Datos directo;
-    // /categoria/X o ?resumen=X → Resumen. Antes abría ambos en cascada,
-    // dejando dos diálogos modales al des-anidar. `abrirFormularioDirecto`
-    // deriva solo de reservarParam, así que ?resumen=X cae en la rama Resumen.
+    // Abrir el slideover en el paso correcto (issue #65): ?reservar=X → "datos";
+    // /categoria/X o ?resumen=X → "resumen". `abrirFormularioDirecto` deriva
+    // solo de reservarParam, así que ?resumen=X cae en la rama "resumen".
     nextTick(() => {
-      if (abrirFormularioDirecto.value) {
-        slideoverReservationForm.value = true;
-      } else {
-        slideoverReservationResume.value = true;
-      }
-      // Reset diferido (nextTick anidado): los watchers de URL (flush:'pre')
-      // disparan tras abrir el slideover y ANTES de este reset, así quedan
-      // enmascarados. Decremento (no =0) por reentrancia.
+      slideoverStep.value = abrirFormularioDirecto.value ? 'datos' : 'resumen';
+      slideoverOpen.value = true;
+      // Reset diferido (nextTick anidado): el watcher de URL (flush:'pre')
+      // dispara tras abrir el slideover y ANTES de este reset, así queda
+      // enmascarado. Decremento (no =0) por reentrancia.
       nextTick(() => {
         urlSyncDepth.value--;
       });
@@ -425,17 +404,16 @@ watch(
   { immediate: true }
 );
 
-// Issue #25: cerrar slideovers (reka-ui Dialog modal:true) ANTES del unmount
+// Issue #25: cerrar el slideover (reka-ui Dialog modal:true) ANTES del unmount
 // por route change. Sin esto, el cleanup interno de Reka UI no corre y
 // `pointer-events: none` queda inline en <body> — DOM compartido en SPA —
 // bloqueando el Searcher cuando el usuario regresa via Back. El contador
-// `urlSyncDepth` evita que los watchers de URL disparen replaceState
-// redundante mientras navegamos a otra ruta.
+// `urlSyncDepth` evita que el watcher de URL dispare replaceState redundante
+// mientras navegamos a otra ruta.
 onBeforeRouteLeave(async () => {
-  if (slideoverReservationForm.value || slideoverReservationResume.value) {
+  if (slideoverOpen.value) {
     urlSyncDepth.value++;
-    slideoverReservationForm.value = false;
-    slideoverReservationResume.value = false;
+    slideoverOpen.value = false;
     await nextTick();
     urlSyncDepth.value--;
   }
@@ -445,22 +423,22 @@ onBeforeRouteLeave(async () => {
 function setSelectedCategory(category: ReturnType<typeof useCategory>) {
   vehiculo.value = category.categoryCode.value;
   selectedCategory.value = category;
-  slideoverReservationResume.value = true;
-  // Actualizar URL con el código de la categoría
-  updateCategoriaUrl(category.categoryCode.value, false);
+  // Abrir en el paso "resumen"; el watcher [slideoverOpen, slideoverStep]
+  // sincroniza la URL a /categoria/X.
+  slideoverStep.value = 'resumen';
+  slideoverOpen.value = true;
 }
 
-// Transiciones Resumen↔Datos (issue #65): mutan AMBOS refs de forma síncrona
-// en el mismo tick (sin nextTick entre asignaciones). Con flush:'pre', los
-// watchers de URL leen el estado ya consolidado, así el guard de Resumen
-// preserva el ?reservar=X. Invariante: a lo sumo un slideover abierto.
+// Transiciones Resumen↔Datos (issue #65): solo cambian `slideoverStep`. El
+// diálogo permanece abierto (una sola capa modal de reka-ui), el contenido del
+// body y el footer se intercambian. Sin cerrar/reabrir → sin corromper el
+// manejo de pointer-events de reka (regresión SCEN-011). Invariante: a lo sumo
+// un [role=dialog], garantizado estructuralmente por el único DialogContent.
 function goToForm() {
-  slideoverReservationForm.value = true;
-  slideoverReservationResume.value = false;
+  slideoverStep.value = 'datos';
 }
 function backToResume() {
-  slideoverReservationResume.value = true;
-  slideoverReservationForm.value = false;
+  slideoverStep.value = 'resumen';
 }
 
 const { submitForm } = storeForm;

--- a/packages/ui-alquilatucarro/app/components/ReservationForm.vue
+++ b/packages/ui-alquilatucarro/app/components/ReservationForm.vue
@@ -13,6 +13,7 @@
             class="w-full"
             placeholder="Nombres*"
             aria-label="Nombres"
+            autocomplete="given-name"
             :ui="inputUi"
           ></u-input>
         </u-form-field>
@@ -22,6 +23,7 @@
             class="w-full"
             placeholder="Apellidos*"
             aria-label="Apellidos"
+            autocomplete="family-name"
             :ui="inputUi"
           ></u-input>
         </u-form-field>
@@ -50,10 +52,16 @@
             class="w-full"
             placeholder="Email*"
             aria-label="Correo electrónico"
+            autocomplete="email"
             :ui="inputUi"
           ></u-input>
         </u-form-field>
-        <u-form-field class="col-span-2" name="telefono" label="Teléfono">
+        <u-form-field class="col-span-2" name="telefono">
+          <!-- VueTelInput no usa useFormField, así que el label autogenerado de
+               UFormField (for=useId()) no asocia su <input>. Label propio con
+               for="telefono" ↔ inputOptions.id="telefono" → nombre accesible
+               "Teléfono" determinista (issue #65 SCEN-008). -->
+          <label for="telefono" class="block font-medium text-sm text-gray-900 mb-1.5">Teléfono</label>
           <VueTelInput
             v-model="formState.telefono"
             mode="international"


### PR DESCRIPTION
## Qué y por qué

Arregla dos defectos de accesibilidad del flujo de reserva (épico #63, auditoría agéntica, Ola 0), en las 3 marcas.

**Problema A — un solo slideover modal.** "Datos para reservas" estaba anidado en el `#footer` de "Resumen de la reserva" → dos `role=dialog` modales abiertos a la vez. Se des-anidan a **hermanos mutuamente excluyentes**: a lo sumo uno activo por cualquier ruta de entrada.

**Problema B — formulario.** `autocomplete` estándar (`given-name`, `family-name`, `email`, `tel`) y nombre accesible "Teléfono" asociado al input.

## Corrección al diagnóstico de la auditoría

La auditoría reportó "falta `aria-modal`". El código dice otra cosa: reka-ui **no emite `aria-modal` en ningún caso** (0 ocurrencias en su dist). El defecto real eran **dos modales simultáneos**, no un atributo faltante. El fix es estructural (des-anidar), y `aria-modal="true"` se inyecta explícitamente vía la prop `content`.

## Cambios

- `CategorySelectionSection.vue` (×3 byte-idénticas): slideovers hermanos; handlers `goToForm`/`backToResume` (mutación síncrona, `flush:'pre'`); watcher de auto-apertura sin la cascada que abría ambos (`?reservar=X` → Datos; `/categoria` o `?resumen` → Resumen); guard de 1 línea que preserva `?reservar=X` en la transición; `urlSyncDepth` (contador reentrante) en vez de booleano; Escape/X/dismiss limpia `?reservar`.
- `ReservationForm.vue` (×3): `autocomplete` en nombres/apellidos/email; `<label for="telefono">` propio para asociar `VueTelInput` (que no usa `useFormField`).
- `usePhoneField.ts` + `PhoneInputOptionsType.ts`: `autocomplete:'tel'`, quitado `aria-label="Número de teléfono"` (violaba WCAG 2.5.3 Label in Name).

## Verificación

- **e2e** `e2e/reservation-a11y-single-dialog.spec.ts` → **7/7** (chromium), 2 corridas estables. Cubre deep-link `?reservar`/cold-load, flujo click completo, URL en cada transición, regresión #25 (Back), Escape, autocomplete y nombre accesible del teléfono. Stub de availability vía `page.route` con un `categoryCode` real.
- **unit** `usePhoneField.test.ts` (failing-first → green); suite logic **304/304**.
- **typecheck**: delta 0 (268 = baseline conocido).
- **paridad**: los 6 archivos de UI byte-idénticos por componente.

## Quality gate (pre-PR)

code-reviewer **APPROVE**, security **limpio**, performance **limpio**, edge-case **resuelto** (HIGH contador + MEDIUM Escape arreglados; re-review iteración 2 sin hallazgos).

## Diferido (no introducido aquí)

`backToResume` escribe la URL desde `vehiculo` y no `selectedCategory` (edge-case MEDIUM preexistente, reachability incierta) — seguimiento aparte.

## Notas

- 3 commits de docs (spec/plan/summary, ambos reviewed) + 2 de implementación.
- ΔLOC inflado por spec + e2e; el delta de código de producción es pequeño.

Closes #65
Part of #63
