### PR TITLE
fix(reservations): hydration mismatch en enlaces de ciudades del footer (#109)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "build:alquilatucarro": "pnpm --filter ui-alquilatucarro build",
     "build:all": "pnpm --filter ui-alquilatucarro build && pnpm --filter ui-alquilame build && pnpm --filter ui-alquicarros build",
     "typecheck": "pnpm --filter 'ui-*' typecheck",
+    "typecheck:safe": "for b in alquilatucarro alquilame alquicarros; do echo \"▸ ui-$b\"; if command -v ionice >/dev/null 2>&1; then ionice -c3 nice -n19 pnpm --filter \"ui-$b\" typecheck || exit 1; else nice -n19 pnpm --filter \"ui-$b\" typecheck || exit 1; fi; done",
     "lint": "pnpm -r lint"
   },
   "dependencies": {

--- a/packages/logic/src/utils/__tests__/buildCityReservationURL.test.ts
+++ b/packages/logic/src/utils/__tests__/buildCityReservationURL.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+
+import { buildCityReservationURL } from "../buildCityReservationURL";
+import type City from "../types/type/City";
+import type BranchData from "../types/data/BranchData";
+
+const bogota: City = {
+  id: "bogota",
+  name: "Bogotá",
+  description: "",
+  testimonials: [],
+};
+
+const branch = (over: Partial<BranchData>): BranchData => ({
+  id: 1,
+  code: "X",
+  name: "Sucursal",
+  city: "bogota",
+  ...over,
+});
+
+const branches: BranchData[] = [
+  branch({ id: 1, code: "OFBO", name: "Oficina Centro", city: "bogota" }),
+  branch({ id: 2, code: "AABO", name: "Aeropuerto El Dorado", city: "bogota" }),
+  branch({ id: 3, code: "AAMD", name: "Aeropuerto Medellín", city: "medellin" }),
+];
+
+const HOURS = { initHour: "12:00", endHour: "12:00" };
+const DATES = { initDay: "2026-06-06", endDay: "2026-06-13", ...HOURS };
+const NULL_DATES = { initDay: null, endDay: null, ...HOURS };
+
+describe("buildCityReservationURL", () => {
+  // SCEN-1 (hydration): server + first client render pass null dates → stable
+  // href identical on both passes → zero hydration attribute mismatch.
+  it("returns the stable /city href when dates are null (SSR + first hydration)", () => {
+    const ssr = buildCityReservationURL(bogota, branches, NULL_DATES);
+    const firstClientRender = buildCityReservationURL(bogota, branches, NULL_DATES);
+    expect(ssr).toBe("/bogota");
+    expect(firstClientRender).toBe(ssr); // byte-identical → no mismatch
+  });
+
+  it("returns the stable /city href when only one date is null", () => {
+    expect(
+      buildCityReservationURL(bogota, branches, { ...DATES, endDay: null }),
+    ).toBe("/bogota");
+  });
+
+  // SCEN-2 (frescura) + SCEN-3 (regresión): after mount, dated deep-link using
+  // the airport branch (code AA*) for the city.
+  it("prefers the airport branch (AA*) and embeds the fresh dates after mount", () => {
+    expect(buildCityReservationURL(bogota, branches, DATES)).toBe(
+      "/bogota/buscar-vehiculos/lugar-recogida/aabo/lugar-devolucion/aabo/fecha-recogida/2026-06-06/fecha-devolucion/2026-06-13/hora-recogida/12:00/hora-devolucion/12:00",
+    );
+  });
+
+  // SCEN-3 (regresión): no airport → first branch in the city.
+  it("falls back to any city branch when there is no airport branch", () => {
+    const noAirport = [branch({ id: 1, code: "OFCL", city: "cali" })];
+    const cali: City = { ...bogota, id: "cali", name: "Cali" };
+    expect(buildCityReservationURL(cali, noAirport, DATES)).toBe(
+      "/cali/buscar-vehiculos/lugar-recogida/ofcl/lugar-devolucion/ofcl/fecha-recogida/2026-06-06/fecha-devolucion/2026-06-13/hora-recogida/12:00/hora-devolucion/12:00",
+    );
+  });
+
+  // SCEN-3 (regresión): no branch for the city → plain city page fallback.
+  it("falls back to /city when the city has no branch at all", () => {
+    expect(buildCityReservationURL(bogota, [], DATES)).toBe("/bogota");
+    const cucuta: City = { ...bogota, id: "cucuta", name: "Cúcuta" };
+    expect(buildCityReservationURL(cucuta, branches, DATES)).toBe("/cucuta");
+  });
+
+  it("tolerates a null/undefined branch list", () => {
+    expect(
+      buildCityReservationURL(bogota, undefined as unknown as BranchData[], DATES),
+    ).toBe("/bogota");
+  });
+});

--- a/packages/logic/src/utils/buildCityReservationURL.ts
+++ b/packages/logic/src/utils/buildCityReservationURL.ts
@@ -1,0 +1,49 @@
+// Builds the deep-link URL for a city footer button (the "Ciudades donde
+// ofrecemos alquiler de carros" section in every brand layout).
+//
+// Branch selection priority: airport branch (code starts with "AA") → any
+// branch in the city → fallback to the plain city page `/${city.id}`.
+//
+// Hydration safety (Issue #109): the dated deep-link must NOT be baked into
+// SSR/ISR-cached HTML, because `today()` recomputed at hydration time produces
+// a different date once the cache crosses a day boundary — causing one
+// "hydration attribute mismatch" per city link. The caller passes `initDay`/
+// `endDay` as null on the server and during the first client render, and only
+// fills them after `onMounted`. When either date is null this returns the
+// stable, crawlable `/${city.id}` href — identical on server and first client
+// render → no mismatch. After mount the fresh (today+1) deep-link is applied.
+
+import type City from "./types/type/City";
+import type BranchData from "./types/data/BranchData";
+
+export interface CityReservationDates {
+  initDay: string | null;
+  endDay: string | null;
+  initHour: string;
+  endHour: string;
+}
+
+export function buildCityReservationURL(
+  city: City,
+  branches: BranchData[],
+  dates: CityReservationDates,
+): string {
+  const list = branches ?? [];
+
+  // Buscar la sucursal de aeropuerto para esta ciudad (código empieza con "AA")
+  const airportBranch = list.find(
+    (branch) => branch.city === city.id && branch.code.startsWith("AA"),
+  );
+
+  // Si no hay aeropuerto, buscar cualquier sucursal de esa ciudad
+  const branch = airportBranch ?? list.find((branch) => branch.city === city.id);
+
+  // Fallback (sin sucursal) o pre-montaje (fechas aún null): href estable y
+  // crawleable, idéntico en servidor y primera hidratación → sin mismatch.
+  if (!branch || !dates.initDay || !dates.endDay) {
+    return `/${city.id}`;
+  }
+
+  const code = branch.code.toLowerCase();
+  return `/${city.id}/buscar-vehiculos/lugar-recogida/${code}/lugar-devolucion/${code}/fecha-recogida/${dates.initDay}/fecha-devolucion/${dates.endDay}/hora-recogida/${dates.initHour}/hora-devolucion/${dates.endHour}`;
+}

--- a/packages/logic/src/utils/index.ts
+++ b/packages/logic/src/utils/index.ts
@@ -27,6 +27,8 @@ export { categoryOffersMonthly } from './categoryOffersMonthly';
 export { pickEffectiveTotalCoverageUnitCharge } from './pickEffectiveTotalCoverage';
 export { resolvePicoyPlacaExempt } from './isPicoyPlacaExempt';
 export { isCategoryVisibleInCity } from './isCategoryVisibleInCity';
+export { buildCityReservationURL } from './buildCityReservationURL';
+export type { CityReservationDates } from './buildCityReservationURL';
 
 // ============================================================================
 // Server Helpers

--- a/packages/ui-alquicarros/app/layouts/default.vue
+++ b/packages/ui-alquicarros/app/layouts/default.vue
@@ -121,7 +121,8 @@
 
 <script lang="ts" setup>
 import type { NavigationMenuItem } from '@nuxt/ui'
-import type { BranchData, City as CityData } from '@rentacar-main/logic/utils'
+import { buildCityReservationURL } from '@rentacar-main/logic/utils'
+import type { City as CityData } from '@rentacar-main/logic/utils'
 import { today } from '@internationalized/date'
 import { storeToRefs } from 'pinia'
 
@@ -186,29 +187,25 @@ const { cities } = useData();
 const { franchise, reservation, defaultTimezone } = useAppConfig();
 const { sortedBranches: branches } = storeToRefs(useStoreAdminData());
 
-// Genera URL de reserva dinámica para cada ciudad (como el selector del hero)
-const reservationInitDay = today(defaultTimezone).add({ days: 1 }).toString();
-const reservationEndDay = today(defaultTimezone).add({ days: 8 }).toString();
-const reservationInitHour = "12:00";
-const reservationEndHour = "12:00";
+// Fechas del deep-link: se calculan SOLO en cliente tras montar para evitar
+// hydration attribute mismatch (Issue #109). En servidor y primera hidratación
+// son null → buildCityReservationURL devuelve el href estable /${city.id},
+// idéntico en ambos pases. Tras onMounted se aplica el deep-link con fecha
+// fresca (today+1), nunca una fecha pasada de una página ISR cacheada.
+const reservationInitDay = ref<string | null>(null);
+const reservationEndDay = ref<string | null>(null);
 
-const getCityReservationURL = (city: CityData): string => {
-  // Buscar la sucursal de aeropuerto para esta ciudad (código empieza con "AA")
-  const airportBranch = (branches.value || []).find(
-    (branch: BranchData) => branch.city === city.id && branch.code.startsWith('AA')
-  );
+onMounted(() => {
+  reservationInitDay.value = today(defaultTimezone).add({ days: 1 }).toString();
+  reservationEndDay.value = today(defaultTimezone).add({ days: 8 }).toString();
+});
 
-  // Si no hay aeropuerto, buscar cualquier sucursal de esa ciudad
-  const branch = airportBranch || (branches.value || []).find(
-    (branch: BranchData) => branch.city === city.id
-  );
-
-  if (!branch) {
-    // Fallback a la ruta simple si no hay sucursal
-    return `/${city.id}`;
-  }
-
-  return `/${city.id}/buscar-vehiculos/lugar-recogida/${branch.code.toLowerCase()}/lugar-devolucion/${branch.code.toLowerCase()}/fecha-recogida/${reservationInitDay}/fecha-devolucion/${reservationEndDay}/hora-recogida/${reservationInitHour}/hora-devolucion/${reservationEndHour}`;
-};
+const getCityReservationURL = (city: CityData): string =>
+  buildCityReservationURL(city, branches.value || [], {
+    initDay: reservationInitDay.value,
+    endDay: reservationEndDay.value,
+    initHour: "12:00",
+    endHour: "12:00",
+  });
 
 </script>

--- a/packages/ui-alquilame/app/layouts/default.vue
+++ b/packages/ui-alquilame/app/layouts/default.vue
@@ -121,7 +121,8 @@
 
 <script lang="ts" setup>
 import type { NavigationMenuItem } from '@nuxt/ui'
-import type { BranchData, City as CityData } from '@rentacar-main/logic/utils'
+import { buildCityReservationURL } from '@rentacar-main/logic/utils'
+import type { City as CityData } from '@rentacar-main/logic/utils'
 import { today } from '@internationalized/date'
 import { storeToRefs } from 'pinia'
 
@@ -186,29 +187,25 @@ const { cities } = useData();
 const { franchise, reservation, defaultTimezone } = useAppConfig();
 const { sortedBranches: branches } = storeToRefs(useStoreAdminData());
 
-// Genera URL de reserva dinámica para cada ciudad (como el selector del hero)
-const reservationInitDay = today(defaultTimezone).add({ days: 1 }).toString();
-const reservationEndDay = today(defaultTimezone).add({ days: 8 }).toString();
-const reservationInitHour = "12:00";
-const reservationEndHour = "12:00";
+// Fechas del deep-link: se calculan SOLO en cliente tras montar para evitar
+// hydration attribute mismatch (Issue #109). En servidor y primera hidratación
+// son null → buildCityReservationURL devuelve el href estable /${city.id},
+// idéntico en ambos pases. Tras onMounted se aplica el deep-link con fecha
+// fresca (today+1), nunca una fecha pasada de una página ISR cacheada.
+const reservationInitDay = ref<string | null>(null);
+const reservationEndDay = ref<string | null>(null);
 
-const getCityReservationURL = (city: CityData): string => {
-  // Buscar la sucursal de aeropuerto para esta ciudad (código empieza con "AA")
-  const airportBranch = (branches.value || []).find(
-    (branch: BranchData) => branch.city === city.id && branch.code.startsWith('AA')
-  );
+onMounted(() => {
+  reservationInitDay.value = today(defaultTimezone).add({ days: 1 }).toString();
+  reservationEndDay.value = today(defaultTimezone).add({ days: 8 }).toString();
+});
 
-  // Si no hay aeropuerto, buscar cualquier sucursal de esa ciudad
-  const branch = airportBranch || (branches.value || []).find(
-    (branch: BranchData) => branch.city === city.id
-  );
-
-  if (!branch) {
-    // Fallback a la ruta simple si no hay sucursal
-    return `/${city.id}`;
-  }
-
-  return `/${city.id}/buscar-vehiculos/lugar-recogida/${branch.code.toLowerCase()}/lugar-devolucion/${branch.code.toLowerCase()}/fecha-recogida/${reservationInitDay}/fecha-devolucion/${reservationEndDay}/hora-recogida/${reservationInitHour}/hora-devolucion/${reservationEndHour}`;
-};
+const getCityReservationURL = (city: CityData): string =>
+  buildCityReservationURL(city, branches.value || [], {
+    initDay: reservationInitDay.value,
+    endDay: reservationEndDay.value,
+    initHour: "12:00",
+    endHour: "12:00",
+  });
 
 </script>

--- a/packages/ui-alquilatucarro/app/layouts/default.vue
+++ b/packages/ui-alquilatucarro/app/layouts/default.vue
@@ -131,7 +131,8 @@
 
 <script lang="ts" setup>
 import type { NavigationMenuItem } from '@nuxt/ui'
-import type { BranchData, City as CityData } from '@rentacar-main/logic/utils'
+import { buildCityReservationURL } from '@rentacar-main/logic/utils'
+import type { City as CityData } from '@rentacar-main/logic/utils'
 import { today } from '@internationalized/date'
 import { storeToRefs } from 'pinia'
 
@@ -196,29 +197,25 @@ const { cities } = useData();
 const { franchise, reservation, defaultTimezone } = useAppConfig();
 const { sortedBranches: branches } = storeToRefs(useStoreAdminData());
 
-// Genera URL de reserva dinámica para cada ciudad (como el selector del hero)
-const reservationInitDay = today(defaultTimezone).add({ days: 1 }).toString();
-const reservationEndDay = today(defaultTimezone).add({ days: 8 }).toString();
-const reservationInitHour = "12:00";
-const reservationEndHour = "12:00";
+// Fechas del deep-link: se calculan SOLO en cliente tras montar para evitar
+// hydration attribute mismatch (Issue #109). En servidor y primera hidratación
+// son null → buildCityReservationURL devuelve el href estable /${city.id},
+// idéntico en ambos pases. Tras onMounted se aplica el deep-link con fecha
+// fresca (today+1), nunca una fecha pasada de una página ISR cacheada.
+const reservationInitDay = ref<string | null>(null);
+const reservationEndDay = ref<string | null>(null);
 
-const getCityReservationURL = (city: CityData): string => {
-  // Buscar la sucursal de aeropuerto para esta ciudad (código empieza con "AA")
-  const airportBranch = (branches.value || []).find(
-    (branch: BranchData) => branch.city === city.id && branch.code.startsWith('AA')
-  );
+onMounted(() => {
+  reservationInitDay.value = today(defaultTimezone).add({ days: 1 }).toString();
+  reservationEndDay.value = today(defaultTimezone).add({ days: 8 }).toString();
+});
 
-  // Si no hay aeropuerto, buscar cualquier sucursal de esa ciudad
-  const branch = airportBranch || (branches.value || []).find(
-    (branch: BranchData) => branch.city === city.id
-  );
-
-  if (!branch) {
-    // Fallback a la ruta simple si no hay sucursal
-    return `/${city.id}`;
-  }
-
-  return `/${city.id}/buscar-vehiculos/lugar-recogida/${branch.code.toLowerCase()}/lugar-devolucion/${branch.code.toLowerCase()}/fecha-recogida/${reservationInitDay}/fecha-devolucion/${reservationEndDay}/hora-recogida/${reservationInitHour}/hora-devolucion/${reservationEndHour}`;
-};
+const getCityReservationURL = (city: CityData): string =>
+  buildCityReservationURL(city, branches.value || [], {
+    initDay: reservationInitDay.value,
+    endDay: reservationEndDay.value,
+    initHour: "12:00",
+    endHour: "12:00",
+  });
 
 </script>


### PR DESCRIPTION
## Problema
Varios `hydration attribute mismatch on <a>` en consola (uno por enlace), concentrados en los **enlaces de ciudades del footer** (`#sedes`).

## Causa raíz
`layouts/default.vue` (3 marcas) construía el `:to` de cada botón de ciudad con una fecha calculada **una vez en `setup`** vía `today()`. Bajo ISR (`isr: 3600`), el HTML cacheado el día D queda con `fecha-recogida=D+1`; al hidratar el día siguiente `today()` recalcula → el `href` del cliente no coincide con el cacheado → un mismatch por ciudad. Bonus bug: una página ISR no regenerada servía fechas pasadas en los deep-links.

## Solución
- Nuevo util puro **`buildCityReservationURL`** en `packages/logic` — saca la lógica de dominio de presentación (boundary "logic NO contiene presentación") y elimina la duplicación 3×.
- Fechas → `ref<string|null>(null)` pobladas en `onMounted`. En servidor y **primera** hidratación son `null` → el util devuelve el `href` estable `/${city.id}`, idéntico en ambos pases → **sin mismatch**. Tras montar se aplica el deep-link con fecha fresca (`today+1`), nunca pasada.
- Preserva la selección de sucursal: aeropuerto `AA*` → cualquier sucursal → fallback `/${city.id}` (crawleable para SEO).

## Escenarios (3/3)
- **SCEN-1 (hydration):** fechas `null` → href estable y byte-idéntico SSR vs primera render.
- **SCEN-2 (frescura):** post-mount → deep-link con `today+1` y sucursal de aeropuerto.
- **SCEN-3 (regresión):** prioridad aeropuerto, fallback a cualquier sucursal, fallback a `/${city.id}`.

## Verificación
- `pnpm --filter @rentacar-main/logic test` → **307 passed** (6 nuevos en `buildCityReservationURL.test.ts`).
- Red-green: al quitar el guard de fechas-null, 2 tests del invariante **fallan**; restaurado → 6 pasan.
- Typecheck (1 marca, throttled): 268 = baseline conocido, **0 en archivos tocados** (delta 0).

> Nota: el bug **no es reproducible en `nuxt dev`** (sin ISR/cruce de día, SSR y cliente coinciden); el unit test del invariante es la prueba determinista.

## Incluye también (chore)
Script `typecheck:safe` en `package.json` raíz: typecheck **secuencial** (una marca a la vez) bajo `ionice -c3 nice -n19`, porque el `typecheck` root lanza las 3 marcas en paralelo y satura el disco en WSL2.

Closes #109