### PR TITLE
perf(logic): Map lookup replaces O(n·m) find in useStoreSearchData (#15)

### DIFF
--- a/docs/specs/issue-15-perf/scenarios/store-search-data-map-lookup.scenarios.md
+++ b/docs/specs/issue-15-perf/scenarios/store-search-data-map-lookup.scenarios.md
@@ -1,0 +1,60 @@
+---
+name: store-search-data-map-lookup
+created_by: pablo
+created_at: 2026-06-09T00:00:00Z
+issue: 15
+---
+
+# Issue #15 — Map lookup replaces O(n·m) find in useStoreSearchData
+
+Performance refactor with **zero observable behavior change**. The `categories`
+computed and the monthly branch of `search()` merge admin rows with availability
+rows. The merge currently does `Array.find()` inside `.map()` (O(n·m)); the
+refactor swaps it for a `Map<categoryCode, row>` lookup (O(n+m)) and simplifies
+the comparator. These scenarios are the holdout: the merged output and ordering
+must be byte-for-byte identical before and after.
+
+> Issue Finding 1 (collapse the multi-pass filter chain + hoist hardcoded
+> allow-lists to Sets) is **obsolete**: issue #28 already replaced that chain
+> with a single `isCategoryVisibleInCity(...)` pass driven by the dashboard.
+> No scenario covers it because the code it describes no longer exists.
+
+## SCEN-001: categories merges availability by code, unmatched become unable cards, sorted ascending
+**Given**: admin data with categories `[B, C, D]` and a non-monthly availability
+payload carrying rows for `C` (estimatedTotalAmount 80000) and `B`
+(estimatedTotalAmount 120000), with no row for `D`
+**When**: `store.categories` is read
+**Then**: it returns 3 entries — `C` and `B` carry their availability amounts
+plus admin metadata (`categoryModels`, `categoryMonthPrices`), `D` is an unable
+card (estimatedTotalAmount 999999999) — ordered ascending by estimatedTotalAmount
+as `[C(80000), B(120000), D(999999999)]`
+**Evidence**: `store.categories.map(c => [c.categoryCode, c.estimatedTotalAmount])`
+=== `[['C',80000],['B',120000],['D',999999999]]`
+
+## SCEN-002: duplicate availability codes resolve to the FIRST occurrence (Array.find semantics)
+**Given**: admin data with category `[C]` and an availability payload containing
+two rows for code `C` — the first with estimatedTotalAmount 50000, the second
+with 90000
+**When**: `store.categories` is read
+**Then**: the merged `C` entry uses the first row (50000), never the last — a
+naive `new Map(entries)` would keep the last and silently regress
+**Evidence**: `store.categories.find(c => c.categoryCode === 'C').estimatedTotalAmount`
+=== `50000`
+
+## SCEN-003: monthly branch copies returnFeeAmount from the matching availability row by code
+**Given**: a monthly reservation, admin categories `C` and `LE` both offering
+monthly pricing, and an availability dataArray with `returnFeeAmount` `{C: 30000, LE: 45000}`
+**When**: `search()` completes
+**Then**: each entry in `categoriesAvailabilityData` carries the `returnFeeAmount`
+of its own code — `C → 30000`, `LE → 45000`
+**Evidence**: `categoriesAvailabilityData` mapped to `[categoryCode, returnFeeAmount]`
+includes `['C',30000]` and `['LE',45000]`
+
+## SCEN-004: existing store suite stays green (no behavioural regression)
+**Given**: the full `useStoreSearchData.*.test.ts` suite (admin reactivity,
+monthly exclusion, LLNRAG009 unable cards, error toast, reset flag)
+**When**: the refactor is applied
+**Then**: every existing spec still passes — the merge/sort/monthly paths they
+exercise are unchanged
+**Evidence**: `pnpm --filter @rentacar-main/logic test` exit code 0, all
+`useStoreSearchData` specs PASS

--- a/packages/logic/src/stores/__tests__/useStoreSearchData.mapLookupMerge.test.ts
+++ b/packages/logic/src/stores/__tests__/useStoreSearchData.mapLookupMerge.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { ref } from 'vue'
+
+import type CategoryAvailabilityData from '../../utils/types/data/CategoryAvailabilityData'
+import type { CategoryType } from '../../utils/types/type/CategoryType'
+
+// Issue #15: the merge of admin rows with availability rows in the `categories`
+// computed and in the monthly branch of search() used `Array.find()` inside a
+// `.map()` (O(n·m)). The refactor swaps it for a Map<categoryCode, row> lookup
+// (O(n+m)) and simplifies the comparator. These specs are the holdout — the
+// merged output and ordering must be identical before and after.
+//
+// SCEN-001: categories merges availability by code, unmatched → unable card,
+//   sorted ascending by estimatedTotalAmount.
+// SCEN-002: duplicate availability codes resolve to the FIRST occurrence — a
+//   naive new Map(entries) would keep the LAST and silently regress.
+// SCEN-003: the monthly branch copies returnFeeAmount from the matching row by
+//   code.
+
+const FETCH_AVAILABILITY = vi.fn()
+
+vi.mock('../../composables/useFetchCategoriesAvailabilityData', () => ({
+  default: () => FETCH_AVAILABILITY(),
+}))
+
+const monthlyPriced = () => ({
+  '1k_kms': 900000,
+  '2k_kms': 1200000,
+  '3k_kms': 1500000,
+  init_date: '2026-01-01',
+  end_date: '2026-12-31',
+  total_insurance_price: 0,
+  one_day_price: 0,
+  status: 'active',
+})
+
+const makeAdminCategory = (code: string, overrides = {}) => ({
+  id: code,
+  code,
+  identification: code,
+  description: `Gama ${code}`,
+  name: code,
+  category: `${code} Demo`,
+  models: [{ name: `model-${code}` }],
+  month_prices: [],
+  total_coverage_unit_charge: 0,
+  extra_km_charge: 0,
+  ...overrides,
+})
+
+const availabilityRow = (
+  code: CategoryType,
+  estimatedTotalAmount: number,
+  overrides: Partial<CategoryAvailabilityData> = {},
+): CategoryAvailabilityData => ({
+  categoryCode: code,
+  categoryDescription: '',
+  totalAmount: estimatedTotalAmount,
+  estimatedTotalAmount,
+  vehicleDayCharge: 0,
+  numberDays: 3,
+  taxFeeAmount: 0,
+  taxFeePercentage: 0,
+  IVAFeeAmount: 0,
+  coverageUnitCharge: 0,
+  coverageQuantity: 0,
+  coverageTotalAmount: 0,
+  totalCoverageUnitCharge: 0,
+  returnFeeAmount: 0,
+  referenceToken: 't',
+  rateQualifier: 'r',
+  ...overrides,
+})
+
+describe('useStoreSearchData Map-lookup merge (issue #15)', () => {
+  beforeEach(() => {
+    FETCH_AVAILABILITY.mockReset()
+    vi.stubGlobal('useToast', () => ({ add: vi.fn(), clear: vi.fn() }))
+    setActivePinia(createPinia())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('SCEN-001: merges availability by code, unmatched → unable card, sorted ascending', async () => {
+    vi.stubGlobal('useState', () => ref({
+      categories: [makeAdminCategory('C'), makeAdminCategory('LE'), makeAdminCategory('GR')],
+      branches: [],
+      extras: undefined,
+      vehicleCategories: {},
+    }))
+
+    const { default: useStoreSearchData } = await import('../useStoreSearchData')
+    const store = useStoreSearchData()
+
+    // GR has no availability row → must surface as an unable card (999999999).
+    store.categoriesAvailabilityData = [
+      availabilityRow('LE', 120000),
+      availabilityRow('C', 80000),
+    ]
+
+    expect(store.categories.map((c) => [c.categoryCode, c.estimatedTotalAmount])).toEqual([
+      ['C', 80000],
+      ['LE', 120000],
+      ['GR', 999999999],
+    ])
+
+    // Matched entries inherit admin metadata via the merge.
+    const c = store.categories.find((x) => x.categoryCode === 'C')
+    expect(c?.categoryModels).toEqual([{ name: 'model-C' }])
+  })
+
+  it('SCEN-002: duplicate availability codes resolve to the FIRST occurrence', async () => {
+    vi.stubGlobal('useState', () => ref({
+      categories: [makeAdminCategory('C')],
+      branches: [],
+      extras: undefined,
+      vehicleCategories: {},
+    }))
+
+    const { default: useStoreSearchData } = await import('../useStoreSearchData')
+    const store = useStoreSearchData()
+
+    store.categoriesAvailabilityData = [
+      availabilityRow('C', 50000),
+      availabilityRow('C', 90000),
+    ]
+
+    expect(store.categories.find((c) => c.categoryCode === 'C')?.estimatedTotalAmount).toBe(50000)
+  })
+
+  it('SCEN-003: monthly branch copies returnFeeAmount from the matching row by code', async () => {
+    vi.stubGlobal('useState', () => ref({
+      categories: [
+        makeAdminCategory('C', { month_prices: [monthlyPriced()] }),
+        makeAdminCategory('LE', { month_prices: [monthlyPriced()] }),
+      ],
+      branches: [],
+      extras: undefined,
+      vehicleCategories: {},
+    }))
+
+    FETCH_AVAILABILITY.mockResolvedValue({
+      data: ref([
+        availabilityRow('LE', 0, { returnFeeAmount: 45000 }),
+        availabilityRow('C', 0, { returnFeeAmount: 30000 }),
+      ]),
+      error: ref(null),
+    })
+
+    const { default: useStoreReservationForm } = await import('../useStoreReservationForm')
+    const formStore = useStoreReservationForm()
+    formStore.haveMonthlyReservation = true
+    formStore.fechaRecogida = '2026-03-15'
+
+    const { default: useStoreSearchData } = await import('../useStoreSearchData')
+    const store = useStoreSearchData()
+
+    await store.search()
+
+    const fees = (store.categoriesAvailabilityData ?? []).map((c) => [c.categoryCode, c.returnFeeAmount])
+    expect(fees).toContainEqual(['C', 30000])
+    expect(fees).toContainEqual(['LE', 45000])
+  })
+
+  // SCEN-002 invariant applied to the monthly call site: it shares indexByCode
+  // with the computed, so first-occurrence must hold here too. Locks the
+  // monthly path against a future divergence even if the sites stop sharing
+  // the helper (code-reviewer issue #15, Minor 2).
+  it('SCEN-003b: monthly branch picks the FIRST occurrence on duplicate availability codes', async () => {
+    vi.stubGlobal('useState', () => ref({
+      categories: [makeAdminCategory('C', { month_prices: [monthlyPriced()] })],
+      branches: [],
+      extras: undefined,
+      vehicleCategories: {},
+    }))
+
+    FETCH_AVAILABILITY.mockResolvedValue({
+      data: ref([
+        availabilityRow('C', 0, { returnFeeAmount: 11111 }),
+        availabilityRow('C', 0, { returnFeeAmount: 99999 }),
+      ]),
+      error: ref(null),
+    })
+
+    const { default: useStoreReservationForm } = await import('../useStoreReservationForm')
+    const formStore = useStoreReservationForm()
+    formStore.haveMonthlyReservation = true
+    formStore.fechaRecogida = '2026-03-15'
+
+    const { default: useStoreSearchData } = await import('../useStoreSearchData')
+    const store = useStoreSearchData()
+
+    await store.search()
+
+    const c = (store.categoriesAvailabilityData ?? []).find((x) => x.categoryCode === 'C')
+    expect(c?.returnFeeAmount).toBe(11111)
+  })
+})

--- a/packages/logic/src/stores/useStoreSearchData.ts
+++ b/packages/logic/src/stores/useStoreSearchData.ts
@@ -19,6 +19,7 @@ import { categoryOffersMonthly, isCategoryVisibleInCity } from '@rentacar-main/l
 import type {
   CategoryAvailabilityData,
   CategoryData,
+  CategoryType,
   ErrorMessage,
 } from '@rentacar-main/logic/utils';
 
@@ -86,6 +87,8 @@ const useStoreSearchData = defineStore("storeSearchData", () => {
       }
       else {
         const dataArray = Array.isArray(data.value) ? data.value : [];
+        // Index once instead of a linear find per category — issue #15.
+        const returnFeeByCode = indexByCode(dataArray);
         categoriesAvailabilityData.value = categoriesAdminData.value?.filter((categoryAdmin: CategoryData) =>
           offersMonthly(categoryAdmin)
         ) // keep only categories that actually offer monthly pricing
@@ -95,9 +98,7 @@ const useStoreSearchData = defineStore("storeSearchData", () => {
         )
         .map((category: CategoryAvailabilityData) => {
           // add return fee amount to each category
-          const categoryAvailability = dataArray.find((categoryAvailability: CategoryAvailabilityData) =>
-            categoryAvailability.categoryCode == category.categoryCode
-          );
+          const categoryAvailability = returnFeeByCode.get(category.categoryCode);
 
           if(categoryAvailability)
             category['returnFeeAmount'] = categoryAvailability.returnFeeAmount;
@@ -160,10 +161,11 @@ const useStoreSearchData = defineStore("storeSearchData", () => {
 
     if (categoriesAvailabilityData.value) {
 
+      // Index once so the merge is O(n+m) instead of O(n·m) — issue #15.
+      const availabilityByCode = indexByCode(categoriesAvailabilityData.value);
+
       return categoriesAdminData.value.map((categoryAdmin: CategoryData) => {
-        const categoryAvailability = categoriesAvailabilityData.value?.find((categoryAvailability: CategoryAvailabilityData) => 
-          categoryAvailability.categoryCode == categoryAdmin.id
-        );
+        const categoryAvailability = availabilityByCode.get(categoryAdmin.id);
 
         if(categoryAvailability){
           
@@ -179,11 +181,9 @@ const useStoreSearchData = defineStore("storeSearchData", () => {
         }
         else return createCategoryAvailability(categoryAdmin, true);
       })
-      .sort((a: CategoryAvailabilityData, b: CategoryAvailabilityData) => {
-        if (a.estimatedTotalAmount < b.estimatedTotalAmount) return -1;
-        else if (a.estimatedTotalAmount > b.estimatedTotalAmount) return 1;
-        return 0;
-      });
+      .sort((a: CategoryAvailabilityData, b: CategoryAvailabilityData) =>
+        a.estimatedTotalAmount - b.estimatedTotalAmount
+      );
       
     } else return [];
     
@@ -231,6 +231,19 @@ const useStoreSearchData = defineStore("storeSearchData", () => {
     noAvailableCategories,
   };
 });
+
+// Index availability rows by category code, keeping the FIRST occurrence for
+// duplicate codes — preserves the semantics of the Array.find it replaced
+// (issue #15). new Map(entries) would keep the LAST and silently regress.
+const indexByCode = (
+  rows: CategoryAvailabilityData[],
+): Map<CategoryType, CategoryAvailabilityData> => {
+  const byCode = new Map<CategoryType, CategoryAvailabilityData>();
+  for (const row of rows) {
+    if (!byCode.has(row.categoryCode)) byCode.set(row.categoryCode, row);
+  }
+  return byCode;
+};
 
 const createCategoryAvailability = (category: CategoryData, unable: boolean = false) : CategoryAvailabilityData => ({
     categoryCode: category.id,


### PR DESCRIPTION
## Qué

Refactor de performance en `packages/logic/src/stores/useStoreSearchData.ts` (issue #15, Finding 2): reemplaza el `Array.find()` dentro de `.map()` (O(n·m)) por un lookup con `Map` (O(n+m)) en los dos sitios de merge — el computed `categories` y la rama monthly de `search()` — y simplifica el comparador de sort.

## Por qué

El merge de filas admin con filas de disponibilidad hacía un `find` lineal por categoría. Acotado hoy (~10 categorías) pero cuadrático a medida que el admin onboarda más gamas.

## Cómo

- Helper `indexByCode()` indexa por `categoryCode` una sola vez, **preservando la primera coincidencia** ante códigos duplicados — réplica exacta de la semántica de `Array.find`. Un `new Map(entries)` ingenuo guardaría la última y regresaría silenciosamente; `SCEN-002` / `SCEN-003b` blindan justo eso.
- Comparador `if/else` → `a.estimatedTotalAmount - b.estimatedTotalAmount` (`estimatedTotalAmount` siempre es número finito → sin riesgo de `NaN`).

## Scope

- **Finding 1 del issue está obsoleto**: la cadena de filtros con allow-lists hardcodeadas que describe ya no existe — el issue #28 la reemplazó por `isCategoryVisibleInCity()`. Nada que colapsar.
- Cambio aislado a `logic`; behavior-preserving en las 3 marcas que lo heredan.

## Evidencia

- `pnpm --filter @rentacar-main/logic test` → **320/320** passed (52 files)
- Test nuevo `mapLookupMerge` → 4/4 (SCEN-001, 002, 003, 003b)
- Typecheck (`ui-alquilatucarro`) → 0 errores en archivos tocados
- Red-green del holdout: last-wins rompe SCEN-002 + SCEN-003b; first-occurrence verde
- Quality gate (code-reviewer + edge-case-detector + performance-engineer + code-simplifier): cero Critical/Important

## Holdout

`docs/specs/issue-15-perf/scenarios/store-search-data-map-lookup.scenarios.md`

## Follow-up (fuera de scope)

El hot-path real *por interacción del usuario* es `filteredCategories`/`hasAvailableCategories`, no el computed optimizado aquí (que corre 1×/búsqueda). Negligible a la escala actual; issue aparte si se quiere perseguir.

Closes #15
