### PR TITLE
feat(seo): declarar ReserveAction y eliminar SearchAction falso (#64)

### DIFF
--- a/docs/specs/2026-06-09-issue-64-reserve-action/design.md
+++ b/docs/specs/2026-06-09-issue-64-reserve-action/design.md
@@ -1,0 +1,52 @@
+# Diseño — #64: ReserveAction + eliminar SearchAction falso
+
+> Épico #63 (auditoría agéntica 2026-05-26, hallazgo W1) · Layer `logic` → 3 marcas
+
+## Problema
+
+El JSON-LD de las marcas declara un `SearchAction` cuyo `urlTemplate` apunta a
+`${franchise.website}/{search_term_string}`. No existe un buscador por término
+libre en el sitio: un agente que ejecute esa acción falla. Además, no se declara
+ninguna `ReserveAction`, así que un agente que lee el grafo no descubre que el
+sitio permite reservar.
+
+## Decisión
+
+1. **Eliminar** el `SearchAction`. Verificado en código: no hay buscador por
+   texto libre. La búsqueda real del sitio es de *disponibilidad* (estructurada:
+   ciudad × lugares × fechas × horas), que no es lo que modela `SearchAction`
+   (caja de búsqueda de contenido por término libre). Repuntarlo seguiría siendo
+   semánticamente falso; construir un buscador de contenido es una feature aparte,
+   fuera del alcance de #64. Lo honesto es quitarlo.
+
+2. **Declarar** un `ReserveAction` en el nodo `AutoRental` (la entidad de negocio
+   que ofrece la reserva — ubicación semánticamente correcta para `potentialAction`):
+   - `target` → `EntryPoint` con `urlTemplate: franchise.website` (la home, donde
+     arranca el flujo de reserva). **Resoluble hoy**, sin dependencias.
+   - `actionPlatform` → desktop + mobile web.
+   - `result` → `RentalCarReservation` (declara qué produce la acción).
+
+3. **Diferir** `actionApplication` (WebAPI programática) a D2
+   (`amaw-sas/rentacar-dashboard#73`, hoy OPEN). Cuando D2 cierre, se enriquece el
+   `ReserveAction` con la API pública documentada y un deep-link parametrizado por
+   ciudad (que necesita el directorio `slug↔code↔ciudad` de D2). Se registra como
+   follow-up en #64 — no bloquea el cierre de los criterios de aceptación actuales.
+
+## Por qué no esperar a D2
+
+Los criterios de aceptación de #64 piden "`SearchAction` falso eliminado" y
+"`ReserveAction` presente y válido". Ambos se cumplen con un `EntryPoint` web
+resoluble hoy. La capa WebAPI es enriquecimiento, no requisito de #64.
+
+## Alcance
+
+- **Archivo:** `packages/logic/src/composables/useBaseSEO.ts` (único).
+- **Blast radius:** `useBaseSEO` corre en `app.vue` de las 3 marcas (todas las
+  páginas) + home + city/search SEO. El `ReserveAction` aparece site-wide
+  (consistente: el `SearchAction` también lo era). Sin consumidores de código;
+  solo cambia el output JSON-LD/SEO. Sin cambios de API ni de datos.
+- **Imports:** quitar `SearchAction`; añadir `ReserveAction`, `RentalCarReservation`.
+
+## Escenarios observables (holdout)
+
+Ver `scenarios/issue-64.scenarios.md`.

--- a/docs/specs/2026-06-09-issue-64-reserve-action/scenarios/issue-64.scenarios.md
+++ b/docs/specs/2026-06-09-issue-64-reserve-action/scenarios/issue-64.scenarios.md
@@ -1,0 +1,33 @@
+# Scenarios — #64 ReserveAction + eliminar SearchAction falso
+
+Holdout observable. Verificación sobre el **JSON-LD renderizado** (no el source).
+Aplica a las 3 marcas (alquilatucarro, alquilame, alquicarros).
+
+## SCEN-001 — No queda SearchAction falso
+- **Given** el HTML renderizado de la home de una marca
+- **When** se extrae el grafo JSON-LD (`<script type="application/ld+json">`)
+- **Then** no existe ningún nodo con `"@type": "SearchAction"`
+- **Verify:** `curl -s <url> | grep -o '"@type":"SearchAction"'` → vacío
+
+## SCEN-002 — ReserveAction resoluble presente
+- **Given** el grafo JSON-LD renderizado de la home
+- **When** un agente busca un `potentialAction` de tipo `ReserveAction`
+- **Then** existe un `ReserveAction` cuyo `target` es un `EntryPoint` con
+  `urlTemplate` igual a una URL resoluble del sitio (`franchise.website`),
+  **no** la raíz con `{search_term_string}`
+- **And** declara `result` de tipo `RentalCarReservation`
+- **Verify:** el JSON-LD contiene `"@type":"ReserveAction"` con
+  `target.urlTemplate` == el dominio de la marca y sin `{search_term_string}`
+
+## SCEN-003 — Schema válido
+- **Given** el `ReserveAction` declarado
+- **When** se valida contra Schema.org (typecheck `schema-dts` + validador estructural)
+- **Then** los tipos son correctos: `ReserveAction.target: EntryPoint`,
+  `EntryPoint.urlTemplate: string`, `EntryPoint.actionPlatform`,
+  `ReserveAction.result: RentalCarReservation`; sin errores de tipo
+- **Verify:** `pnpm --filter ui-<brand> typecheck` (build-mode) verde para el archivo;
+  validación estructural del nodo
+
+## Fuera de alcance (follow-up, gated por D2 = dashboard#73)
+- `actionApplication` (WebAPI) apuntando a la API pública documentada.
+- Deep-link `urlTemplate` parametrizado por ciudad (necesita directorio `slug↔code↔ciudad`).

--- a/packages/logic/src/composables/useBaseSEO.ts
+++ b/packages/logic/src/composables/useBaseSEO.ts
@@ -1,5 +1,5 @@
 // External dependencies
-import type { AutoRental, Brand, OpeningHoursSpecification, SearchAction, EntryPoint } from 'schema-dts';
+import type { AutoRental, Brand, OpeningHoursSpecification, EntryPoint, ReserveAction, RentalCarReservation } from 'schema-dts';
 
 export const useBaseSEO = () => {
 
@@ -28,14 +28,6 @@ export const useBaseSEO = () => {
     useSchemaOrg([
         defineWebSite({
             inLanguage: "es",
-            potentialAction: <SearchAction>{
-                '@type': 'SearchAction',
-                target: <EntryPoint>{
-                    '@type': 'EntryPoint',
-                    urlTemplate: `${franchise.website}/{search_term_string}`
-                },
-                'query-input': 'required name=search_term_string'
-            }
         }),
         defineWebPage({
             title: organization.name,
@@ -93,6 +85,24 @@ export const useBaseSEO = () => {
                 "alquiler de autos"
             ],
             sameAs: franchise.socialmedia,
+            // Acción de reserva descubrible por agentes (épico #63, W1).
+            // EntryPoint web resoluble hoy; el actionApplication (WebAPI) se
+            // añade cuando cierre D2 (amaw-sas/rentacar-dashboard#73).
+            potentialAction: <ReserveAction>{
+                '@type': 'ReserveAction',
+                name: `Reservar vehículo en ${franchise.name}`,
+                target: <EntryPoint>{
+                    '@type': 'EntryPoint',
+                    urlTemplate: franchise.website,
+                    actionPlatform: [
+                        'https://schema.org/DesktopWebPlatform',
+                        'https://schema.org/MobileWebPlatform',
+                    ],
+                },
+                result: <RentalCarReservation>{
+                    '@type': 'RentalCarReservation',
+                },
+            },
         }
     ])
 }

--- a/packages/logic/tests/seo-reserve-action.test.ts
+++ b/packages/logic/tests/seo-reserve-action.test.ts
@@ -1,0 +1,83 @@
+// Holdout para #64 — ReserveAction + eliminar SearchAction falso.
+// Ejecuta useBaseSEO con los auto-imports de Nuxt stubbeados y captura el grafo
+// que se pasa a useSchemaOrg, para aserción directa sobre el output (no el source).
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { useBaseSEO } from '../src/composables/useBaseSEO'
+
+const FRANCHISE = {
+  name: 'Marca Test',
+  title: 'Marca Test — alquiler',
+  shortname: 'MT',
+  description: 'desc',
+  website: 'https://marca.test',
+  logo: 'https://marca.test/logo.png',
+  phone: '+57 300',
+  email: 'a@b.co',
+  socialmedia: ['https://x.com/mt'],
+}
+const ORGANIZATION = { name: 'AMAW SAS', logo: 'l', brand: 'B', otherbrands: ['C'] }
+
+let captured: any[] = []
+
+beforeEach(() => {
+  captured = []
+  vi.stubGlobal('useAppConfig', () => ({ franchise: FRANCHISE, organization: ORGANIZATION }))
+  vi.stubGlobal('useRoute', () => ({ path: '/' }))
+  vi.stubGlobal('useSeoMeta', () => {})
+  vi.stubGlobal('useHead', () => {})
+  // define* devuelven su input con @type, suficiente para inspeccionar el grafo.
+  vi.stubGlobal('defineWebSite', (x: any) => ({ '@type': 'WebSite', ...x }))
+  vi.stubGlobal('defineWebPage', (x: any) => ({ '@type': 'WebPage', ...x }))
+  vi.stubGlobal('defineOrganization', (x: any) => ({ '@type': 'Organization', ...x }))
+  vi.stubGlobal('useSchemaOrg', (graph: any[]) => { captured = graph })
+})
+
+afterEach(() => vi.unstubAllGlobals())
+
+// Busca recursivamente nodos cuyo '@type' coincide (string o array).
+function findByType(graph: any[], type: string): any[] {
+  const out: any[] = []
+  const walk = (n: any) => {
+    if (!n || typeof n !== 'object') return
+    const t = n['@type']
+    if (t === type || (Array.isArray(t) && t.includes(type))) out.push(n)
+    Object.values(n).forEach((v) => Array.isArray(v) ? v.forEach(walk) : walk(v))
+  }
+  graph.forEach(walk)
+  return out
+}
+
+describe('#64 useBaseSEO — ReserveAction reemplaza SearchAction falso', () => {
+  it('SCEN-001: no declara ningún SearchAction', () => {
+    useBaseSEO()
+    expect(findByType(captured, 'SearchAction')).toHaveLength(0)
+    // y el WebSite ya no lleva potentialAction falso
+    const website = findByType(captured, 'WebSite')[0]
+    expect(website?.potentialAction).toBeUndefined()
+  })
+
+  it('SCEN-002: declara un ReserveAction resoluble con EntryPoint al sitio', () => {
+    useBaseSEO()
+    const actions = findByType(captured, 'ReserveAction')
+    expect(actions).toHaveLength(1)
+    const action = actions[0]
+    // target = EntryPoint a una URL resoluble (no la raíz con {search_term_string})
+    expect(action.target['@type']).toBe('EntryPoint')
+    expect(action.target.urlTemplate).toBe(FRANCHISE.website)
+    expect(action.target.urlTemplate).not.toContain('{search_term_string}')
+    // actionPlatform debe usar los IRIs canónicos https:// del enum (no http://)
+    expect(action.target.actionPlatform).toEqual([
+        'https://schema.org/DesktopWebPlatform',
+        'https://schema.org/MobileWebPlatform',
+    ])
+    // result declara qué produce la acción
+    expect(action.result['@type']).toBe('RentalCarReservation')
+  })
+
+  it('SCEN-002b: el ReserveAction cuelga del nodo AutoRental', () => {
+    useBaseSEO()
+    const autoRental = findByType(captured, 'AutoRental')[0]
+    expect(autoRental).toBeDefined()
+    expect(autoRental.potentialAction['@type']).toBe('ReserveAction')
+  })
+})


### PR DESCRIPTION
## Qué y por qué

Issue #64 (épico auditoría agéntica #63, hallazgo W1). El JSON-LD de las 3 marcas declaraba un `SearchAction` falso (apuntaba a un buscador por término libre inexistente, `urlTemplate` a la raíz con `{search_term_string}`) y no declaraba ninguna acción de reserva. Un agente que leyera el grafo no descubría que el sitio permite reservar, y uno que ejecutara el `SearchAction` fallaba.

## Cambios

`packages/logic/src/composables/useBaseSEO.ts` (layer compartido → **afecta las 3 marcas**):

- **Eliminado** el `SearchAction` falso. No existe buscador de contenido por texto libre en el sitio; quitarlo es lo honesto (la búsqueda real es de *disponibilidad*, estructurada, que no es lo que modela `SearchAction`).
- **Declarado** un `ReserveAction` en el nodo `AutoRental` (host semánticamente correcto para `potentialAction`):
  - `target` → `EntryPoint` con `urlTemplate: franchise.website` (**resoluble hoy**) + `actionPlatform` desktop/mobile (IRIs canónicos `https://schema.org/...`).
  - `result` → `RentalCarReservation`.
- **Diferido** el `actionApplication` (WebAPI programática) a D2 (`amaw-sas/rentacar-dashboard#73`, hoy OPEN) → follow-up #116.

Incluye holdout `packages/logic/tests/seo-reserve-action.test.ts` (ejecuta el composable con los auto-imports stubbeados y asercia sobre el grafo producido) y design + scenarios bajo `docs/specs/`.

## Criterios de aceptación (#64)

- [x] `SearchAction` falso eliminado.
- [x] `ReserveAction` presente y válido en el JSON-LD de las 3 marcas.

## Verificación

| Claim | Comando | Resultado |
|---|---|---|
| Holdout | `pnpm --filter @rentacar-main/logic test -- seo-reserve-action` | 3/3 passed |
| Red-green | revertir source → correr | 3 failed → restaurar → 3 passed |
| No-regresión | `pnpm --filter @rentacar-main/logic test` | 323/323 |
| Tipos | `pnpm --filter ui-alquilatucarro typecheck` | 0 errores en useBaseSEO.ts |
| Runtime | curl home 3 marcas + parse JSON-LD | HTTP 200; sin `SearchAction`; `ReserveAction` resoluble por marca (alquilatucarro.com / alquilame.co / alquicarros.com); `actionPlatform` https canónico |

**Quality gate** (code-reviewer / security / edge-case / performance): sin blockers. Hallazgo Important del code-reviewer (`actionPlatform` `http://`→`https://`) corregido + guardado con aserción en el holdout.

## Blast radius

1 archivo de producción en el layer (3 marcas). Sin consumidores de código (solo output JSON-LD/SEO). Sin cambios de API, datos, auth ni rendimiento (+~300 bytes/página, <0.5%).

## Notas

- Enriquecer el `ReserveAction` con `actionApplication` (WebAPI) queda en **#116**, bloqueado hasta que cierre D2.

Closes #64
