### PR TITLE
fix(logic): identification format validation + sentinel blocklist (#44)

### DIFF
--- a/docs/specs/issue-44-identification-validation/scenarios/identification-validation.scenarios.md
+++ b/docs/specs/issue-44-identification-validation/scenarios/identification-validation.scenarios.md
@@ -1,0 +1,86 @@
+---
+name: identification-validation
+created_by: pablo
+created_at: 2026-06-09T00:00:00Z
+issue: 44
+---
+
+# Issue #44 — Identification field rejects sentinel values and enforces format by type
+
+The reservation form accepted trivial sentinels (`123456`, `000000`, …) and
+arbitrary strings as `identificacion`. Combined with a backend `findOrCreateCustomer`
+bug (mutates the customer record on CC collision), one user typing `123456` could
+hijack any active customer sharing that CC. This is the **frontend defense-in-depth**:
+strengthen `identificacion` based on the sibling `tipoIdentificacion`.
+
+The UI offers only two document types — **Cédula de Ciudadanía** (`"Cedula Ciudadania"`)
+and **Pasaporte** (`"Pasaporte"`). Cédula de Extranjería is no longer offered.
+
+The logic lives in a single pure function `identificationError(tipo, id)` reused by
+the four composed schemas (`UserInformationForm`, `UserInformationWithFlightForm`,
+`ReservationForm`, `ReservationWithFlightForm`). The cross-field rule is wired as a
+forwarded `partialCheck` so the inline error lands on the `identificacion` field.
+
+## SCEN-001: valid CC passes
+**Given**: `tipoIdentificacion = "Cedula Ciudadania"`, `identificacion = "1020304050"`
+(10 digits)
+**When**: the form is validated
+**Then**: validation succeeds, no issue on `identificacion`
+**Evidence**: `identificationError("Cedula Ciudadania", "1020304050") === null`
+
+## SCEN-002: valid passport passes (including real lowercase passports)
+**Given**: `tipoIdentificacion = "Pasaporte"`, `identificacion` ∈ `{"AB123456", "a13676498"}`
+(the incident's real passport was `a13676498`)
+**When**: the form is validated
+**Then**: validation succeeds
+**Evidence**: `identificationError("Pasaporte", "AB123456") === null` and
+`identificationError("Pasaporte", "a13676498") === null`
+
+## SCEN-003: sentinel `123456` for CC is blocked with an inline error
+**Given**: `tipoIdentificacion = "Cedula Ciudadania"`, `identificacion = "123456"`
+**When**: the form is validated
+**Then**: validation fails; the issue path is `["identificacion"]`; submit is blocked
+**Evidence**: `safeParse(...).success === false` and the issue path key is
+`identificacion`
+
+## SCEN-004: every blocklisted sentinel is rejected, for any offered type
+**Given**: each value in the blocklist `{123456, 1234567, 12345678, 123456789,
+1234567890, 000000, 0000000, 00000000, 111111, 999999, 9999999, 99999999,
+999999999, 9999999999}` under both `"Cedula Ciudadania"` and `"Pasaporte"`
+**When**: validated
+**Then**: every one fails
+**Evidence**: `identificationError(type, value) !== null` for all (type, value) pairs
+
+## SCEN-005: CC format rejects non-digits and out-of-range lengths
+**Given**: `tipoIdentificacion = "Cedula Ciudadania"` with
+`identificacion` ∈ `{"12ab567" (letters), "123456" (6 digits, too short),
+"1234567890123" (13 digits, too long)}`
+**When**: validated
+**Then**: each fails with the CC message
+**Evidence**: `identificationError("Cedula Ciudadania", v) === "La cédula debe tener solo números (7 a 12 dígitos)"`
+(except `"123456"`, which is also blocklisted and may fail on the blocklist message)
+
+## SCEN-006: passport format rejects symbols and out-of-range lengths
+**Given**: `tipoIdentificacion = "Pasaporte"` with `identificacion` ∈
+`{"AB12" (4 chars, too short), "AB-1234" (symbol), "ABCDEFGHIJ1234567" (17 chars, too long)}`
+**When**: validated
+**Then**: each fails with the passport message
+**Evidence**: `identificationError("Pasaporte", v) === "El pasaporte debe tener entre 6 y 15 caracteres (letras y números)"`
+
+## SCEN-007: same behavior across all three franchise apps
+**Given**: the three brand `ReservationForm.vue` components bind `:schema` to
+`ReservationFormValidationSchema` / `ReservationWithFlightFormValidationSchema`
+imported from `@rentacar-main/logic`
+**When**: the shared schema is hardened
+**Then**: alquilame, alquilatucarro and alquicarros all enforce the rules with no
+per-brand code change
+**Evidence**: `grep` shows all three import the same schemas; no brand overrides
+`identificacion` validation
+
+## SCEN-008: leading/trailing whitespace is tolerated, not a bypass
+**Given**: `tipoIdentificacion = "Cedula Ciudadania"`, `identificacion = "  1020304050  "`
+**When**: validated
+**Then**: passes (trimmed before format check); but `"  123456  "` still fails
+(trimmed value is blocklisted)
+**Evidence**: `identificationError("Cedula Ciudadania", "  1020304050  ") === null`
+and `identificationError("Cedula Ciudadania", "  123456  ") !== null`

--- a/packages/logic/src/utils/validation/__tests__/userInformationForm.test.ts
+++ b/packages/logic/src/utils/validation/__tests__/userInformationForm.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest'
+import * as v from 'valibot'
+import {
+  identificationError,
+  UserInformationFormValidationSchema,
+} from '../userInformationForm'
+import { ReservationFormValidationSchema } from '../reservationForm'
+import { ReservationWithFlightFormValidationSchema } from '../reservationWithFlightForm'
+
+// Scenarios: docs/specs/issue-44-identification-validation/scenarios/identification-validation.scenarios.md
+//
+// The reservation form accepted trivial sentinels (123456, 000000, …) and arbitrary
+// strings as `identificacion`, which — combined with a backend findOrCreateCustomer
+// bug — let one user hijack any customer sharing that CC. These tests pin the
+// frontend hardening: CC = digits 7–12, PP = alphanumeric 6–15, sentinel blocklist
+// for every type, error forwarded onto the `identificacion` field.
+
+const CC = 'Cedula Ciudadania'
+const PP = 'Pasaporte'
+
+const CC_MSG = 'La cédula debe tener solo números (7 a 12 dígitos)'
+const PP_MSG = 'El pasaporte debe tener entre 6 y 15 caracteres (letras y números)'
+const SENTINEL_MSG = 'Escribe tu identificación real, no un valor de prueba'
+
+const BLOCKLIST = [
+  '123456', '1234567', '12345678', '123456789', '1234567890',
+  '000000', '0000000', '00000000',
+  '111111',
+  '999999', '9999999', '99999999', '999999999', '9999999999',
+]
+
+// Valid base for full-schema parsing — only identificacion/tipoIdentificacion vary.
+const validBase = {
+  nombreCompleto: 'Juan',
+  apellidos: 'Pérez',
+  telefono: '+573001234567',
+  email: 'juan@example.com',
+  politicaPrivacidad: true,
+}
+
+const parse = (tipoIdentificacion: string, identificacion: string) =>
+  v.safeParse(UserInformationFormValidationSchema, {
+    ...validBase,
+    tipoIdentificacion,
+    identificacion,
+  })
+
+describe('identificationError — pure cross-field rule', () => {
+  // SCEN-001
+  it('accepts a valid CC (digits 7–12)', () => {
+    expect(identificationError(CC, '1020304050')).toBeNull()
+    expect(identificationError(CC, '1023456')).toBeNull() // min 7 (not blocklisted)
+    expect(identificationError(CC, '123456789012')).toBeNull() // max 12
+  })
+
+  // SCEN-002 — real incident passport was lowercase `a13676498`
+  it('accepts a valid passport, including real lowercase ones', () => {
+    expect(identificationError(PP, 'AB123456')).toBeNull()
+    expect(identificationError(PP, 'a13676498')).toBeNull()
+    expect(identificationError(PP, 'ABC123')).toBeNull() // min 6
+    expect(identificationError(PP, 'ABCDEFGHIJ12345')).toBeNull() // max 15
+  })
+
+  // SCEN-004 — blocklist applies to every offered type
+  it('rejects every blocklisted sentinel under both CC and PP', () => {
+    for (const value of BLOCKLIST) {
+      expect(identificationError(CC, value), `CC ${value}`).not.toBeNull()
+      expect(identificationError(PP, value), `PP ${value}`).not.toBeNull()
+    }
+  })
+
+  it('lets the sentinel message win over format for a blocklisted but well-formed length', () => {
+    // 1234567 is 7 digits (valid CC length) but blocklisted → sentinel message, not null.
+    expect(identificationError(CC, '1234567')).toBe(SENTINEL_MSG)
+  })
+
+  // SCEN-005
+  it('rejects CC with non-digits or out-of-range length', () => {
+    expect(identificationError(CC, '12ab567')).toBe(CC_MSG) // letters
+    expect(identificationError(CC, '123456')).not.toBeNull() // 6 digits (too short + blocklisted)
+    expect(identificationError(CC, '1234567890123')).toBe(CC_MSG) // 13 digits
+    expect(identificationError(CC, '102030')).toBe(CC_MSG) // 6 digits, not blocklisted
+  })
+
+  // SCEN-006
+  it('rejects passport with symbols or out-of-range length', () => {
+    expect(identificationError(PP, 'AB12')).toBe(PP_MSG) // too short
+    expect(identificationError(PP, 'AB-1234')).toBe(PP_MSG) // symbol
+    expect(identificationError(PP, 'ABCDEFGHIJ1234567')).toBe(PP_MSG) // 17 chars
+  })
+
+  // SCEN-008
+  it('tolerates surrounding whitespace but is not bypassed by it', () => {
+    expect(identificationError(CC, '  1020304050  ')).toBeNull()
+    expect(identificationError(CC, '  123456  ')).toBe(SENTINEL_MSG)
+  })
+
+  it('returns null for empty input (presence enforced at field level)', () => {
+    expect(identificationError(CC, '')).toBeNull()
+    expect(identificationError(CC, null)).toBeNull()
+    expect(identificationError(CC, undefined)).toBeNull()
+  })
+})
+
+describe('UserInformationFormValidationSchema — full form integration', () => {
+  // SCEN-001
+  it('passes a valid CC submission', () => {
+    expect(parse(CC, '1020304050').success).toBe(true)
+  })
+
+  // SCEN-002
+  it('passes a valid passport submission', () => {
+    expect(parse(PP, 'AB123456').success).toBe(true)
+    expect(parse(PP, 'a13676498').success).toBe(true)
+  })
+
+  // SCEN-003 — sentinel blocked and the issue lands on the identificacion field
+  it('blocks sentinel 123456 with the error forwarded to identificacion', () => {
+    const result = parse(CC, '123456')
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const idIssue = result.issues.find(
+        (i) => i.path?.some((p) => (p as { key?: unknown }).key === 'identificacion')
+      )
+      expect(idIssue, 'an issue must target the identificacion path').toBeDefined()
+    }
+  })
+
+  // SCEN-004
+  it('blocks every blocklisted sentinel at the schema level', () => {
+    for (const value of BLOCKLIST) {
+      expect(parse(CC, value).success, `CC ${value}`).toBe(false)
+      expect(parse(PP, value).success, `PP ${value}`).toBe(false)
+    }
+  })
+
+  it('blocks malformed CC and passport at the schema level', () => {
+    expect(parse(CC, '12ab567').success).toBe(false)
+    expect(parse(PP, 'AB-1234').success).toBe(false)
+  })
+})
+
+// SCEN-007 — the reservation schemas the brand forms actually bind to inherit the
+// same hardening, with no per-brand code.
+describe('Reservation schemas inherit identification hardening', () => {
+  const reservationBase = { ...validBase, vehiculo: 'C' }
+  const flightBase = { ...reservationBase, aerolinea: 'AVA', numeroVueloIda: '123' }
+
+  it('ReservationFormValidationSchema passes a valid CC and blocks a sentinel', () => {
+    expect(
+      v.safeParse(ReservationFormValidationSchema, {
+        ...reservationBase, tipoIdentificacion: CC, identificacion: '1020304050',
+      }).success
+    ).toBe(true)
+    expect(
+      v.safeParse(ReservationFormValidationSchema, {
+        ...reservationBase, tipoIdentificacion: CC, identificacion: '123456',
+      }).success
+    ).toBe(false)
+  })
+
+  it('ReservationWithFlightFormValidationSchema passes a valid passport and blocks a sentinel', () => {
+    expect(
+      v.safeParse(ReservationWithFlightFormValidationSchema, {
+        ...flightBase, tipoIdentificacion: PP, identificacion: 'a13676498',
+      }).success
+    ).toBe(true)
+    expect(
+      v.safeParse(ReservationWithFlightFormValidationSchema, {
+        ...flightBase, tipoIdentificacion: PP, identificacion: '000000',
+      }).success
+    ).toBe(false)
+  })
+})

--- a/packages/logic/src/utils/validation/reservationForm.ts
+++ b/packages/logic/src/utils/validation/reservationForm.ts
@@ -3,11 +3,28 @@ import '@valibot/i18n/es';
 v.setGlobalConfig({ lang: 'es' });
 
 import { CategoryFormValidationSchema } from './categoryForm';
-import { UserInformationFormValidationSchema } from './userInformationForm';
+import { userInformationEntries, identificationError } from './userInformationForm';
 
-export const ReservationFormValidationSchema = v.object({
+// Exported so the with-flight schema composes on the raw entries: `.entries` would
+// drop the object-level identification check, so each leaf re-applies it.
+export const reservationEntries = {
     ...CategoryFormValidationSchema.entries,
-    ...UserInformationFormValidationSchema.entries
-})
+    ...userInformationEntries,
+};
+
+export const ReservationFormValidationSchema = v.pipe(
+    v.object(reservationEntries),
+    // Cross-field identification check forwarded onto the `identificacion` field.
+    v.forward(
+        v.partialCheck(
+            [["tipoIdentificacion"], ["identificacion"]],
+            (input) => identificationError(input.tipoIdentificacion, input.identificacion) === null,
+            (issue) =>
+                identificationError(issue.input.tipoIdentificacion, issue.input.identificacion) ??
+                "Identificación no válida"
+        ),
+        ["identificacion"]
+    )
+);
 
 export type ReservationFormValidationSchemaType = v.InferOutput<typeof ReservationFormValidationSchema>

--- a/packages/logic/src/utils/validation/reservationWithFlightForm.ts
+++ b/packages/logic/src/utils/validation/reservationWithFlightForm.ts
@@ -2,12 +2,26 @@ import * as v from 'valibot';
 import '@valibot/i18n/es';
 v.setGlobalConfig({ lang: 'es' });
 
-import { ReservationFormValidationSchema } from './reservationForm';
+import { reservationEntries } from './reservationForm';
+import { identificationError } from './userInformationForm';
 import { FlightFormValidationSchema } from './flightForm';
 
-export const ReservationWithFlightFormValidationSchema = v.object({
-    ...ReservationFormValidationSchema.entries,
-    ...FlightFormValidationSchema.entries,
-});
+export const ReservationWithFlightFormValidationSchema = v.pipe(
+    v.object({
+        ...reservationEntries,
+        ...FlightFormValidationSchema.entries,
+    }),
+    // Cross-field identification check forwarded onto the `identificacion` field.
+    v.forward(
+        v.partialCheck(
+            [["tipoIdentificacion"], ["identificacion"]],
+            (input) => identificationError(input.tipoIdentificacion, input.identificacion) === null,
+            (issue) =>
+                identificationError(issue.input.tipoIdentificacion, issue.input.identificacion) ??
+                "Identificación no válida"
+        ),
+        ["identificacion"]
+    )
+);
 
 export type ReservationWithFlightFormValidationSchemaType = v.InferOutput<typeof ReservationWithFlightFormValidationSchema>

--- a/packages/logic/src/utils/validation/userInformationForm.ts
+++ b/packages/logic/src/utils/validation/userInformationForm.ts
@@ -4,13 +4,58 @@ import * as v from "valibot";
 import "@valibot/i18n/es";
 v.setGlobalConfig({ lang: "es" });
 
-export const UserInformationFormValidationSchema = v.object({
+// Identification formats by document type. The UI offers only these two:
+// CC (Cédula de Ciudadanía): digits only, 7–12.
+// PP (Pasaporte): alphanumeric, 6–15 — real passports include lowercase letters.
+const CC_FORMAT = /^\d{7,12}$/;
+const PP_FORMAT = /^[A-Za-z0-9]{6,15}$/;
+
+// Trivial sentinels that hijack customer records on CC collision (issue #44).
+// Rejected for every document type.
+const SENTINEL_BLOCKLIST = new Set([
+  "123456", "1234567", "12345678", "123456789", "1234567890",
+  "000000", "0000000", "00000000",
+  "111111",
+  "999999", "9999999", "99999999", "999999999", "9999999999",
+]);
+
+/**
+ * Pure cross-field rule for `identificacion`, keyed on `tipoIdentificacion`.
+ * Returns a Spanish error message, or `null` when the value is acceptable.
+ * Empty input returns `null` — presence is enforced by the field-level pipe.
+ * Surrounding whitespace is tolerated (trimmed before checks).
+ */
+export function identificationError(
+  tipoIdentificacion: unknown,
+  identificacion: unknown
+): string | null {
+  const id = String(identificacion ?? "").trim();
+  if (id === "") return null;
+  if (SENTINEL_BLOCKLIST.has(id)) {
+    return "Escribe tu identificación real, no un valor de prueba";
+  }
+  if (tipoIdentificacion === "Cedula Ciudadania") {
+    return CC_FORMAT.test(id) ? null : "La cédula debe tener solo números (7 a 12 dígitos)";
+  }
+  if (tipoIdentificacion === "Pasaporte") {
+    return PP_FORMAT.test(id) ? null : "El pasaporte debe tener entre 6 y 15 caracteres (letras y números)";
+  }
+  // Unknown/unselected type: blocklist already applied, no format enforced.
+  return null;
+}
+
+// Shared field entries. Exported so composed schemas spread them WITHOUT the
+// object-level identification check (which `.entries` would drop) and re-apply it
+// themselves. The check itself is inlined per schema — valibot only infers the
+// cross-field input type when `v.forward(v.partialCheck(...))` is written directly
+// inside the `v.pipe`, so it can't be shared; the LOGIC stays in `identificationError`.
+export const userInformationEntries = {
   nombreCompleto: v.pipe(v.string("Escribe tus nombres"), v.minLength(1)),
   apellidos: v.pipe(v.string("Escribe tus apellidos"), v.minLength(1)),
   tipoIdentificacion: v.string("Selecciona una identificación"),
   identificacion: v.pipe(
     v.string("Escribe tu identificación"),
-    v.minLength(5, "La identificación debe tener más de 5 caracteres")
+    v.minLength(1, "Escribe tu identificación")
   ),
   telefono: v.pipe(
     v.string("Escribe tu número de teléfono o WhatsApp"),
@@ -22,7 +67,22 @@ export const UserInformationFormValidationSchema = v.object({
     v.boolean("Debe aceptar las políticas de privacidad"),
     v.value(true, "Debe aceptar las políticas de privacidad")
   ),
-});
+};
+
+export const UserInformationFormValidationSchema = v.pipe(
+  v.object(userInformationEntries),
+  // Cross-field identification check forwarded onto the `identificacion` field.
+  v.forward(
+    v.partialCheck(
+      [["tipoIdentificacion"], ["identificacion"]],
+      (input) => identificationError(input.tipoIdentificacion, input.identificacion) === null,
+      (issue) =>
+        identificationError(issue.input.tipoIdentificacion, issue.input.identificacion) ??
+        "Identificación no válida"
+    ),
+    ["identificacion"]
+  )
+);
 
 export type UserInformationFormValidationSchemaType = v.InferOutput<
   typeof UserInformationFormValidationSchema

--- a/packages/logic/src/utils/validation/userInformationWithFlightForm.ts
+++ b/packages/logic/src/utils/validation/userInformationWithFlightForm.ts
@@ -2,10 +2,23 @@ import * as v from 'valibot';
 import '@valibot/i18n/es';
 v.setGlobalConfig({ lang: 'es' });
 
-import { UserInformationFormValidationSchema } from './userInformationForm';
+import { userInformationEntries, identificationError } from './userInformationForm';
 import { FlightFormValidationSchema } from './flightForm';
 
-export const UserInformationWithFlightFormValidationSchema = v.object({
-    ...UserInformationFormValidationSchema.entries,
-    ...FlightFormValidationSchema.entries,
-});
+export const UserInformationWithFlightFormValidationSchema = v.pipe(
+    v.object({
+        ...userInformationEntries,
+        ...FlightFormValidationSchema.entries,
+    }),
+    // Cross-field identification check forwarded onto the `identificacion` field.
+    v.forward(
+        v.partialCheck(
+            [["tipoIdentificacion"], ["identificacion"]],
+            (input) => identificationError(input.tipoIdentificacion, input.identificacion) === null,
+            (issue) =>
+                identificationError(issue.input.tipoIdentificacion, issue.input.identificacion) ??
+                "Identificación no válida"
+        ),
+        ["identificacion"]
+    )
+);


### PR DESCRIPTION
## Qué

Endurece la validación de `identificacion` en el formulario de reserva, compartido por las tres marcas vía `@rentacar-main/logic`. Defensa-en-profundidad frontend para el incidente del 2026-05-12.

## Por qué

El campo aceptaba centinelas triviales (`123456`, `000000`, …) y strings arbitrarios. Combinado con el bug `findOrCreateCustomer` del dashboard (muta el registro del cliente ante colisión de CC — `amaw-sas/rentacar-dashboard#25/#26`), un usuario escribiendo `123456` podía secuestrar el registro de cualquier cliente con esa cédula y corromper data histórica. Incidente real: JOSE CHIACHIO (alquilame.co) entró `123456` y cayó en un registro de prueba en producción.

## Reglas

Función pura `identificationError(tipoIdentificacion, identificacion)`:
- **CC** (`Cedula Ciudadania`): solo dígitos, longitud 7–12.
- **PP** (`Pasaporte`): alfanumérico, longitud 6–15 (acepta minúsculas — el pasaporte real era `a13676498`).
- **Blocklist** de 14 centinelas, rechazada para cualquier tipo.
- Tolera espacios al inicio/fin (trim previo); no se usan como bypass.
- Cédula de Extranjería **eliminada** (ya no se ofrece en la UI).

Cableada como `v.forward(v.partialCheck(...))` para que el error inline aparezca bajo el campo `identificacion`.

## Cómo (nota arquitectónica)

`.entries` (usado para componer schemas) descarta checks a nivel de objeto, y la acción `forward` no se puede compartir (su `TInput` se fija y rompe `v.pipe`). Por eso se exportan las `entries` crudas (`userInformationEntries`, `reservationEntries`) y el `forward` se inlinea en cada uno de los 4 schemas compuestos. La lógica vive centralizada en `identificationError`. Las 3 marcas heredan la conducta sin código por marca.

## Blast radius

- `packages/logic/src/utils/validation/{userInformationForm,reservationForm,reservationWithFlightForm,userInformationWithFlightForm}.ts`
- Tests: `__tests__/userInformationForm.test.ts` (nuevo, 15 casos)
- Holdout: `docs/specs/issue-44-identification-validation/scenarios/`
- Los 3 `ReservationForm.vue` **sin cambios** — bindean el schema y la conducta propaga sola.

## Verificación

- **Logic suite: 338/338 pass** (15 tests nuevos): cada regla + cada centinela de la blocklist, a nivel función pura y a nivel schema completo (incl. `ReservationForm` / `ReservationWithFlight`).
- **Typecheck `ui-alquilame`: delta 0** vs baseline (174≡174). Los archivos de validación compilan limpios; los errores restantes son baseline preexistente (cluster C/D).

## Acceptance (issue)

- [x] `123456` para CC muestra error inline y bloquea el submit.
- [x] CC válida `1020304050` pasa.
- [x] Pasaporte válido `AB123456` pasa.
- [x] Misma conducta en las tres marcas.
- [x] Tests unitarios por regla + por valor de la blocklist.

Closes #44