### PR TITLE
feat(seo): precio real por categoría en JSON-LD de ciudad sin JS (#68)

### DIFF
--- a/docs/specs/2026-06-10-issue-68-ssr-representative-prices/design.md
+++ b/docs/specs/2026-06-10-issue-68-ssr-representative-prices/design.md
@@ -1,0 +1,186 @@
+# Issue #68 — Representative per-category price in city-page JSON-LD without JS
+
+> Épico: #63 · Origen: auditoría agéntica 2026-05-26 · Label: enhancement, auditoria-agentica
+
+## Problem
+
+A crawler that does not execute JS reading a city landing page should see a real,
+representative "from" price per vehicle category in the structured data. Today it does
+see per-category `AggregateOffer` nodes — but the numbers are fabricated.
+
+`packages/logic/src/composables/useCityProductSchema.ts` builds those offers from two
+hardcoded sources, neither tied to real pricing:
+
+- A 19-city price matrix typed by hand (`cityPricing`, lines 10–30). The comment even
+  says the numbers were copied "from useCityFAQs.ts" — i.e. from FAQ marketing copy, not
+  from pricing data.
+- Per-category multipliers (`priceMultiplier` 1.0 / 1.3 / 1.8 / 2.5, lines 33–58).
+
+Final price = `cityPricing[city] × priceMultiplier` (lines 69–73). Example: a SUV in
+Bogotá publishes `110000 × 1.8 = 198.000 COP` — a number invented in source that Google
+indexes as a real price. Publishing fabricated prices in structured data is a
+credibility and rich-result-penalty risk, and it never matches the checkout.
+
+Two adjacent fabrications live in the same file:
+
+- `name: 'Alquilatucarro'` hardcoded in `brand` and `seller` (lines 84, 96) — emitted
+  even on alquilame and alquicarros. Same multi-brand leak class as issue #108.
+- `offerCount: 4` and `priceValidUntil: '2026-12-31'` hardcoded (lines 92, 94).
+
+## Goal
+
+Replace the fabricated per-category price with a real one derived at SSR from the
+`category_pricing` data already present in the `rentacar-data` payload, so a JS-less
+crawler reads an accurate "from" price per featured category. Acceptance criterion
+(from the issue): the HTML/JSON-LD of a city page exposes a representative price per
+category without executing JS.
+
+## Key constraint discovered (pricing reality)
+
+There are two distinct daily prices in the system, and only one is reachable without JS:
+
+| Price | Source | Available at SSR |
+| --- | --- | --- |
+| Short-term daily (`vehicleDayCharge + coverageUnitCharge`) | Localiza, via POST `/api/reservations/availability` | No — JS only |
+| Monthly-plan daily (`one_day_price` in `category_pricing`) | Supabase, via `rentacar-data` | **Yes** |
+
+`one_day_price` is the per-day-equivalent base rate of the monthly plan — the same field
+`useCategory.ts:159` already uses as the displayed daily base price. It is lower than the
+short-term daily rate (volume discount), which makes it the honest, attractive basis for
+a "desde $X/día" representation. It is sourced from the same `category_pricing` table that
+feeds `pickPriceForDate` in the booking flow, so the published number is structurally
+consistent with the checkout.
+
+Consequence accepted by design: the SSR "from" price is the monthly-plan daily rate, not a
+3-day short rental. A category with no monthly plan (`one_day_price = 0`, per issue #28's
+`monthly_*_price = NULL` modeling) has no static daily price at all — those categories are
+omitted rather than priced at a fabricated or zero value.
+
+### Why not `pickPriceForDate` (the obvious reuse)
+
+`pickPriceForDate(month_prices, date)` is the booking flow's date-aware selector, but it is
+the wrong tool for a date-less landing page. A city page has no pickup date, so any
+representative date we pass is arbitrary. Worse, `pickPriceForDate`'s Rule-3 `seasonLow`
+fallback (`useTariffs`-adjacent, sorts active rows by `1k_kms`) can return a row whose
+`one_day_price` is `0` or otherwise non-representative when the chosen date falls outside
+every configured range — exactly the boundary a "today" date hits against seasonal ranges.
+It also introduces a server/client `Date` that risks a hydration mismatch in the JSON-LD.
+
+Instead the representative "from" price is selected date-free: the **minimum positive
+`one_day_price` among `active` rows**. This matches "desde $X/día" semantics precisely, is
+deterministic (no `Date`, so SSR and client renders are byte-identical), and structurally
+cannot emit a `0` price.
+
+## Approach (chosen: A)
+
+Two files changed in the logic layer (propagates to all three brands):
+
+1. **New pure util** `packages/logic/src/utils/pickRepresentativeDailyPrice.ts`:
+   `pickRepresentativeDailyPrice(prices: CategoryMonthPriceData[]): CategoryMonthPriceData | undefined`
+   — returns the `active` row with the smallest `one_day_price > 0` (tie-break by most
+   recent `init_date`, mirroring `pickPriceForDate`'s convention); `undefined` if no active
+   row has a positive `one_day_price`. Exported from `utils` and unit-tested. This is a
+   trivial "cheapest active daily rate" selector — it does **not** touch the temporal
+   season rules in `pickPriceForDate`, so it stays clear of that money landmine.
+2. **`useCityProductSchema.ts` rewrite of the price path:**
+   - **Data.** Add `categories` (`CategoryData[]`) and `organization` to the existing
+     `useFetchRentacarData()` / `useAppConfig()` destructuring (already pull
+     `vehicleCategories` / `franchise`).
+   - **Price selection.** For each representative category code (C / FX / GC / LE), find its
+     `CategoryData` by `id`, then `pickRepresentativeDailyPrice(month_prices)` → the row;
+     `price = row.one_day_price`.
+   - **Fail-soft.** If a category is absent from `categories` or the selector returns
+     `undefined`, omit that `Product` node entirely — never a zero or fabricated price.
+     Same sentinel-safe posture as the existing test.
+   - **Schema shape.** `Product` → `offers: Offer` with `price = one_day_price`,
+     `priceCurrency: 'COP'`, `priceSpecification: UnitPriceSpecification { unitCode: 'DAY' }`
+     so the daily nature is explicit (the number is not read as a total),
+     `availability: InStock`, `priceValidUntil` = the selected row's real `end_date` when
+     non-empty, otherwise the field is **omitted** (no fabricated validity date — this is
+     what removes the last hardcoded `'2026-12-31'`), and `seller` / `brand` name =
+     **`organization.brand`** (the human brand label, e.g. `Alquilame` — NOT
+     `franchise.name`, which holds the bare domain `alquilame.co`).
+   - **Delete.** The `cityPricing` matrix (lines 10–30) and `priceMultiplier` (lines 33–58).
+     Keep the curated Spanish category names and descriptions.
+
+### Why not the alternatives
+
+- **B — keep `AggregateOffer` low/high.** The issue asks for a concrete representative
+  price, "not just the aggregate range". A single `Offer.price` answers that directly and
+  avoids reintroducing a semi-arbitrary `highPrice`.
+- **C — iterate the full real catalog.** Maximizes coverage but surfaces Localiza's
+  Portuguese category descriptions (issue #74, unresolved) and loses editorial control.
+  Out of scope for #68, which is about price truthfulness, not catalog coverage.
+
+## Blast radius
+
+- 2 files in `logic/` (1 composable rewrite + 1 new pure util) → city pages of all three
+  brands (alquilatucarro, alquilame, alquicarros).
+- Consumers: `CityPage.vue:435–437` (the call site), `useSchemaOrg` (JSON-LD output). The
+  new util is consumed only by `useCityProductSchema`.
+- Does **not** touch `/api/rentacar-data` → respects the `getKey=buildId` cache contract
+  (#62) and introduces no cache-schema-drift risk.
+- Does **not** touch `pickPriceForDate` or the booking-flow pricing path.
+- Tests: new `pickRepresentativeDailyPrice` unit test; `useCityProductSchema.sentinelSafety.test.ts`
+  must stay green and is extended for the new behavior.
+- Export surface: `pickRepresentativeDailyPrice` added to the `utils` barrel.
+
+## Out of scope (YAGNI)
+
+Full catalog coverage; PT→ES translation (#74); cache TTL tuning; per-city SSR availability
+(D2 / #116).
+
+## Observable scenarios
+
+Concrete inputs/expected values are pinned here so the holdout encodes them exactly.
+
+- **SCEN-001 — real price replaces fabrication.** Given `categories` contains category `C`
+  whose only active `category_pricing` row has `one_day_price = 90000`, when a city page
+  renders its product schema at SSR, then the `C` `Product`'s `offers.price` is exactly
+  `90000`, and no value derived from the deleted `cityPricing × priceMultiplier` formula
+  (e.g. `198000` for a Bogotá SUV) appears anywhere in the output.
+- **SCEN-002 — "desde" picks the cheapest active positive rate.** Given category `C` has
+  active rows with `one_day_price` of `120000`, `90000`, and an inactive row of `70000`,
+  when the offer is built, then `offers.price` is `90000` (the minimum positive **active**
+  rate) — the inactive `70000` is ignored.
+- **SCEN-003 — daily unit is explicit.** Given any emitted category offer, when the JSON-LD
+  is read, then the offer carries a `priceSpecification` of type `UnitPriceSpecification`
+  with `unitCode: 'DAY'` and `priceCurrency: 'COP'`, so the number cannot be misread as a
+  rental total.
+- **SCEN-004 — multi-brand seller/brand.** Given the alquilame app config
+  (`organization.brand = 'Alquilame'`), when a city page renders product schema, then every
+  emitted `seller.name` and `brand.name` equals the exact string `'Alquilame'` — never the
+  hardcoded `'Alquilatucarro'` and never the domain `'alquilame.co'`.
+- **SCEN-005 — fail-soft on missing/zero price.** Given a representative category that is
+  absent from `categories`, or whose active rows all have `one_day_price = 0`, when the
+  schema renders, then `pickRepresentativeDailyPrice` returns `undefined`, that category
+  emits no `Product`, and rendering does not throw (sentinel payload handled safely).
+- **SCEN-006 — mixed positive+zero active set never emits $0.** Given category `C` has two
+  active rows, one with `one_day_price = 0` (monthly disabled) and one with
+  `one_day_price = 110000`, when the offer is built, then `offers.price` is `110000` — the
+  `0` row is excluded, and no `Product` with `price: 0` is emitted.
+- **SCEN-007 — deterministic across renders.** Given the selection is date-free (no `Date`
+  call), when the same payload renders on server and on client hydration, then the selected
+  price is byte-identical between the two — no hydration mismatch.
+
+These scenarios are the holdout set carried into scenario-driven-development; they define
+"done", not the tests. SCEN-001/002/004/006 assert exact values; SCEN-005/007 assert
+structural invariants.
+
+### Testing strategy (avoids the source-regex trap)
+
+The existing `useCityProductSchema.sentinelSafety.test.ts` asserts against the source
+*string* (regex), which can confirm a selector is referenced but **cannot** prove a numeric
+output (`offers.price === 90000`) — a `1k_kms`-vs-`one_day_price` field bug would ship
+green under it. So:
+
+- **Exact-value oracle lives in the `pickRepresentativeDailyPrice` unit test** (pure
+  function, trivially runtime-asserted): SCEN-002 and SCEN-006 inputs/outputs are pinned
+  there as real value assertions (`90000`, `110000`, ignores inactive/zero rows, `undefined`
+  when none).
+- **`useCityProductSchema` numeric/brand scenarios (SCEN-001/004) are runtime-asserted on
+  the emitted schema object** — mock `useAppConfig` / `useFetchRentacarData` / `useSchemaOrg`,
+  call the composable, and assert the captured `productSchemas` (`offers.price`,
+  `offers.priceSpecification.unitCode`, `seller.name`/`brand.name`). Not a regex.
+- The source-regex sentinel test is kept/extended only for its original purpose: structural
+  optional-chaining safety against a sentinel payload (SCEN-005/007 posture).

--- a/docs/specs/2026-06-10-issue-68-ssr-representative-prices/scenarios/city-representative-price.scenarios.md
+++ b/docs/specs/2026-06-10-issue-68-ssr-representative-prices/scenarios/city-representative-price.scenarios.md
@@ -1,0 +1,55 @@
+---
+name: city-representative-price
+created_by: brainstorming
+created_at: 2026-06-10T12:00:00Z
+---
+
+# Issue #68 — Representative per-category price in city-page JSON-LD (no JS)
+
+Holdout for replacing the fabricated `cityPricing × priceMultiplier` matrix in
+`useCityProductSchema` with the real `one_day_price` from `category_pricing`, selected
+date-free as the cheapest positive active rate. SCEN-001/002/006 carry exact-value oracles
+in the `pickRepresentativeDailyPrice` unit test; SCEN-003/004/005 are runtime-asserted on
+the emitted schema object; SCEN-007 is a determinism invariant.
+
+## SCEN-001: real price replaces the fabricated value
+**Given**: `categories` contains category `C` whose only `active` `category_pricing` row has `one_day_price = 90000`
+**When**: `pickRepresentativeDailyPrice(month_prices)` selects the row and the city product schema is built
+**Then**: the `C` `Product`'s `offers.price` is exactly `90000`, and no value derivable from the deleted `cityPricing × priceMultiplier` formula (e.g. `198000` for a Bogotá SUV) appears in the output
+**Evidence**: `pickRepresentativeDailyPrice` unit test returns the row with `one_day_price === 90000`; composable runtime test captures `productSchemas[i].offers.price === 90000`
+
+## SCEN-002: "desde" picks the cheapest active positive rate, ignoring inactive
+**Given**: category `C` has `active` rows with `one_day_price` of `120000` and `90000`, plus an `inactive` row with `one_day_price = 70000`
+**When**: `pickRepresentativeDailyPrice(month_prices)` runs
+**Then**: it returns the row with `one_day_price === 90000` — the minimum among **active** rows; the cheaper inactive `70000` is ignored
+**Evidence**: unit test asserts the returned row's `one_day_price === 90000`
+
+## SCEN-003: the daily unit is explicit in the offer
+**Given**: any category that yields a representative price
+**When**: its `Offer` is emitted into the JSON-LD
+**Then**: the offer carries `priceCurrency: 'COP'` and a `priceSpecification` of `@type` `UnitPriceSpecification` with `unitCode: 'DAY'`, so the number cannot be misread as a rental total
+**Evidence**: composable runtime test asserts `offers.priceSpecification['@type'] === 'UnitPriceSpecification'` and `offers.priceSpecification.unitCode === 'DAY'` and `offers.priceCurrency === 'COP'`
+
+## SCEN-004: seller/brand use the human brand label per brand
+**Given**: an app config where `organization.brand === 'Alquilame'`
+**When**: a city page renders its product schema
+**Then**: every emitted `seller.name` and `brand.name` equals the exact string `'Alquilame'` — never the previously-hardcoded `'Alquilatucarro'`, and never the domain `'alquilame.co'` (which is `franchise.name`)
+**Evidence**: composable runtime test with mocked `useAppConfig` (`organization.brand = 'Alquilame'`) asserts each emitted `seller.name === 'Alquilame'` and `brand.name === 'Alquilame'`
+
+## SCEN-005: fail-soft when a category has no real price
+**Given**: a representative category that is absent from `categories`, OR whose `active` rows all have `one_day_price = 0` (no monthly plan)
+**When**: the schema renders
+**Then**: `pickRepresentativeDailyPrice` returns `undefined`, that category emits no `Product`, the rendered `productSchemas` array simply omits it, and rendering does not throw on a sentinel/empty payload
+**Evidence**: unit test asserts `undefined` for an all-zero/empty/inactive-only input; composable runtime test with a payload missing `C` asserts no schema has `@id` ending `#vehicle-C` and the call does not throw
+
+## SCEN-006: a mixed positive+zero active set never emits $0
+**Given**: category `C` has two `active` rows, one with `one_day_price = 0` and one with `one_day_price = 110000`
+**When**: `pickRepresentativeDailyPrice(month_prices)` runs and the offer is built
+**Then**: it returns the row with `one_day_price === 110000` — the `0` row is excluded — and no `Product` with `offers.price === 0` is emitted
+**Evidence**: unit test asserts returned `one_day_price === 110000`; composable runtime test asserts no emitted `offers.price === 0`
+
+## SCEN-007: selection is deterministic across server and client renders
+**Given**: the representative-price selection makes no `Date`/`now` call (date-free)
+**When**: the same `categories` payload is rendered on the server and again on client hydration
+**Then**: the selected price for each category is identical between the two renders — no hydration mismatch in the JSON-LD
+**Evidence**: source of `pickRepresentativeDailyPrice` and the composable price path contain no `Date`/`Date.now`/`new Date` reference (grep); unit test is a pure function of its input (same input → same output across repeated calls)

--- a/packages/logic/src/composables/__tests__/useCityProductSchema.runtime.test.ts
+++ b/packages/logic/src/composables/__tests__/useCityProductSchema.runtime.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useCityProductSchema } from '../useCityProductSchema'
+import type { CategoryData, CategoryMonthPriceData } from '../../utils'
+
+// Runtime test for issue #68: the city product schema must emit a REAL
+// per-category daily price (from category_pricing via rentacar-data), the
+// correct per-brand label, and an explicit per-day unit — never the deleted
+// fabricated cityPricing matrix. Auto-imported Nuxt globals are stubbed.
+
+const priceRow = (
+  one_day_price: number,
+  status: 'active' | 'inactive' = 'active',
+  init_date = '2026-01-01',
+  end_date = '2026-12-31',
+): CategoryMonthPriceData => ({
+  '1k_kms': 3_000_000,
+  '2k_kms': 3_500_000,
+  '3k_kms': 4_000_000,
+  init_date,
+  end_date,
+  total_insurance_price: 476_000,
+  one_day_price,
+  status,
+})
+
+const category = (id: string, month_prices: CategoryMonthPriceData[]): CategoryData =>
+  ({
+    id,
+    identification: id,
+    name: `cat-${id}`,
+    category: 'Alquiler de Vehículos',
+    description: '',
+    image: '',
+    ad: '',
+    models: [],
+    month_prices,
+    total_coverage_unit_charge: 0,
+    extra_km_charge: 0,
+  }) as unknown as CategoryData
+
+let capturedSchemas: any[] = []
+
+const stub = (categories: CategoryData[], brand = 'Alquilame') => {
+  vi.stubGlobal('useAppConfig', () => ({
+    franchise: { website: 'https://alquilame.co' },
+    organization: { brand },
+  }))
+  vi.stubGlobal('useFetchRentacarData', () => ({
+    vehicleCategories: { C: { modelos: [{ image: '/c.jpg' }] } },
+    categories,
+  }))
+  vi.stubGlobal('useSchemaOrg', (schemas: any[]) => {
+    capturedSchemas = schemas
+  })
+}
+
+beforeEach(() => {
+  capturedSchemas = []
+})
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+const offerOf = (schemas: any[], code: string) =>
+  schemas.find((s) => String(s['@id']).endsWith(`#vehicle-${code}`))?.offers
+
+describe('useCityProductSchema runtime (issue #68)', () => {
+  // SCEN-001: real price replaces the fabricated value
+  it('emits the real one_day_price as offers.price, not a cityPricing×multiplier value', () => {
+    stub([category('C', [priceRow(90_000)])])
+    const { productSchemas } = useCityProductSchema('Bogotá', 'bogota')
+    const offer = offerOf(productSchemas, 'C')
+    expect(offer.price).toBe(90_000)
+    // the deleted Bogotá-SUV fabrication (110000 × 1.8 = 198000) must not appear
+    const serialized = JSON.stringify(productSchemas)
+    expect(serialized).not.toContain('198000')
+    expect(serialized).not.toContain('110000') // old Bogotá lowPrice base
+    // the schema actually reaches the JSON-LD emitter (useSchemaOrg), not just the return value
+    expect(capturedSchemas).toBe(productSchemas)
+  })
+
+  // SCEN-003: the daily unit is explicit
+  it('marks the offer as a per-day unit price in COP', () => {
+    stub([category('C', [priceRow(90_000)])])
+    const { productSchemas } = useCityProductSchema('Cali', 'cali')
+    const offer = offerOf(productSchemas, 'C')
+    expect(offer.priceCurrency).toBe('COP')
+    expect(offer.priceSpecification['@type']).toBe('UnitPriceSpecification')
+    expect(offer.priceSpecification.unitCode).toBe('DAY')
+    expect(offer.priceSpecification.priceCurrency).toBe('COP')
+  })
+
+  // SCEN-004: seller/brand use the human brand label per brand
+  it('uses organization.brand (not the domain, not a hardcoded brand) for seller and brand', () => {
+    stub([category('C', [priceRow(90_000)])], 'Alquilame')
+    const { productSchemas } = useCityProductSchema('Bogotá', 'bogota')
+    for (const schema of productSchemas as any[]) {
+      expect(schema.brand.name).toBe('Alquilame')
+      expect(schema.offers.seller.name).toBe('Alquilame')
+    }
+    const serialized = JSON.stringify(productSchemas)
+    expect(serialized).not.toContain('Alquilatucarro')
+    expect(serialized).not.toContain('"name":"alquilame.co"') // domain must never be a NAME value
+  })
+
+  // SCEN-005: fail-soft — categories without a real price are omitted, no throw
+  it('omits categories that are absent or have no positive active price', () => {
+    // C has a price; FX/GC/LE absent from payload
+    stub([category('C', [priceRow(90_000)])])
+    const { productSchemas } = useCityProductSchema('Bogotá', 'bogota')
+    expect(offerOf(productSchemas, 'C')).toBeTruthy()
+    expect(offerOf(productSchemas, 'FX')).toBeUndefined()
+    expect(productSchemas).toHaveLength(1)
+  })
+
+  it('renders an empty schema set without throwing when categories is empty', () => {
+    stub([])
+    expect(() => useCityProductSchema('Bogotá', 'bogota')).not.toThrow()
+    const { productSchemas } = useCityProductSchema('Bogotá', 'bogota')
+    expect(productSchemas).toHaveLength(0)
+  })
+
+  // SCEN-006: mixed positive+zero active set never emits $0
+  it('never emits a $0 offer for a category with a mixed positive+zero active set', () => {
+    stub([category('C', [priceRow(0), priceRow(110_000)])])
+    const { productSchemas } = useCityProductSchema('Bogotá', 'bogota')
+    const offer = offerOf(productSchemas, 'C')
+    expect(offer.price).toBe(110_000)
+    expect(JSON.stringify(productSchemas)).not.toContain('"price":0')
+  })
+
+  it('omits a category whose only active row is zero-priced', () => {
+    stub([category('C', [priceRow(0)])])
+    const { productSchemas } = useCityProductSchema('Bogotá', 'bogota')
+    expect(offerOf(productSchemas, 'C')).toBeUndefined()
+    expect(productSchemas).toHaveLength(0)
+  })
+
+  // priceValidUntil = real end_date when present, omitted otherwise
+  it('sets priceValidUntil from the selected row end_date and omits it when empty', () => {
+    stub([category('C', [priceRow(90_000, 'active', '2026-01-01', '2026-09-30')])])
+    let offer = offerOf(useCityProductSchema('Bogotá', 'bogota').productSchemas, 'C')
+    expect(offer.priceValidUntil).toBe('2026-09-30')
+
+    vi.unstubAllGlobals()
+    stub([category('C', [priceRow(90_000, 'active', '2026-01-01', '')])])
+    offer = offerOf(useCityProductSchema('Bogotá', 'bogota').productSchemas, 'C')
+    expect(offer.priceValidUntil).toBeUndefined()
+  })
+
+  // SCEN-007: deterministic — same payload yields the same price across renders
+  it('is deterministic: server and client renders select the same price', () => {
+    stub([category('C', [priceRow(120_000), priceRow(95_000)])])
+    const first = offerOf(useCityProductSchema('Bogotá', 'bogota').productSchemas, 'C')
+    const second = offerOf(useCityProductSchema('Bogotá', 'bogota').productSchemas, 'C')
+    expect(first.price).toBe(95_000)
+    expect(second.price).toBe(95_000)
+  })
+})

--- a/packages/logic/src/composables/__tests__/useCityProductSchema.sentinelSafety.test.ts
+++ b/packages/logic/src/composables/__tests__/useCityProductSchema.sentinelSafety.test.ts
@@ -16,8 +16,8 @@ const source = readFileSync(
 )
 
 describe('useCityProductSchema sentinel safety (SCEN-005 part 2)', () => {
-  it('extracts vehicleCategories via destructuring', () => {
-    expect(source).toMatch(/const\s*\{\s*vehicleCategories\s*\}\s*=\s*useFetchRentacarData\(\)/)
+  it('extracts vehicleCategories and categories via destructuring', () => {
+    expect(source).toMatch(/const\s*\{\s*vehicleCategories\s*,\s*categories\s*\}\s*=\s*useFetchRentacarData\(\)/)
   })
 
   it('uses optional chaining on every step into vehicleCategories', () => {

--- a/packages/logic/src/composables/useCityProductSchema.ts
+++ b/packages/logic/src/composables/useCityProductSchema.ts
@@ -1,79 +1,65 @@
 // External dependencies
-import type { Product, AggregateOffer } from 'schema-dts';
+import type { Product, Offer, UnitPriceSpecification } from 'schema-dts';
 
-interface CityPricing {
-  lowPrice: number
-  highPrice: number
-}
+// Internal dependencies - utils
+import { pickRepresentativeDailyPrice } from '../utils';
 
-// Base prices per city (in COP) - from useCityFAQs.ts
-const cityPricing: Record<string, CityPricing> = {
-  'Bogotá': { lowPrice: 110000, highPrice: 450000 },
-  'Medellín': { lowPrice: 115000, highPrice: 460000 },
-  'Cali': { lowPrice: 105000, highPrice: 420000 },
-  'Cartagena': { lowPrice: 120000, highPrice: 480000 },
-  'Barranquilla': { lowPrice: 100000, highPrice: 400000 },
-  'Santa Marta': { lowPrice: 110000, highPrice: 440000 },
-  'Pereira': { lowPrice: 105000, highPrice: 420000 },
-  'Bucaramanga': { lowPrice: 100000, highPrice: 400000 },
-  'Armenia': { lowPrice: 100000, highPrice: 400000 },
-  'Manizales': { lowPrice: 105000, highPrice: 420000 },
-  'Villavicencio': { lowPrice: 95000, highPrice: 380000 },
-  'Valledupar': { lowPrice: 95000, highPrice: 380000 },
-  'Ibagué': { lowPrice: 95000, highPrice: 380000 },
-  'Neiva': { lowPrice: 90000, highPrice: 360000 },
-  'Cúcuta': { lowPrice: 90000, highPrice: 360000 },
-  'Montería': { lowPrice: 95000, highPrice: 380000 },
-  'Floridablanca': { lowPrice: 95000, highPrice: 380000 },
-  'Palmira': { lowPrice: 100000, highPrice: 400000 },
-  'Soledad': { lowPrice: 95000, highPrice: 380000 },
-}
-
-// Representative vehicle categories for schema
+// Representative vehicle categories featured in the city landing schema.
+// Curated Spanish names/descriptions (the Localiza catalog descriptions are in
+// Portuguese — see issue #74). The real PRICE is no longer hardcoded: it is read
+// per category from category_pricing (SSR via rentacar-data). See issue #68.
 const representativeCategories = [
   {
     code: 'C',
     name: 'Económico',
     description: 'Vehículos compactos perfectos para ciudad. Fiat Mobi, Kia Picanto, Renault Kwid.',
-    priceMultiplier: 1.0
   },
   {
     code: 'FX',
     name: 'Sedán Automático',
     description: 'Sedanes cómodos con transmisión automática. Kia Rio, Hyundai Accent, Suzuki Dzire.',
-    priceMultiplier: 1.3
   },
   {
     code: 'GC',
     name: 'Camioneta SUV',
     description: 'Camionetas compactas ideales para familias. Suzuki Vitara, Hyundai Creta, Fiat Pulse.',
-    priceMultiplier: 1.8
   },
   {
     code: 'LE',
     name: 'Camioneta Premium',
     description: 'SUVs de lujo con todas las comodidades. Kia Sportage, Hyundai Tucson, Renault Koleos.',
-    priceMultiplier: 2.5
-  }
+  },
 ]
 
 /**
- * Generates Product Schema for city landing pages
- * This provides structured data for Google to show rich results
- * even when no search has been performed
+ * Generates Product schema for city landing pages so a JS-less crawler reads a
+ * real, representative "from" price per featured category.
+ *
+ * The price is the cheapest positive active `one_day_price` from
+ * category_pricing (`pickRepresentativeDailyPrice`) — the same source the
+ * checkout uses — emitted as a per-day `UnitPriceSpecification`. A category with
+ * no real price (absent, or no monthly plan) is omitted rather than published
+ * with a fabricated or $0 value. The brand label comes from `organization.brand`
+ * (per-brand), never a hardcoded name.
  */
 export function useCityProductSchema(cityName: string, citySlug: string) {
-  const { franchise } = useAppConfig()
-  const { vehicleCategories } = useFetchRentacarData()
+  const { franchise, organization } = useAppConfig()
+  const { vehicleCategories, categories } = useFetchRentacarData()
 
-  const pricing = cityPricing[cityName] || { lowPrice: 100000, highPrice: 400000 }
+  const brandName = organization.brand
 
-  const productSchemas = representativeCategories.map((category) => {
-    const categoryLowPrice = Math.round(pricing.lowPrice * category.priceMultiplier)
-    const categoryHighPrice = Math.round(pricing.highPrice * category.priceMultiplier)
+  const productSchemas = representativeCategories.flatMap((category) => {
+    const categoryData = categories?.find((c) => c.id === category.code)
+    const priceRow = categoryData ? pickRepresentativeDailyPrice(categoryData.month_prices) : undefined
+
+    // Fail-soft: no real price → omit this category (never $0 or fabricated).
+    if (!priceRow) return []
+
+    const dailyPrice = priceRow.one_day_price
     const categoryImage = vehicleCategories?.[category.code]?.modelos?.[0]?.image || ''
+    const validUntil = priceRow.end_date || undefined
 
-    return <Product>{
+    return [<Product>{
       '@type': 'Product',
       '@id': `${franchise.website}/${citySlug}#vehicle-${category.code}`,
       name: `Alquiler ${category.name} en ${cityName}`,
@@ -81,37 +67,42 @@ export function useCityProductSchema(cityName: string, citySlug: string) {
       category: 'Alquiler de Vehículos',
       brand: {
         '@type': 'Brand',
-        name: 'Alquilatucarro'
+        name: brandName,
       },
-      image: categoryImage,
-      offers: <AggregateOffer>{
-        '@type': 'AggregateOffer',
+      // Omit empty image rather than emit image:'' (incomplete Product node).
+      ...(categoryImage ? { image: categoryImage } : {}),
+      offers: <Offer>{
+        '@type': 'Offer',
         priceCurrency: 'COP',
-        lowPrice: categoryLowPrice,
-        highPrice: categoryHighPrice,
-        offerCount: 4,
+        price: dailyPrice,
+        priceSpecification: <UnitPriceSpecification>{
+          '@type': 'UnitPriceSpecification',
+          priceCurrency: 'COP',
+          price: dailyPrice,
+          unitCode: 'DAY', // UN/CEFACT: per-day rate, not a rental total
+        },
         availability: 'https://schema.org/InStock',
-        priceValidUntil: '2026-12-31',
+        ...(validUntil ? { priceValidUntil: validUntil } : {}),
         seller: {
           '@type': 'Organization',
-          name: 'Alquilatucarro',
-          url: franchise.website
+          name: brandName,
+          url: franchise.website,
         },
         areaServed: {
           '@type': 'City',
           name: cityName,
           containedInPlace: {
             '@type': 'Country',
-            name: 'Colombia'
-          }
-        }
-      }
-    }
+            name: 'Colombia',
+          },
+        },
+      },
+    }]
   })
 
   useSchemaOrg(productSchemas)
 
   return {
-    productSchemas
+    productSchemas,
   }
 }

--- a/packages/logic/src/utils/__tests__/pickRepresentativeDailyPrice.test.ts
+++ b/packages/logic/src/utils/__tests__/pickRepresentativeDailyPrice.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { pickRepresentativeDailyPrice } from '../pickRepresentativeDailyPrice'
+import type { CategoryMonthPriceData } from '../index'
+
+const row = (
+  one_day_price: number,
+  status: 'active' | 'inactive' = 'active',
+  init_date = '2026-01-01',
+  end_date = '2026-12-31',
+): CategoryMonthPriceData => ({
+  '1k_kms': 3_000_000,
+  '2k_kms': 3_500_000,
+  '3k_kms': 4_000_000,
+  init_date,
+  end_date,
+  total_insurance_price: 476_000,
+  one_day_price,
+  status,
+})
+
+describe('pickRepresentativeDailyPrice', () => {
+  // SCEN-001: real price replaces the fabricated value
+  it('returns the single active row when it has a positive one_day_price', () => {
+    const result = pickRepresentativeDailyPrice([row(90_000)])
+    expect(result?.one_day_price).toBe(90_000)
+  })
+
+  // SCEN-002: cheapest active positive, ignoring inactive
+  it('picks the minimum one_day_price among active rows and ignores inactive', () => {
+    const prices = [
+      row(120_000, 'active'),
+      row(90_000, 'active'),
+      row(70_000, 'inactive'), // cheaper but inactive → ignored
+    ]
+    const result = pickRepresentativeDailyPrice(prices)
+    expect(result?.one_day_price).toBe(90_000)
+  })
+
+  // SCEN-006: mixed positive+zero active set never yields 0
+  it('excludes zero-priced active rows (no monthly plan)', () => {
+    const prices = [row(0, 'active'), row(110_000, 'active')]
+    const result = pickRepresentativeDailyPrice(prices)
+    expect(result?.one_day_price).toBe(110_000)
+  })
+
+  // SCEN-005: fail-soft — undefined when no positive active price exists
+  it('returns undefined when all active rows are zero', () => {
+    expect(pickRepresentativeDailyPrice([row(0, 'active'), row(0, 'active')])).toBeUndefined()
+  })
+
+  it('returns undefined when prices is empty', () => {
+    expect(pickRepresentativeDailyPrice([])).toBeUndefined()
+  })
+
+  it('returns undefined when only inactive rows carry a price', () => {
+    expect(pickRepresentativeDailyPrice([row(80_000, 'inactive')])).toBeUndefined()
+  })
+
+  // Tie-break: equal one_day_price → most recent init_date wins
+  it('breaks ties on equal price by most recent init_date', () => {
+    const older = row(90_000, 'active', '2026-01-01')
+    const newer = row(90_000, 'active', '2026-06-01')
+    const result = pickRepresentativeDailyPrice([older, newer])
+    expect(result?.init_date).toBe('2026-06-01')
+  })
+
+  // SCEN-007: deterministic — same input yields identical output across calls
+  it('is a pure function: repeated calls on the same input return the same row', () => {
+    const prices = [row(120_000), row(95_000), row(150_000)]
+    const a = pickRepresentativeDailyPrice(prices)
+    const b = pickRepresentativeDailyPrice(prices)
+    expect(a?.one_day_price).toBe(95_000)
+    expect(a).toEqual(b)
+  })
+
+  // Does not mutate the caller's array (order-independent selection)
+  it('does not mutate the input array order', () => {
+    const prices = [row(120_000), row(90_000)]
+    const snapshot = prices.map((p) => p.one_day_price)
+    pickRepresentativeDailyPrice(prices)
+    expect(prices.map((p) => p.one_day_price)).toEqual(snapshot)
+  })
+})

--- a/packages/logic/src/utils/index.ts
+++ b/packages/logic/src/utils/index.ts
@@ -23,6 +23,7 @@ export { slugify } from './slugify';
 // Pricing
 // ============================================================================
 export { pickPriceForDate } from './pickPriceForDate';
+export { pickRepresentativeDailyPrice } from './pickRepresentativeDailyPrice';
 export { categoryOffersMonthly } from './categoryOffersMonthly';
 export { pickEffectiveTotalCoverageUnitCharge } from './pickEffectiveTotalCoverage';
 export { resolvePicoyPlacaExempt } from './isPicoyPlacaExempt';

--- a/packages/logic/src/utils/pickRepresentativeDailyPrice.ts
+++ b/packages/logic/src/utils/pickRepresentativeDailyPrice.ts
@@ -1,0 +1,32 @@
+import type CategoryMonthPriceData from './types/data/CategoryMonthPriceData'
+
+/**
+ * Picks the representative "from" daily rate for a category landing page: the
+ * cheapest positive `one_day_price` among `active` rows.
+ *
+ * Date-free by design. A city landing page has no pickup date, so any date we
+ * could pass would be arbitrary. "Desde $X/día" semantics mean a floor, so the
+ * lowest active daily rate is the honest representative. Being date-free also
+ * makes selection deterministic — server and client renders produce the same
+ * price, with no hydration mismatch in the JSON-LD.
+ *
+ * Returns `undefined` when no `active` row carries a positive `one_day_price`
+ * (e.g. a category with no monthly plan, modeled as `one_day_price = 0`), so the
+ * caller omits the offer rather than publishing a fabricated or $0 price.
+ *
+ * This is deliberately NOT `pickPriceForDate`: it never touches the temporal
+ * season rules (which can fall back to a $0 season-low row for an out-of-range
+ * date). It only selects the lowest active daily rate.
+ */
+export function pickRepresentativeDailyPrice(
+  prices: CategoryMonthPriceData[],
+): CategoryMonthPriceData | undefined {
+  return prices
+    .filter((p) => p.status === 'active' && p.one_day_price > 0)
+    .sort((a, b) => {
+      const delta = a.one_day_price - b.one_day_price
+      if (delta !== 0) return delta
+      // tie-break: most recent init_date wins, mirroring pickPriceForDate
+      return b.init_date.localeCompare(a.init_date)
+    })[0]
+}


### PR DESCRIPTION
> Épico #63 · auditoría agéntica 2026-05-26 · Closes #68

## Problema

Las páginas de ciudad ya emitían un precio por categoría en el JSON-LD al SSR, pero los números eran **fabricados**: una matriz de 19 ciudades tecleada a mano × multiplicadores hardcodeados, con `brand`/`seller` fijados a `Alquilatucarro` en las **3 marcas**. Un crawler sin JS leía precios inventados que nunca coinciden con el checkout.

## Solución

Reemplaza la fabricación por el `one_day_price` **real** de `category_pricing`, ya disponible en SSR vía el payload `rentacar-data` (mismo dato que alimenta el checkout). No toca `/api/rentacar-data` → respeta el contrato de cache `getKey=buildId` (#62).

- **Nuevo util puro** `pickRepresentativeDailyPrice`: elige la tarifa diaria **activa positiva más baja**. Date-free (una landing no tiene fecha de recogida; "desde" = piso), determinista (sin `Date` → sin hydration mismatch), nunca $0. **No** toca las reglas temporales de `pickPriceForDate`.
- **`useCityProductSchema`** reescrito:
  - precio real por categoría representativa (C/FX/GC/LE); **fail-soft**: omite la categoría si no hay precio real (nunca un nodo $0/inventado);
  - un solo `Offer` con `UnitPriceSpecification` (`unitCode: DAY`) explícito → el número no se lee como total;
  - `brand`/`seller` desde `organization.brand` (por marca), nunca hardcodeado;
  - `priceValidUntil` desde el `end_date` real de la fila, omitido si ausente;
  - elimina la matriz `cityPricing`, los multiplicadores, `offerCount:4` y el `priceValidUntil` hardcodeado.

## Decisión de diseño

El `category_pricing` disponible sin JS es **global por categoría, no por ciudad** (la variación por ciudad solo existe en el POST dinámico de availability, que requiere JS). Se priorizó **precio real global** sobre **fabricado por ciudad** — honesto y consistente con el checkout. Aprobado por el negocio.

## Blast radius

1 util nuevo + 1 composable en `logic/` → páginas de ciudad de las 3 marcas. Consumidor: `CityPage.vue:436` (firma sin cambios). No toca `pickPriceForDate` ni el flujo de reserva.

## Verificación

- **Holdout SCEN-001..007** (spec `docs/specs/2026-06-10-issue-68-ssr-representative-prices/`): util 9/9 (oráculos de valor exacto, red→green) + composable runtime 9/9 (red→green).
- **Suite logic**: 360/360 (secuencial).
- **Typecheck** (ui-alquilame, niced): 0 errores nuevos en archivos cambiados.
- **Runtime real** (alquilame `/bogota` + `/santa-marta`, data Supabase): 4 Products con precios reales `220000/300000/550000/570000` COP, `unitCode DAY`, `brand`/`seller` = **Alquilame**, sin el `198000` fabricado, precios idénticos entre ciudades (confirma global + determinismo).
- **Quality gate**: code-reviewer (APPROVED), edge-case-detector (clean), performance-engineer (negligible), code-simplifier — todos los hallazgos accionables corregidos.