### PR TITLE
feat(alquilame): F2 — city landing + legal pages reskin (SEO + engine preserved)

### DIFF
--- a/docs/specs/2026-06-11-issue-112-f2-landing-legal-design.md
+++ b/docs/specs/2026-06-11-issue-112-f2-landing-legal-design.md
@@ -41,7 +41,8 @@ Diseño city: hero, `#intro`, `#fleet`, `#puntos-entrega`, `#how-it-works`, `#re
 **Nota h1**: el hero city adopta el **estilo** del diseño y el h1 city-SEO "Alquiler de carros en {city}" (el del diseño ES city-targeted, válido para SEO). SCEN-F2-02 cubre la preservación de las **secciones de contenido**, no el wording exacto del h1 del hero.
 
 ### Cross-cutting (preservar + lecciones F1)
-- **Engine**: `Searcher`/`SelectBranch`/`CategorySelectionSection` sin cambios de comportamiento; `data-testid` intactos; navegación a `buscar-vehiculos` igual.
+- **Engine**: `Searcher.vue` (hero city, sus `data-testid` `pickup/return-location-test`) + `CategorySelectionSection` (resultados) sin cambios de comportamiento; `SelectBranch` (solo en el modal del Fleet reusado) preserva su flujo; navegación a `buscar-vehiculos` igual.
+- **Heading city de testimonios**: al reemplazar `#testimonios` por `HomeReviews`, conservar un encabezado city-targeted ("…en {city.name}") — pasar `city.name` como prop/heading a `HomeReviews` para no perder ese texto indexable (los cards usan `franchiseTestimonials` reales igual).
 - **#41 pin**: el `<span aria-hidden>` inerte de copy-to-WhatsApp se preserva (no reintroducir el `<button>`).
 - **#109**: sin `Date`/`today()` horneado en SSR/ISR.
 - **SEO/schema**: `useCityProductSchema` (#68, precio real por categoría), `FAQPage`, breadcrumb, canonical, og — preservados.
@@ -56,7 +57,7 @@ Diseño city: hero, `#intro`, `#fleet`, `#puntos-entrega`, `#how-it-works`, `#re
 
 - **SCEN-F2-01 (hero+searcher):** Given `/{city}` en el alias, when se ve el hero, then tiene el estilo del diseño (rojo, city name) y el `Searcher.vue` funciona igual — al completar la búsqueda navega a `/{city}/buscar-vehiculos/...` y conserva sus `data-testid` (`pickup-location-test`/`return-location-test`).
 - **SCEN-F2-02 (SEO content preservado):** Given la city landing, when se inspecciona el texto, then todas las secciones SEO actuales (descripcion/ventajas/destinos/consejos/temporada/ciudades-cercanas) siguen presentes con su contenido indexable (restilizado, no removido).
-- **SCEN-F2-03 (marketing del diseño):** Given la city landing, when se recorre, then existen las secciones de marketing del diseño reusando componentes F1 (fleet, how-it-works, requirements, contact).
+- **SCEN-F2-03 (marketing del diseño):** Given la city landing, when se recorre, then existen las secciones de marketing del diseño reusando componentes F1 (fleet, how-it-works, requirements, contact), y el CTA "Reserva Ahora" del contact ancla a un target existente in-page (`#searcher` del hero city), NO al `#hero` inexistente (prop `reserveAnchor`).
 - **SCEN-F2-04 (puntos-entrega):** Given una ciudad con branches, when se ve `#puntos-entrega`, then lista los `cityBranches` reales con el estilo del diseño.
 - **SCEN-F2-05 (resultados condicionales intactos):** Given una ruta `buscar-vehiculos` con params, when renderiza, then `#seleccion-categorias`/`CategorySelectionSection` muestra resultados como hoy (engine sin cambios).
 - **SCEN-F2-06 (#41 + #109):** Given el hero, when se inspecciona, then el pin de copy-to-WhatsApp sigue inerte (`<span aria-hidden>`, fuera del accessible name del `<h1>`) y no hay `Date`/`today()` horneado bajo ISR.

--- a/docs/specs/2026-06-11-issue-112-f2-landing-legal-design.md
+++ b/docs/specs/2026-06-11-issue-112-f2-landing-legal-design.md
@@ -1,0 +1,70 @@
+# Issue #112 — F2: City landing + legales (Astro → Nuxt)
+
+**Issue:** #112 (reskin completo alquilame) · fase **3 de 4**
+**Rama:** `feat/issue-112-f2-landing-legal` (worktree `.worktrees/issue-112-f2`, desde `main` con F0+F1)
+**Estado:** diseño para revisión
+**Depende de:** F0 (fundación) + F1 (home + componentes `home/*`) — ya en `main`.
+
+## Contexto
+
+F0 dejó el chrome de marca; F1 reskó el home con 12 componentes en `app/components/home/*`. F2 porta la **city landing** (`/{city}`, render por `CityPage.vue`) y las **2 páginas legales** (`terminos-condiciones.vue`, `politica-privacidad.vue`) al diseño entregado (`/tmp/alqui_f1_design/dist/{alquiler-de-carros-bogota,terminos,privacidad}/index.html`).
+
+`alquilame.co` público sigue legacy; verificación en el alias Vercel `-git-feat-…` de la rama.
+
+## Decisiones (brainstorming)
+
+1. **City landing = reskin marketing, engine/rutas INTACTOS.** El searcher (`Searcher`/`SelectBranch`) sigue navegando a `/{city}/buscar-vehiculos/...` como hoy; **F3** lo reapunta a `/reservas`. El bloque de resultados live (`#seleccion-categorias` → `CategorySelectionSection`) es **condicional** (solo con params de búsqueda) y se **preserva intacto** — la landing sin params ya es "marketing".
+2. **Preservar TODO el contenido SEO** de la city landing (restilizado), no dropear secciones. AGREGAR las secciones de marketing del diseño reusando componentes `home/*` de F1.
+3. **Legales = copy legal del diseño** (secciones numeradas, escrito para alquilame) + estilo del diseño. Reemplaza el contenido actual.
+
+## Parte A — City landing (`CityPage.vue`)
+
+`CityPage.vue` (464 líneas) lo usa `[city]/index.vue` Y las rutas `buscar-vehiculos` (condicional por params). Secciones actuales: hero (searcher + pin #41), `#seleccion-categorias` (resultados condicionales), `#descripcion`, `#ventajas`, `#puntos-entrega` (branches), `#introduccion`, `#destinos`, `#consejos-conduccion`, `#mejor-temporada`, `#ciudades-cercanas`, `#faqs`, `#testimonios`.
+
+Diseño city: hero, `#intro`, `#fleet`, `#puntos-entrega`, `#how-it-works`, `#requirements`, `#google-reviews`, `#faq`, `#contact`.
+
+### Mapeo
+
+| Bloque actual | Acción | Notas |
+|---|---|---|
+| Hero (searcher + pin #41) | **Restyle** al hero del diseño (rojo `bg-linear`) | **Preservar `Searcher`/`SelectBranch`** (mismo destino `buscar-vehiculos`, mismos `data-testid`), pin #41 inerte, guard #109 (sin `Date`/`today()` horneado) |
+| `#seleccion-categorias` (`CategorySelectionSection`) | **Preservar intacto** | Condicional (`v-if` params). No tocar el engine de resultados |
+| `#descripcion` / `#introduccion` | **Restyle** → `#intro` del diseño; **texto SEO preservado** | El `#intro` del diseño mapea aquí |
+| `#ventajas` / `#destinos` / `#consejos-conduccion` / `#mejor-temporada` / `#ciudades-cercanas` | **Restyle**, **texto SEO preservado** (indexable) | Cero pérdida de contenido |
+| `#puntos-entrega` (`cityBranches`) | **Restyle** al diseño | Datos branches preservados |
+| `#faqs` | **Restyle** (reusar `HomeFaq` si el contenido es brand-level; si city-specific, restyle in-place) | `FAQPage` schema preservado |
+| `#testimonios` | **Reusar `HomeReviews`** de F1 | `franchiseTestimonials` reales |
+| Marketing del diseño (`#fleet`, `#how-it-works`, `#requirements`, `#contact`) | **Agregar reusando `home/*` de F1** (`HomeFleet`, `HomeHowItWorks`, `HomeRequirements`, `HomeContact`) | DRY; mismas decisiones F1 (precio real, etc.) |
+
+### Cross-cutting (preservar + lecciones F1)
+- **Engine**: `Searcher`/`SelectBranch`/`CategorySelectionSection` sin cambios de comportamiento; `data-testid` intactos; navegación a `buscar-vehiculos` igual.
+- **#41 pin**: el `<span aria-hidden>` inerte de copy-to-WhatsApp se preserva (no reintroducir el `<button>`).
+- **#109**: sin `Date`/`today()` horneado en SSR/ISR.
+- **SEO/schema**: `useCityProductSchema` (#68, precio real por categoría), `FAQPage`, breadcrumb, canonical, og — preservados.
+- **Estilo**: `bg-linear-to-*` (NO `bg-gradient-to-*`); `[--ctx-text-primary:#fff]` en secciones de fondo rojo/oscuro (lección F1 contraste); `.heading-*` → Plus Jakarta. Ver [[reference_tailwind4_gradient_bg_linear]].
+- **CLS**: `aspect-ratio` en imágenes; estado client-only sin shift (lección F1 announcement).
+
+## Parte B — Legales
+
+`terminos-condiciones.vue` (186 líneas, 11 secciones actuales) y `politica-privacidad.vue` (140 líneas). Reemplazar el contenido por el **copy legal del diseño** (terminos: 11×h2 "Identificación del prestador / Aceptación / Requisitos / Reserva y pago / …"; privacidad: 10×h2 "Responsable / Marco legal / Datos / Finalidad / …") con el **estilo del diseño** (`font-heading` h2s, layout de documento legal limpio). Preservar `useSeoMeta`/`definePageMeta`/layout y los enlaces del footer (`politica-privacidad`, `terminos-condiciones`).
+
+## Holdout — escenarios observables
+
+- **SCEN-F2-01 (hero+searcher):** Given `/{city}` en el alias, when se ve el hero, then tiene el estilo del diseño (rojo, city name) y el `Searcher`/`SelectBranch` funciona igual (al buscar navega a `/{city}/buscar-vehiculos/...`, mismo `data-testid`).
+- **SCEN-F2-02 (SEO content preservado):** Given la city landing, when se inspecciona el texto, then todas las secciones SEO actuales (descripcion/ventajas/destinos/consejos/temporada/ciudades-cercanas) siguen presentes con su contenido indexable (restilizado, no removido).
+- **SCEN-F2-03 (marketing del diseño):** Given la city landing, when se recorre, then existen las secciones de marketing del diseño reusando componentes F1 (fleet, how-it-works, requirements, contact).
+- **SCEN-F2-04 (puntos-entrega):** Given una ciudad con branches, when se ve `#puntos-entrega`, then lista los `cityBranches` reales con el estilo del diseño.
+- **SCEN-F2-05 (resultados condicionales intactos):** Given una ruta `buscar-vehiculos` con params, when renderiza, then `#seleccion-categorias`/`CategorySelectionSection` muestra resultados como hoy (engine sin cambios).
+- **SCEN-F2-06 (#41 + #109):** Given el hero, when se inspecciona, then el pin de copy-to-WhatsApp sigue inerte (`<span aria-hidden>`, fuera del accessible name del `<h1>`) y no hay `Date`/`today()` horneado bajo ISR.
+- **SCEN-F2-07 (legales):** Given `/terminos-condiciones` y `/politica-privacidad`, when se ven, then usan el copy legal del diseño (secciones numeradas) con el estilo del diseño; los enlaces del footer resuelven 200.
+- **SCEN-F2-08 (estilo):** Given las secciones de fondo rojo/oscuro, when se mide, then gradientes renderizan (`bg-linear`, no `none`), headings legibles (blancos vía `--ctx-text-primary`), `bg-gradient-to-` en source = 0.
+- **SCEN-F2-09 (SEO/schema preservado):** Given el HTML renderizado de la city landing, when se inspecciona, then `useCityProductSchema` (#68, precio real), `FAQPage`, breadcrumb, canonical y og siguen presentes y correctos.
+- **SCEN-F2-10 (CLS no peor):** Given `/{city}` en el alias, when se mide CLS, then no es peor que el baseline pre-F2.
+- **SCEN-F2-11 (aislamiento):** Given el branch F2, when `git diff main --stat`, then solo cambia `packages/ui-alquilame/**` (+ `docs/specs`); engine/rutas/logic intactos.
+- **SCEN-F2-12 (E2E sin regresión):** Given `BRAND=alquilame` contra el preview, when se corre el subconjunto de city/legales, then sin regresión vs baseline y `data-testid` intactos.
+
+## Plan de verificación
+Estática (unit/typecheck/grep aislamiento + `bg-gradient-to` cero) + **runtime en preview Vercel** (`agent-browser`: hero+searcher, secciones SEO presentes, puntos-entrega, legales copy, gradientes+contraste, JSON-LD #68/FAQPage, CLS; ruta `buscar-vehiculos` con params muestra resultados; E2E city+legales). Cierre con `/verification-before-completion`.
+
+## Fuera de F2
+`/reservas` + flujo resultados/reserva + blog → **F3** (cierra #112 con `Closes`). F3 reapunta el searcher de `buscar-vehiculos` a `/reservas` y decide redirects/SEO.

--- a/docs/specs/2026-06-11-issue-112-f2-landing-legal-design.md
+++ b/docs/specs/2026-06-11-issue-112-f2-landing-legal-design.md
@@ -13,9 +13,9 @@ F0 dejó el chrome de marca; F1 reskó el home con 12 componentes en `app/compon
 
 ## Decisiones (brainstorming)
 
-1. **City landing = reskin marketing, engine/rutas INTACTOS.** El searcher (`Searcher`/`SelectBranch`) sigue navegando a `/{city}/buscar-vehiculos/...` como hoy; **F3** lo reapunta a `/reservas`. El bloque de resultados live (`#seleccion-categorias` → `CategorySelectionSection`) es **condicional** (solo con params de búsqueda) y se **preserva intacto** — la landing sin params ya es "marketing".
+1. **City landing = reskin marketing, engine/rutas INTACTOS.** El navegador del hero city es **`Searcher.vue`** (con sus `data-testid` `pickup-location-test`/`return-location-test`) — NO `SelectBranch` (ese solo aparece vía el modal del Fleet reusado). El flujo sigue navegando a `/{city}/buscar-vehiculos/...` como hoy; **F3** lo reapunta a `/reservas`. El bloque de resultados live (`#seleccion-categorias` → `CategorySelectionSection`) es **condicional** (solo con params de búsqueda) y se **preserva intacto** — la landing sin params ya es "marketing".
 2. **Preservar TODO el contenido SEO** de la city landing (restilizado), no dropear secciones. AGREGAR las secciones de marketing del diseño reusando componentes `home/*` de F1.
-3. **Legales = copy legal del diseño** (secciones numeradas, escrito para alquilame) + estilo del diseño. Reemplaza el contenido actual.
+3. **Legales = ESTILO del diseño + PRESERVAR el encuadre legal de intermediación del contenido actual.** El copy del diseño describe a alquilame como operador DIRECTO y dropea "plataforma de intermediación / no somos empresa de alquiler" (modelo AMAW agregador) → riesgo de tergiversar el modelo. Se aplica el layout/tipografía del diseño (secciones numeradas, `font-heading`) al **contenido legal actual** (con sus disclaimers de intermediación), NO se reemplaza el texto por el del diseño.
 
 ## Parte A — City landing (`CityPage.vue`)
 
@@ -27,14 +27,18 @@ Diseño city: hero, `#intro`, `#fleet`, `#puntos-entrega`, `#how-it-works`, `#re
 
 | Bloque actual | Acción | Notas |
 |---|---|---|
-| Hero (searcher + pin #41) | **Restyle** al hero del diseño (rojo `bg-linear`) | **Preservar `Searcher`/`SelectBranch`** (mismo destino `buscar-vehiculos`, mismos `data-testid`), pin #41 inerte, guard #109 (sin `Date`/`today()` horneado) |
+> **Regla anti-colisión de `id`**: las secciones reusadas/restiladas **REEMPLAZAN** la sección actual equivalente, nunca se agregan al lado (evita `id` duplicado en la misma página: `#testimonios`, `#faqs`, `#contact`, `#requisitos`). Verificar que ninguna otra sección ya posea `#contact`/`#requisitos` antes de montar los componentes F1.
+
+| Hero (searcher + pin #41) | **Restyle** al hero del diseño (rojo `bg-linear`) | **Preservar `Searcher.vue`** (mismo destino `buscar-vehiculos`, **sus** `data-testid` `pickup/return-location-test`), pin #41 inerte (`<span aria-hidden>`, NO reintroducir `<button>`), guard #109 (sin `Date`/`today()` horneado) |
 | `#seleccion-categorias` (`CategorySelectionSection`) | **Preservar intacto** | Condicional (`v-if` params). No tocar el engine de resultados |
-| `#descripcion` / `#introduccion` | **Restyle** → `#intro` del diseño; **texto SEO preservado** | El `#intro` del diseño mapea aquí |
+| `#descripcion` / `#introduccion` | **Restyle** → `#intro` del diseño; **texto SEO preservado** | El `#intro` del diseño (h1 "Alquiler de carros en {city}, sin vueltas") mapea aquí; ver nota h1 abajo |
 | `#ventajas` / `#destinos` / `#consejos-conduccion` / `#mejor-temporada` / `#ciudades-cercanas` | **Restyle**, **texto SEO preservado** (indexable) | Cero pérdida de contenido |
 | `#puntos-entrega` (`cityBranches`) | **Restyle** al diseño | Datos branches preservados |
-| `#faqs` | **Restyle** (reusar `HomeFaq` si el contenido es brand-level; si city-specific, restyle in-place) | `FAQPage` schema preservado |
-| `#testimonios` | **Reusar `HomeReviews`** de F1 | `franchiseTestimonials` reales |
-| Marketing del diseño (`#fleet`, `#how-it-works`, `#requirements`, `#contact`) | **Agregar reusando `home/*` de F1** (`HomeFleet`, `HomeHowItWorks`, `HomeRequirements`, `HomeContact`) | DRY; mismas decisiones F1 (precio real, etc.) |
+| `#faqs` | **Restyle in-place — MANTENER `useCityFAQs(city.name)`** (FAQs city-specific: pico y placa, El Dorado, etc.). **NO** reusar `HomeFaq` (renderiza `useData().faqs` brand-level → regresión de contenido SEO city). | El `FAQPage` schema city lo emite `useCityFAQSchema` dentro de `useCityPageSEO` (en `[city]/index.vue`), NO acá — **no moverlo** |
+| `#testimonios` | **REEMPLAZAR por `HomeReviews`** de F1 | `franchiseTestimonials` reales; quita el `#testimonios` viejo (no duplicar `id`) |
+| Marketing del diseño (`#fleet`, `#how-it-works`, `#requirements`, `#contact`) | **Agregar reusando `home/*` de F1** (`HomeFleet`, `HomeHowItWorks`, `HomeRequirements`, `HomeContact`) | `HomeContact` hardcodea `href="#hero"` (id del home, **no existe en city** → ancla muerta): añadir prop `reserveAnchor` (default `#hero`; city pasa `#searcher`). Resto DRY (precio real, etc.) |
+
+**Nota h1**: el hero city adopta el **estilo** del diseño y el h1 city-SEO "Alquiler de carros en {city}" (el del diseño ES city-targeted, válido para SEO). SCEN-F2-02 cubre la preservación de las **secciones de contenido**, no el wording exacto del h1 del hero.
 
 ### Cross-cutting (preservar + lecciones F1)
 - **Engine**: `Searcher`/`SelectBranch`/`CategorySelectionSection` sin cambios de comportamiento; `data-testid` intactos; navegación a `buscar-vehiculos` igual.
@@ -46,19 +50,20 @@ Diseño city: hero, `#intro`, `#fleet`, `#puntos-entrega`, `#how-it-works`, `#re
 
 ## Parte B — Legales
 
-`terminos-condiciones.vue` (186 líneas, 11 secciones actuales) y `politica-privacidad.vue` (140 líneas). Reemplazar el contenido por el **copy legal del diseño** (terminos: 11×h2 "Identificación del prestador / Aceptación / Requisitos / Reserva y pago / …"; privacidad: 10×h2 "Responsable / Marco legal / Datos / Finalidad / …") con el **estilo del diseño** (`font-heading` h2s, layout de documento legal limpio). Preservar `useSeoMeta`/`definePageMeta`/layout y los enlaces del footer (`politica-privacidad`, `terminos-condiciones`).
+`terminos-condiciones.vue` (186 líneas, 11 secciones actuales) y `politica-privacidad.vue` (140 líneas). **Conservar el CONTENIDO legal actual** (incluido el encuadre de intermediación: "plataforma de intermediación / no somos empresa de alquiler", secciones de naturaleza del servicio/responsabilidades) y aplicarle el **estilo del diseño**: layout de documento legal limpio, `font-heading` en h2s numerados, tipografía/espaciado del diseño. **No** sustituir el texto por el copy del diseño (operador directo). Preservar `useSeoMeta`/`definePageMeta`/layout y los enlaces del footer (`politica-privacidad`, `terminos-condiciones`).
 
 ## Holdout — escenarios observables
 
-- **SCEN-F2-01 (hero+searcher):** Given `/{city}` en el alias, when se ve el hero, then tiene el estilo del diseño (rojo, city name) y el `Searcher`/`SelectBranch` funciona igual (al buscar navega a `/{city}/buscar-vehiculos/...`, mismo `data-testid`).
+- **SCEN-F2-01 (hero+searcher):** Given `/{city}` en el alias, when se ve el hero, then tiene el estilo del diseño (rojo, city name) y el `Searcher.vue` funciona igual — al completar la búsqueda navega a `/{city}/buscar-vehiculos/...` y conserva sus `data-testid` (`pickup-location-test`/`return-location-test`).
 - **SCEN-F2-02 (SEO content preservado):** Given la city landing, when se inspecciona el texto, then todas las secciones SEO actuales (descripcion/ventajas/destinos/consejos/temporada/ciudades-cercanas) siguen presentes con su contenido indexable (restilizado, no removido).
 - **SCEN-F2-03 (marketing del diseño):** Given la city landing, when se recorre, then existen las secciones de marketing del diseño reusando componentes F1 (fleet, how-it-works, requirements, contact).
 - **SCEN-F2-04 (puntos-entrega):** Given una ciudad con branches, when se ve `#puntos-entrega`, then lista los `cityBranches` reales con el estilo del diseño.
 - **SCEN-F2-05 (resultados condicionales intactos):** Given una ruta `buscar-vehiculos` con params, when renderiza, then `#seleccion-categorias`/`CategorySelectionSection` muestra resultados como hoy (engine sin cambios).
 - **SCEN-F2-06 (#41 + #109):** Given el hero, when se inspecciona, then el pin de copy-to-WhatsApp sigue inerte (`<span aria-hidden>`, fuera del accessible name del `<h1>`) y no hay `Date`/`today()` horneado bajo ISR.
-- **SCEN-F2-07 (legales):** Given `/terminos-condiciones` y `/politica-privacidad`, when se ven, then usan el copy legal del diseño (secciones numeradas) con el estilo del diseño; los enlaces del footer resuelven 200.
+- **SCEN-F2-07 (legales estilo):** Given `/terminos-condiciones` y `/politica-privacidad`, when se ven, then tienen el estilo del diseño (layout legal limpio, `font-heading` en h2s) y los enlaces del footer resuelven 200.
+- **SCEN-F2-07b (intermediación preservada):** Given `/terminos-condiciones`, when se inspecciona el contenido, then conserva el encuadre de intermediación ("plataforma de intermediación / no somos empresa de alquiler") — NO se reemplazó por el copy de operador directo del diseño.
 - **SCEN-F2-08 (estilo):** Given las secciones de fondo rojo/oscuro, when se mide, then gradientes renderizan (`bg-linear`, no `none`), headings legibles (blancos vía `--ctx-text-primary`), `bg-gradient-to-` en source = 0.
-- **SCEN-F2-09 (SEO/schema preservado):** Given el HTML renderizado de la city landing, when se inspecciona, then `useCityProductSchema` (#68, precio real), `FAQPage`, breadcrumb, canonical y og siguen presentes y correctos.
+- **SCEN-F2-09 (SEO/schema preservado):** Given el HTML renderizado de la city landing, when se inspecciona, then `useCityProductSchema` (#68, precio real), el `FAQPage` city (de `useCityFAQSchema` en `useCityPageSEO`, **sin mover**), breadcrumb, canonical y og siguen presentes y correctos.
 - **SCEN-F2-10 (CLS no peor):** Given `/{city}` en el alias, when se mide CLS, then no es peor que el baseline pre-F2.
 - **SCEN-F2-11 (aislamiento):** Given el branch F2, when `git diff main --stat`, then solo cambia `packages/ui-alquilame/**` (+ `docs/specs`); engine/rutas/logic intactos.
 - **SCEN-F2-12 (E2E sin regresión):** Given `BRAND=alquilame` contra el preview, when se corre el subconjunto de city/legales, then sin regresión vs baseline y `data-testid` intactos.

--- a/docs/specs/2026-06-11-issue-112-f2-landing-legal-design.md
+++ b/docs/specs/2026-06-11-issue-112-f2-landing-legal-design.md
@@ -35,14 +35,14 @@ Diseño city: hero, `#intro`, `#fleet`, `#puntos-entrega`, `#how-it-works`, `#re
 | `#ventajas` / `#destinos` / `#consejos-conduccion` / `#mejor-temporada` / `#ciudades-cercanas` | **Restyle**, **texto SEO preservado** (indexable) | Cero pérdida de contenido |
 | `#puntos-entrega` (`cityBranches`) | **Restyle** al diseño | Datos branches preservados |
 | `#faqs` | **Restyle in-place — MANTENER `useCityFAQs(city.name)`** (FAQs city-specific: pico y placa, El Dorado, etc.). **NO** reusar `HomeFaq` (renderiza `useData().faqs` brand-level → regresión de contenido SEO city). | El `FAQPage` schema city lo emite `useCityFAQSchema` dentro de `useCityPageSEO` (en `[city]/index.vue`), NO acá — **no moverlo** |
-| `#testimonios` | **REEMPLAZAR por `HomeReviews`** de F1 | `franchiseTestimonials` reales; quita el `#testimonios` viejo (no duplicar `id`) |
+| `#testimonios` | **Restyle in-place** (estilo del diseño + heading city-targeted) | **Mantener `props.city.testimonials`** (city-specific) + `useCityAggregateRating`. **NO** reusar `HomeReviews` (usa `franchiseTestimonials` brand-level → cambia el display city→brand y arriesga inconsistencia con el `AggregateRating` city). Mismo criterio que `#faqs`: contenido city = restyle in-place. |
 | Marketing del diseño (`#fleet`, `#how-it-works`, `#requirements`, `#contact`) | **Agregar reusando `home/*` de F1** (`HomeFleet`, `HomeHowItWorks`, `HomeRequirements`, `HomeContact`) | `HomeContact` hardcodea `href="#hero"` (id del home, **no existe en city** → ancla muerta): añadir prop `reserveAnchor` (default `#hero`; city pasa `#searcher`). Resto DRY (precio real, etc.) |
 
 **Nota h1**: el hero city adopta el **estilo** del diseño y el h1 city-SEO "Alquiler de carros en {city}" (el del diseño ES city-targeted, válido para SEO). SCEN-F2-02 cubre la preservación de las **secciones de contenido**, no el wording exacto del h1 del hero.
 
 ### Cross-cutting (preservar + lecciones F1)
 - **Engine**: `Searcher.vue` (hero city, sus `data-testid` `pickup/return-location-test`) + `CategorySelectionSection` (resultados) sin cambios de comportamiento; `SelectBranch` (solo en el modal del Fleet reusado) preserva su flujo; navegación a `buscar-vehiculos` igual.
-- **Heading city de testimonios**: al reemplazar `#testimonios` por `HomeReviews`, conservar un encabezado city-targeted ("…en {city.name}") — pasar `city.name` como prop/heading a `HomeReviews` para no perder ese texto indexable (los cards usan `franchiseTestimonials` reales igual).
+- **Testimonios city**: restyle in-place conservando `props.city.testimonials` + el heading city-targeted ("…en {city.name}") indexable; `useCityAggregateRating` queda consistente con lo mostrado.
 - **#41 pin**: el `<span aria-hidden>` inerte de copy-to-WhatsApp se preserva (no reintroducir el `<button>`).
 - **#109**: sin `Date`/`today()` horneado en SSR/ISR.
 - **SEO/schema**: `useCityProductSchema` (#68, precio real por categoría), `FAQPage`, breadcrumb, canonical, og — preservados.

--- a/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/plan.md
+++ b/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/plan.md
@@ -1,0 +1,88 @@
+# F2 — City landing + legales · Plan de implementación
+
+**Spec (detailed design):** `docs/specs/2026-06-11-issue-112-f2-landing-legal-design.md` (aprobada).
+**Rama:** `feat/issue-112-f2-landing-legal` · **Holdout:** SCEN-F2-01..12 (+07b).
+**Approach:** restyle preservando engine + todo el SEO; reusar componentes `home/*` de F1; legales = estilo del diseño sobre contenido de intermediación actual.
+
+---
+
+## Chunk 1: File structure + steps
+
+### File-structure map
+
+Todo bajo `packages/ui-alquilame/` (aislamiento F2 — `logic/`, rutas y otras marcas intactas).
+
+**MODIFICADOS (F1 reuse — prereq):**
+| Archivo | Cambio |
+|---|---|
+| `app/components/home/Contact.vue` | Añadir prop `reserveAnchor?: string` (default `'#hero'`); el CTA "Reserva Ahora" usa `:href="reserveAnchor"`. En city se pasa `#searcher`. Backward-compat con el home. |
+| `app/components/home/Reviews.vue` | Añadir prop opcional de heading city-targeted (p.ej. `cityName?: string`) → heading "…en {cityName}" cuando se pasa; sin prop = copy actual (home). |
+
+**MODIFICADO (página principal F2):**
+| Archivo | Cambio |
+|---|---|
+| `app/components/CityPage.vue` | Restyle al diseño city: hero (preservar `Searcher`/#41/#109), secciones SEO restiladas, montar marketing F1 (`HomeFleet`/`HomeHowItWorks`/`HomeRequirements`/`HomeContact reserveAnchor="#searcher"`), **reemplazar** `#testimonios` por `HomeReviews :cityName`, **mantener** `#faqs` city (`useCityFAQs`), preservar `#seleccion-categorias`/`cityBranches`. Regla "replace not append" (sin `id` duplicado). |
+
+**NUEVOS (extracción de secciones city SEO — decomposición, opcional pero recomendada):**
+| Archivo | Responsabilidad |
+|---|---|
+| `app/components/city/Hero.vue` | Hero city restilizado (city name + `Searcher` + pin #41) |
+| `app/components/city/Intro.vue` | `#intro`/descripcion + introduccion (texto SEO city) |
+| `app/components/city/SeoContent.vue` | ventajas/destinos/consejos/temporada/ciudades-cercanas (texto SEO, restilizado) — o un componente por sección si crece |
+| `app/components/city/DeliveryPoints.vue` | `#puntos-entrega` (`cityBranches`) |
+| `app/components/city/Faq.vue` | `#faqs` city (`useCityFAQs`, restilizado in-place) |
+
+> CityPage queda como **orquestador** (mirror del patrón `home/*` de F1): monta `city/*` + los `home/*` reusados + preserva el bloque condicional de resultados. Cada sección = componente con responsabilidad única, testeable.
+
+**MODIFICADOS (legales):**
+| Archivo | Cambio |
+|---|---|
+| `app/pages/terminos-condiciones.vue` | Estilo del diseño (layout legal, `font-heading` h2s numerados) sobre el **contenido actual** (intermediación preservada) |
+| `app/pages/politica-privacidad.vue` | Igual |
+
+### Pasos de implementación (SDD)
+
+> Cada paso preserva el engine y deja la city landing renderizando. Tamaño ≤ M. Tests en `app/components/city/__tests__/` o `tests/`.
+
+1. **F1 reuse props** | S | deps: none
+   - Escenario: `HomeContact` acepta `reserveAnchor` (CTA ancla ahí; default `#hero` = home intacto); `HomeReviews` acepta `cityName` (heading city-targeted).
+   - AC: props añadidas backward-compat; el home (sin props) no cambia; test: default `#hero` en Contact, heading city con prop en Reviews; sin `bg-gradient-to-`.
+
+2. **City hero restyle** | M | deps: 1
+   - Escenario (SCEN-F2-01, F2-06): `city/Hero.vue` con estilo del diseño (rojo `bg-linear`, h1 "Alquiler de carros en {city}"), `Searcher` preservado (testids `pickup/return-location-test`, navega a `buscar-vehiculos`), pin #41 inerte (`<span aria-hidden>`), `[--ctx-text-primary:#fff]`, sin `Date` horneado (#109).
+   - AC: hero montado en CityPage; Searcher + #41 intactos; test: Searcher presente con testids, pin es `<span aria-hidden>` no `<button>`, bg-linear, ctx-text-primary.
+
+3. **City SEO content restyle** | M | deps: 1
+   - Escenario (SCEN-F2-02): `city/Intro.vue` + `city/SeoContent.vue` restilan intro/descripcion/ventajas/destinos/consejos/temporada/ciudades-cercanas al diseño, **texto SEO preservado** (indexable).
+   - AC: todas las secciones presentes con su texto; test: cada sección/heading presente, sin pérdida de copy; `.heading-*`, bg-linear.
+
+4. **Puntos-entrega restyle** | S | deps: 1
+   - Escenario (SCEN-F2-04): `city/DeliveryPoints.vue` restila `#puntos-entrega` con `cityBranches` reales.
+   - AC: itera `cityBranches`, estilo diseño; test: v-for branches, presente solo si `cityBranches.length > 0`.
+
+5. **FAQ city restyle** | S | deps: 1
+   - Escenario (SCEN-F2-02): `city/Faq.vue` restila `#faqs` **manteniendo `useCityFAQs(city.name)`** (NO HomeFaq); el schema `useCityFAQSchema` en `useCityPageSEO` no se toca.
+   - AC: acordeón con `useCityFAQs`; test: usa `useCityFAQs` (no `useData().faqs`), `.heading-*`.
+
+6. **Mount F1 marketing + replace testimonios** | M | deps: 1,2,3,4,5
+   - Escenario (SCEN-F2-03, F2-05): CityPage orquesta — monta `HomeFleet`/`HomeHowItWorks`/`HomeRequirements`/`HomeContact reserveAnchor="#searcher"`, **reemplaza** `#testimonios` por `<HomeReviews :cityName>`, **preserva** `#seleccion-categorias` condicional intacto. Sin `id` duplicado.
+   - AC: secciones marketing montadas; "Reserva Ahora" ancla a `#searcher`; resultados condicionales intactos; test: componentes montados, cero `id` duplicado, reserveAnchor=#searcher, CategorySelectionSection preservado.
+
+7. **Legales restyle** | M | deps: none
+   - Escenario (SCEN-F2-07, F2-07b): `terminos-condiciones.vue` + `politica-privacidad.vue` con estilo del diseño (layout legal, `font-heading` h2s) sobre el **contenido actual** — encuadre de intermediación preservado ("no somos empresa de alquiler / plataforma de intermediación").
+   - AC: estilo aplicado, contenido de intermediación intacto; test: presencia del disclaimer de intermediación, h2 `font-heading`, sin reemplazo por copy operador-directo.
+
+8. **Integración + verificación runtime (preview)** | M | deps: 1–7
+   - Escenario: holdout SCEN-F2-01..12 (+07b) satisfecho en el preview.
+   - AC: `agent-browser` en `/{city}` y `/{city}/buscar-vehiculos/...` (con params): hero+searcher navega, secciones SEO presentes, puntos-entrega, marketing F1, resultados condicionales con params, gradientes+contraste (headings blancos sobre rojo), JSON-LD #68/FAQPage/canonical/og preservados, legales estilo+intermediación, CLS ≤ baseline; aislamiento `git diff main --stat` solo `ui-alquilame`+`docs/specs`; grep `bg-gradient-to-` (home/city/legales tocados) = 0; E2E `BRAND=alquilame` (city+legales) sin regresión + `data-testid` intactos. Cierre con `/verification-before-completion`.
+
+### Prerequisitos
+- Worktree `.worktrees/issue-112-f2` (desde main con F0+F1). Sin nuevas deps. Preview Vercel push-gated.
+
+### Testing
+- **Unit (estático)**: por paso, contratos observables (Searcher/testids, #41 span, useCityFAQs, reserveAnchor, intermediación en legales, sin id duplicado, bg-linear).
+- **Runtime**: paso 8, `agent-browser` + `vitals` en preview, incl. la ruta `buscar-vehiculos` con params (resultados).
+- **E2E**: `BRAND=alquilame` contra el preview (city + legales), comparar vs baseline.
+
+### Rollout
+- Commits faseados (`feat(alquilame): F2 step NN …`, `Refs #112`). Push gated. PR `Refs #112` (NO Closes — F3 cierra #112). Merge tras runtime verde.

--- a/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/plan.md
+++ b/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/plan.md
@@ -12,16 +12,17 @@
 
 Todo bajo `packages/ui-alquilame/` (aislamiento F2 — `logic/`, rutas y otras marcas intactas).
 
-**MODIFICADOS (F1 reuse — prereq):**
+**MODIFICADO (F1 reuse — prereq):**
 | Archivo | Cambio |
 |---|---|
-| `app/components/home/Contact.vue` | Añadir prop `reserveAnchor?: string` (default `'#hero'`); el CTA "Reserva Ahora" usa `:href="reserveAnchor"`. En city se pasa `#searcher`. Backward-compat con el home. |
-| `app/components/home/Reviews.vue` | Añadir prop opcional de heading city-targeted (p.ej. `cityName?: string`) → heading "…en {cityName}" cuando se pasa; sin prop = copy actual (home). |
+| `app/components/home/Contact.vue` | Añadir prop `reserveAnchor?: string` (default `'#hero'`); el CTA "Reserva Ahora" usa `:href="reserveAnchor"`. En city se pasa `#searcher`. Backward-compat con el home (sin prop = `#hero`). |
+
+> `HomeReviews` **NO** se modifica ni se reusa en city: el `#testimonios` city se restila in-place con `props.city.testimonials` (ver City Testimonios abajo).
 
 **MODIFICADO (página principal F2):**
 | Archivo | Cambio |
 |---|---|
-| `app/components/CityPage.vue` | Restyle al diseño city: hero (preservar `Searcher`/#41/#109), secciones SEO restiladas, montar marketing F1 (`HomeFleet`/`HomeHowItWorks`/`HomeRequirements`/`HomeContact reserveAnchor="#searcher"`), **reemplazar** `#testimonios` por `HomeReviews :cityName`, **mantener** `#faqs` city (`useCityFAQs`), preservar `#seleccion-categorias`/`cityBranches`. Regla "replace not append" (sin `id` duplicado). |
+| `app/components/CityPage.vue` | Orquestador: hero (preservar `Searcher`/#41/#109), secciones SEO restiladas, montar marketing F1 (`HomeFleet`/`HomeHowItWorks`/`HomeRequirements`/`HomeContact reserveAnchor="#searcher"`), **restyle in-place** `#testimonios` (city.testimonials) y `#faqs` (`useCityFAQs`), preservar `#seleccion-categorias`/`cityBranches`. Regla "replace not append" para los marketing nuevos (sin `id` duplicado). |
 
 **NUEVOS (extracción de secciones city SEO — decomposición, opcional pero recomendada):**
 | Archivo | Responsabilidad |
@@ -31,6 +32,7 @@ Todo bajo `packages/ui-alquilame/` (aislamiento F2 — `logic/`, rutas y otras m
 | `app/components/city/SeoContent.vue` | ventajas/destinos/consejos/temporada/ciudades-cercanas (texto SEO, restilizado) — o un componente por sección si crece |
 | `app/components/city/DeliveryPoints.vue` | `#puntos-entrega` (`cityBranches`) |
 | `app/components/city/Faq.vue` | `#faqs` city (`useCityFAQs`, restilizado in-place) |
+| `app/components/city/Testimonios.vue` | `#testimonios` city (`props.city.testimonials` + heading city, restilizado) |
 
 > CityPage queda como **orquestador** (mirror del patrón `home/*` de F1): monta `city/*` + los `home/*` reusados + preserva el bloque condicional de resultados. Cada sección = componente con responsabilidad única, testeable.
 
@@ -42,11 +44,11 @@ Todo bajo `packages/ui-alquilame/` (aislamiento F2 — `logic/`, rutas y otras m
 
 ### Pasos de implementación (SDD)
 
-> Cada paso preserva el engine y deja la city landing renderizando. Tamaño ≤ M. Tests en `app/components/city/__tests__/` o `tests/`.
+> **Ordering**: los pasos 2–5 **cablean cada componente `city/*` en CityPage como drop-in replacement** de la sección inline equivalente (incremental → CityPage renderiza verde tras cada paso). El paso 6 monta las secciones de marketing F1 **nuevas** (no existían en city). Cada paso preserva el engine. Tamaño ≤ M. Tests en `app/components/city/__tests__/` o `tests/`.
 
-1. **F1 reuse props** | S | deps: none
-   - Escenario: `HomeContact` acepta `reserveAnchor` (CTA ancla ahí; default `#hero` = home intacto); `HomeReviews` acepta `cityName` (heading city-targeted).
-   - AC: props añadidas backward-compat; el home (sin props) no cambia; test: default `#hero` en Contact, heading city con prop en Reviews; sin `bg-gradient-to-`.
+1. **HomeContact reserveAnchor prop** | S | deps: none
+   - Escenario: `HomeContact` acepta `reserveAnchor` (CTA "Reserva Ahora" ancla ahí; default `#hero` → home intacto).
+   - AC: prop backward-compat; el home (sin prop) no cambia; test: default `#hero`, override aplica al `:href`; sin `bg-gradient-to-`.
 
 2. **City hero restyle** | M | deps: 1
    - Escenario (SCEN-F2-01, F2-06): `city/Hero.vue` con estilo del diseño (rojo `bg-linear`, h1 "Alquiler de carros en {city}"), `Searcher` preservado (testids `pickup/return-location-test`, navega a `buscar-vehiculos`), pin #41 inerte (`<span aria-hidden>`), `[--ctx-text-primary:#fff]`, sin `Date` horneado (#109).
@@ -60,12 +62,12 @@ Todo bajo `packages/ui-alquilame/` (aislamiento F2 — `logic/`, rutas y otras m
    - Escenario (SCEN-F2-04): `city/DeliveryPoints.vue` restila `#puntos-entrega` con `cityBranches` reales.
    - AC: itera `cityBranches`, estilo diseño; test: v-for branches, presente solo si `cityBranches.length > 0`.
 
-5. **FAQ city restyle** | S | deps: 1
-   - Escenario (SCEN-F2-02): `city/Faq.vue` restila `#faqs` **manteniendo `useCityFAQs(city.name)`** (NO HomeFaq); el schema `useCityFAQSchema` en `useCityPageSEO` no se toca.
-   - AC: acordeón con `useCityFAQs`; test: usa `useCityFAQs` (no `useData().faqs`), `.heading-*`.
+5. **FAQ + Testimonios city restyle (in-place)** | M | deps: 1
+   - Escenario (SCEN-F2-02): `city/Faq.vue` restila `#faqs` **manteniendo `useCityFAQs(city.name)`** (NO HomeFaq; el schema `useCityFAQSchema` en `useCityPageSEO` no se toca); `city/Testimonios.vue` restila `#testimonios` **manteniendo `props.city.testimonials`** + heading city-targeted (`useCityAggregateRating` consistente).
+   - AC: ambos cableados en CityPage (drop-in); FAQ usa `useCityFAQs` (no `useData().faqs`); Testimonios usa `city.testimonials` (no `franchiseTestimonials`); test: fuentes correctas, heading city, `.heading-*`, bg-linear.
 
-6. **Mount F1 marketing + replace testimonios** | M | deps: 1,2,3,4,5
-   - Escenario (SCEN-F2-03, F2-05): CityPage orquesta — monta `HomeFleet`/`HomeHowItWorks`/`HomeRequirements`/`HomeContact reserveAnchor="#searcher"`, **reemplaza** `#testimonios` por `<HomeReviews :cityName>`, **preserva** `#seleccion-categorias` condicional intacto. Sin `id` duplicado.
+6. **Mount F1 marketing (nuevas) + orquestación** | M | deps: 1,2,3,4,5
+   - Escenario (SCEN-F2-03, F2-05): CityPage orquesta — monta las secciones de marketing **nuevas** `HomeFleet`/`HomeHowItWorks`/`HomeRequirements`/`HomeContact reserveAnchor="#searcher"`, **preserva** `#seleccion-categorias` condicional intacto. Sin `id` duplicado (`#contact`/`#requisitos` no existían en city; verificar).
    - AC: secciones marketing montadas; "Reserva Ahora" ancla a `#searcher`; resultados condicionales intactos; test: componentes montados, cero `id` duplicado, reserveAnchor=#searcher, CategorySelectionSection preservado.
 
 7. **Legales restyle** | M | deps: none

--- a/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step01/task-01-homecontact-reserveanchor.code-task.md
+++ b/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step01/task-01-homecontact-reserveanchor.code-task.md
@@ -1,0 +1,60 @@
+## Status: PENDING
+## Blocked-By:
+## Completed:
+
+# Task: F2 Step 1 — HomeContact `reserveAnchor` prop (F1 reuse prereq)
+
+## Description
+Añadir una prop `reserveAnchor?: string` a `app/components/home/Contact.vue` para que el CTA "Reserva Ahora" pueda anclar a un target distinto según la página. Default `'#hero'` (home intacto); la city landing pasará `'#searcher'` (su hero no tiene `#hero`).
+
+## Background
+`HomeContact` se reusará en la city landing (F2). Hoy hardcodea `href="#hero"` (id del home); en la city page ese id NO existe (el scroll target es `#searcher`) → ancla muerta. Esta prop lo hace reusable sin romper el home.
+
+## Reference Documentation
+**Required:**
+- Design: `docs/specs/2026-06-11-issue-112-f2-landing-legal-design.md` (mapeo `#contact`, nota `reserveAnchor`)
+**Additional:**
+- Plan: `docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/plan.md` (paso 1)
+- `app/components/home/Contact.vue` (hoy `href="#hero"`)
+
+**Note:** Leer el detailed design antes de implementar.
+
+## Technical Requirements
+1. `defineProps` con `reserveAnchor?: string` default `'#hero'`.
+2. El CTA "Reserva Ahora" usa `:href="reserveAnchor"`.
+3. Backward-compat: el home (sin pasar la prop) sigue anclando a `#hero` — cero cambio visible.
+4. Sin `bg-gradient-to-*`.
+
+## Dependencies
+- **F1 mergeado**: `home/Contact.vue` existe.
+
+## Implementation Approach
+1. Añadir `const props = withDefaults(defineProps<{ reserveAnchor?: string }>(), { reserveAnchor: '#hero' })`.
+2. Cambiar el `href="#hero"` del CTA a `:href="reserveAnchor"`.
+3. Test: default `#hero`, override aplica al `:href`.
+
+## Acceptance Criteria
+1. **Prop con default**
+   - Given `HomeContact` sin props
+   - When renderiza
+   - Then el CTA "Reserva Ahora" ancla a `#hero` (home intacto).
+2. **Override**
+   - Given `<HomeContact reserveAnchor="#searcher" />`
+   - When renderiza
+   - Then el CTA ancla a `#searcher`.
+3. **Test de contrato**
+   - Given el componente
+   - When corre el unit test
+   - Then valida default `#hero` + override + ausencia de `bg-gradient-to-`.
+
+## Metadata
+- **Complexity**: Low
+- **Estimated Effort**: S
+- **Labels**: alquilame, f2, reuse, contact
+- **Required Skills**: Vue 3
+- **Related Tasks**: bloquea steps 2,6
+- **Step**: 01 of 08
+- **Files to Modify**: `app/components/home/Contact.vue`, `app/components/home/__tests__/contact-announcement.test.ts` (extender)
+- **Files to Read**: `app/components/home/Contact.vue`
+- **Context Estimate**: S
+- **Scenario-Strategy**: required

--- a/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step01/task-01-homecontact-reserveanchor.code-task.md
+++ b/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step01/task-01-homecontact-reserveanchor.code-task.md
@@ -1,6 +1,6 @@
-## Status: PENDING
+## Status: COMPLETED
 ## Blocked-By:
-## Completed:
+## Completed: 2026-06-11
 
 # Task: F2 Step 1 — HomeContact `reserveAnchor` prop (F1 reuse prereq)
 

--- a/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step02/task-02-city-hero.code-task.md
+++ b/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step02/task-02-city-hero.code-task.md
@@ -1,0 +1,64 @@
+## Status: PENDING
+## Blocked-By: step01/task-01-homecontact-reserveanchor.code-task.md
+## Completed:
+
+# Task: F2 Step 2 — City hero restyle (preservar Searcher/#41/#109)
+
+## Description
+Extraer y restilizar el hero de la city landing a `app/components/city/Hero.vue` con el estilo del diseño (rojo, h1 city-targeted), cableado en `CityPage.vue` como drop-in del hero inline actual. Preserva el motor de búsqueda (`Searcher`), el pin secreto #41 y el guard de hidratación #109.
+
+## Background
+El hero actual de `CityPage.vue` tiene `UPageHero` con `Searcher` (testids `pickup-location-test`/`return-location-test`), el pin inerte #41 (`<span aria-hidden>` copy-to-WhatsApp, NO `<button>`), e imágenes. F2 lo restila SIN tocar el comportamiento del searcher (sigue navegando a `/{city}/buscar-vehiculos/...`) ni reintroducir el `<button>` del #41. Lecciones F1: `bg-linear-to-*`, `[--ctx-text-primary:#fff]` (hero rojo → headings blancos), `.heading-*`.
+
+## Reference Documentation
+**Required:**
+- Design: `docs/specs/2026-06-11-issue-112-f2-landing-legal-design.md` (SCEN-F2-01, F2-06; fila hero)
+**Additional:**
+- `app/components/CityPage.vue` (hero actual, líneas ~1-91)
+- `app/components/Searcher.vue` (preservar testids)
+- Diseño: `/tmp/alqui_f1_design/dist/alquiler-de-carros-bogota/index.html` (`<section id="hero">`)
+- `[[reference_tailwind4_gradient_bg_linear]]`
+
+**Note:** Leer el detailed design antes de implementar.
+
+## Technical Requirements
+1. `city/Hero.vue` con estilo del diseño: gradiente rojo `bg-linear-to-*` + `[--ctx-text-primary:#fff]`, h1 city-targeted "Alquiler de carros en {city}".
+2. **Preservar `Searcher`** (mismos testids, mismo destino `buscar-vehiculos`) y `#searcher` scroll target.
+3. **Preservar el pin #41**: `<span aria-hidden>` inerte (NO `<button>`, fuera del accessible name del `<h1>`).
+4. **#109**: sin `Date`/`today()` horneado en SSR/ISR.
+5. Cableado en `CityPage.vue` reemplazando el hero inline; `aspect-ratio` en imágenes (CLS).
+
+## Dependencies
+- **Step 1** (no estricto, pero comparte la rama). **`Searcher.vue`**, **datos `city`** (props de CityPage).
+
+## Implementation Approach
+1. Crear `city/Hero.vue` recibiendo `city` (y lo que el hero necesite).
+2. Portar `Searcher` + pin #41 + imágenes; aplicar estilo del diseño.
+3. Reemplazar el bloque hero inline de `CityPage.vue` por `<CityHero :city="..." />`.
+4. Test: Searcher presente con testids, pin `<span aria-hidden>`, bg-linear + ctx-text-primary, h1 city.
+
+## Acceptance Criteria
+1. **Hero city restilizado + Searcher (SCEN-F2-01)**
+   - Given `/{city}`
+   - When se ve el hero
+   - Then tiene el estilo del diseño y el `Searcher` funciona igual (testids `pickup/return-location-test`, navega a `buscar-vehiculos`).
+2. **Pin #41 + #109 (SCEN-F2-06)**
+   - Given el hero
+   - When se inspecciona
+   - Then el pin es `<span aria-hidden>` inerte (no `<button>`) y no hay `Date`/`today()` horneado.
+3. **Test de contrato**
+   - Given el componente
+   - When corre el unit test
+   - Then valida Searcher+testids, pin span, `bg-linear`, `[--ctx-text-primary`, ausencia de `bg-gradient-to-`.
+
+## Metadata
+- **Complexity**: Medium
+- **Estimated Effort**: M
+- **Labels**: alquilame, f2, city, hero, engine-preserve
+- **Required Skills**: Vue 3, @nuxt/ui v4, Tailwind 4
+- **Related Tasks**: Blocked-By step 1
+- **Step**: 02 of 08
+- **Files to Modify**: `app/components/city/Hero.vue` (nuevo), `app/components/CityPage.vue`, `app/components/city/__tests__/Hero.test.ts` (nuevo)
+- **Files to Read**: `app/components/CityPage.vue`, `app/components/Searcher.vue`, `/tmp/alqui_f1_design/dist/alquiler-de-carros-bogota/index.html`
+- **Context Estimate**: M
+- **Scenario-Strategy**: required

--- a/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step02/task-02-city-hero.code-task.md
+++ b/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step02/task-02-city-hero.code-task.md
@@ -1,6 +1,6 @@
-## Status: PENDING
+## Status: COMPLETED
 ## Blocked-By: step01/task-01-homecontact-reserveanchor.code-task.md
-## Completed:
+## Completed: 2026-06-11
 
 # Task: F2 Step 2 — City hero restyle (preservar Searcher/#41/#109)
 

--- a/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step03/task-03-city-seo-content.code-task.md
+++ b/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step03/task-03-city-seo-content.code-task.md
@@ -1,0 +1,62 @@
+## Status: PENDING
+## Blocked-By: step01/task-01-homecontact-reserveanchor.code-task.md
+## Completed:
+
+# Task: F2 Step 3 — City SEO content restyle (preservar texto indexable)
+
+## Description
+Extraer y restilizar las secciones de contenido SEO de la city landing a `app/components/city/Intro.vue` + `app/components/city/SeoContent.vue`, cableadas en `CityPage.vue` como drop-in. **Todo el texto SEO se preserva** (indexable); solo cambia el estilo.
+
+## Background
+`CityPage.vue` tiene secciones de contenido SEO city-specific: `#descripcion`, `#introduccion` (→ `#intro` del diseño), `#ventajas`, `#destinos`, `#consejos-conduccion`, `#mejor-temporada`, `#ciudades-cercanas`. Son activos SEO (texto indexable). F2 las restila al diseño SIN remover contenido (decisión: preservar todo el SEO).
+
+## Reference Documentation
+**Required:**
+- Design: `docs/specs/2026-06-11-issue-112-f2-landing-legal-design.md` (SCEN-F2-02; filas de contenido SEO)
+**Additional:**
+- `app/components/CityPage.vue` (secciones ~102-322)
+- Diseño: `/tmp/alqui_f1_design/dist/alquiler-de-carros-bogota/index.html` (`#intro` y estilo de secciones)
+- `app/components/city/Hero.vue` (sibling conventions, step 2)
+
+**Note:** Leer el detailed design antes de implementar.
+
+## Technical Requirements
+1. `city/Intro.vue`: intro/descripcion + introduccion con el estilo `#intro` del diseño; **texto preservado**.
+2. `city/SeoContent.vue`: ventajas/destinos/consejos/temporada/ciudades-cercanas restiladas; **texto preservado** (o un componente por sección si crece — mantener ≤ responsabilidad clara).
+3. Cableadas en `CityPage.vue` como drop-in de las secciones inline equivalentes.
+4. `bg-linear-to-*`, `.heading-*` (Plus Jakarta); `[--ctx-text-primary:#fff]` solo si la sección es de fondo oscuro.
+
+## Dependencies
+- **Step 1** (rama). Datos `city` (props CityPage), `relatedCities`.
+
+## Implementation Approach
+1. Crear `city/Intro.vue` y `city/SeoContent.vue` recibiendo `city`/`relatedCities`.
+2. Portar el texto SEO actual verbatim + aplicar estilo del diseño.
+3. Cablear en `CityPage.vue`.
+4. Test: cada sección/heading presente con su texto; sin pérdida de copy.
+
+## Acceptance Criteria
+1. **SEO content preservado (SCEN-F2-02)**
+   - Given `/{city}`
+   - When se inspecciona el texto
+   - Then todas las secciones SEO (descripcion/intro/ventajas/destinos/consejos/temporada/ciudades-cercanas) están presentes con su contenido indexable, restiladas.
+2. **Estilo del diseño**
+   - Given las secciones
+   - When se ven
+   - Then usan `.heading-*` + `bg-linear`, sin `bg-gradient-to-`.
+3. **Test de contrato**
+   - Given los componentes
+   - When corre el unit test
+   - Then valida presencia de cada sección + su texto clave + `.heading-*`.
+
+## Metadata
+- **Complexity**: Medium
+- **Estimated Effort**: M
+- **Labels**: alquilame, f2, city, seo, content
+- **Required Skills**: Vue 3, Tailwind 4
+- **Related Tasks**: Blocked-By step 1
+- **Step**: 03 of 08
+- **Files to Modify**: `app/components/city/Intro.vue` (nuevo), `app/components/city/SeoContent.vue` (nuevo), `app/components/CityPage.vue`, `app/components/city/__tests__/seo-content.test.ts` (nuevo)
+- **Files to Read**: `app/components/CityPage.vue`, `/tmp/alqui_f1_design/dist/alquiler-de-carros-bogota/index.html`
+- **Context Estimate**: M
+- **Scenario-Strategy**: required

--- a/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step03/task-03-city-seo-content.code-task.md
+++ b/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step03/task-03-city-seo-content.code-task.md
@@ -1,6 +1,6 @@
-## Status: PENDING
+## Status: COMPLETED
 ## Blocked-By: step01/task-01-homecontact-reserveanchor.code-task.md
-## Completed:
+## Completed: 2026-06-11
 
 # Task: F2 Step 3 — City SEO content restyle (preservar texto indexable)
 

--- a/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step04/task-04-city-delivery-points.code-task.md
+++ b/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step04/task-04-city-delivery-points.code-task.md
@@ -1,6 +1,6 @@
-## Status: PENDING
+## Status: COMPLETED
 ## Blocked-By: step01/task-01-homecontact-reserveanchor.code-task.md
-## Completed:
+## Completed: 2026-06-11
 
 # Task: F2 Step 4 — Puntos-entrega restyle (branches reales)
 

--- a/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step04/task-04-city-delivery-points.code-task.md
+++ b/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step04/task-04-city-delivery-points.code-task.md
@@ -1,0 +1,60 @@
+## Status: PENDING
+## Blocked-By: step01/task-01-homecontact-reserveanchor.code-task.md
+## Completed:
+
+# Task: F2 Step 4 — Puntos-entrega restyle (branches reales)
+
+## Description
+Extraer y restilizar `#puntos-entrega` a `app/components/city/DeliveryPoints.vue`, cableado en `CityPage.vue` como drop-in. Lista los `cityBranches` reales con el estilo del diseño.
+
+## Background
+`CityPage.vue` (`#puntos-entrega`, ~182-208) lista los branches de la ciudad (`cityBranches`, derivado de los datos de sucursales). Solo se renderiza si `cityBranches.length > 0`. F2 lo restila preservando los datos.
+
+## Reference Documentation
+**Required:**
+- Design: `docs/specs/2026-06-11-issue-112-f2-landing-legal-design.md` (SCEN-F2-04; fila puntos-entrega)
+**Additional:**
+- `app/components/CityPage.vue` (`#puntos-entrega`, `cityBranches` computed ~416)
+- Diseño: `/tmp/alqui_f1_design/dist/alquiler-de-carros-bogota/index.html` (`#puntos-entrega`)
+
+**Note:** Leer el detailed design antes de implementar.
+
+## Technical Requirements
+1. `city/DeliveryPoints.vue` itera `cityBranches` (pasados como prop) con el estilo del diseño.
+2. Solo renderiza si hay branches (`v-if="cityBranches.length > 0"`).
+3. `bg-linear-to-*`, `.heading-*`; CLS-safe.
+
+## Dependencies
+- **Step 1** (rama). `cityBranches` (computed en CityPage).
+
+## Implementation Approach
+1. Crear `city/DeliveryPoints.vue` recibiendo `cityBranches` (+ `city` si hace falta para textos).
+2. Portar el markup de branches + estilo del diseño.
+3. Cablear en `CityPage.vue` (drop-in, mantener el `v-if`).
+4. Test: v-for branches, condicional por longitud.
+
+## Acceptance Criteria
+1. **Puntos-entrega restilizado (SCEN-F2-04)**
+   - Given una ciudad con branches
+   - When se ve `#puntos-entrega`
+   - Then lista los `cityBranches` reales con el estilo del diseño.
+2. **Condicional**
+   - Given una ciudad sin branches
+   - When renderiza
+   - Then la sección no aparece.
+3. **Test de contrato**
+   - Given el componente
+   - When corre el unit test
+   - Then valida v-for sobre branches + el guard de longitud + `.heading-*`.
+
+## Metadata
+- **Complexity**: Low
+- **Estimated Effort**: S
+- **Labels**: alquilame, f2, city, branches
+- **Required Skills**: Vue 3
+- **Related Tasks**: Blocked-By step 1
+- **Step**: 04 of 08
+- **Files to Modify**: `app/components/city/DeliveryPoints.vue` (nuevo), `app/components/CityPage.vue`, `app/components/city/__tests__/DeliveryPoints.test.ts` (nuevo)
+- **Files to Read**: `app/components/CityPage.vue`, `/tmp/alqui_f1_design/dist/alquiler-de-carros-bogota/index.html`
+- **Context Estimate**: S
+- **Scenario-Strategy**: required

--- a/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step05/task-05-city-faq-testimonios.code-task.md
+++ b/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step05/task-05-city-faq-testimonios.code-task.md
@@ -1,0 +1,61 @@
+## Status: PENDING
+## Blocked-By: step01/task-01-homecontact-reserveanchor.code-task.md
+## Completed:
+
+# Task: F2 Step 5 — FAQ + Testimonios city restyle (in-place, datos city)
+
+## Description
+Extraer y restilizar `#faqs` y `#testimonios` de la city landing a `app/components/city/Faq.vue` + `app/components/city/Testimonios.vue`, cableados en `CityPage.vue` como drop-in. **Mantienen sus datos city-specific** — NO se reusan los componentes brand-level de F1.
+
+## Background
+- `#faqs` city usa `useCityFAQs(city.name)` (FAQs city-specific: pico y placa, El Dorado, etc.) — distinto de `HomeFaq` (que usa `useData().faqs` brand-level). Reusar HomeFaq = regresión de contenido SEO city. El schema `FAQPage` city lo emite `useCityFAQSchema` dentro de `useCityPageSEO` (en `[city]/index.vue`), NO acá → **no moverlo**.
+- `#testimonios` city usa `props.city.testimonials` (city-specific) y alimenta `useCityAggregateRating`. Reusar `HomeReviews` (`franchiseTestimonials` brand-level) cambiaría el display y arriesga inconsistencia con el `AggregateRating` city.
+
+## Reference Documentation
+**Required:**
+- Design: `docs/specs/2026-06-11-issue-112-f2-landing-legal-design.md` (SCEN-F2-02; filas faqs/testimonios; nota schema)
+**Additional:**
+- `app/components/CityPage.vue` (`#faqs` ~324-344 `useCityFAQs`; `#testimonios` ~345-... `city.testimonials`)
+- Diseño: `/tmp/alqui_f1_design/dist/alquiler-de-carros-bogota/index.html` (`#faq`, `#google-reviews`)
+
+**Note:** Leer el detailed design antes de implementar.
+
+## Technical Requirements
+1. `city/Faq.vue`: acordeón con `useCityFAQs(city.name)` (NO `useData().faqs`), estilo del diseño. **No** inline el `FAQPage` schema (queda en `useCityPageSEO`).
+2. `city/Testimonios.vue`: cards con `props.city.testimonials`, **heading city-targeted** ("…en {city.name}"), estilo del diseño. `useCityAggregateRating` queda consistente con lo mostrado.
+3. Cableados en `CityPage.vue` como drop-in de las secciones inline.
+4. `bg-linear-to-*`, `.heading-*`.
+
+## Dependencies
+- **Step 1** (rama). `useCityFAQs`, `props.city.testimonials`.
+
+## Implementation Approach
+1. Crear `city/Faq.vue` (usa `useCityFAQs`) y `city/Testimonios.vue` (usa `city.testimonials` + heading city).
+2. Cablear en `CityPage.vue` (drop-in).
+3. Test: Faq usa `useCityFAQs`, Testimonios usa `city.testimonials` + heading city.
+
+## Acceptance Criteria
+1. **FAQ city in-place (SCEN-F2-02)**
+   - Given la city landing
+   - When se ve `#faqs`
+   - Then el acordeón usa `useCityFAQs(city.name)` (FAQs city-specific), restilado; el schema no se movió.
+2. **Testimonios city in-place**
+   - Given la city landing
+   - When se ve `#testimonios`
+   - Then usa `props.city.testimonials` con heading city-targeted; `useCityAggregateRating` consistente.
+3. **Test de contrato**
+   - Given los componentes
+   - When corre el unit test
+   - Then Faq referencia `useCityFAQs` (no `useData().faqs`), Testimonios referencia `city.testimonials` (no `franchiseTestimonials`), heading city, `.heading-*`.
+
+## Metadata
+- **Complexity**: Medium
+- **Estimated Effort**: M
+- **Labels**: alquilame, f2, city, faq, testimonios, seo
+- **Required Skills**: Vue 3, @nuxt/ui v4
+- **Related Tasks**: Blocked-By step 1
+- **Step**: 05 of 08
+- **Files to Modify**: `app/components/city/Faq.vue` (nuevo), `app/components/city/Testimonios.vue` (nuevo), `app/components/CityPage.vue`, `app/components/city/__tests__/faq-testimonios.test.ts` (nuevo)
+- **Files to Read**: `app/components/CityPage.vue`, `/tmp/alqui_f1_design/dist/alquiler-de-carros-bogota/index.html`
+- **Context Estimate**: M
+- **Scenario-Strategy**: required

--- a/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step05/task-05-city-faq-testimonios.code-task.md
+++ b/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step05/task-05-city-faq-testimonios.code-task.md
@@ -1,6 +1,6 @@
-## Status: PENDING
+## Status: COMPLETED
 ## Blocked-By: step01/task-01-homecontact-reserveanchor.code-task.md
-## Completed:
+## Completed: 2026-06-11
 
 # Task: F2 Step 5 — FAQ + Testimonios city restyle (in-place, datos city)
 

--- a/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step06/task-06-mount-f1-marketing.code-task.md
+++ b/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step06/task-06-mount-f1-marketing.code-task.md
@@ -1,6 +1,6 @@
-## Status: PENDING
+## Status: COMPLETED
 ## Blocked-By: step01/task-01-homecontact-reserveanchor.code-task.md, step02/task-02-city-hero.code-task.md, step03/task-03-city-seo-content.code-task.md, step04/task-04-city-delivery-points.code-task.md, step05/task-05-city-faq-testimonios.code-task.md
-## Completed:
+## Completed: 2026-06-11
 
 # Task: F2 Step 6 — Montar marketing F1 + orquestación CityPage
 

--- a/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step06/task-06-mount-f1-marketing.code-task.md
+++ b/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step06/task-06-mount-f1-marketing.code-task.md
@@ -1,0 +1,62 @@
+## Status: PENDING
+## Blocked-By: step01/task-01-homecontact-reserveanchor.code-task.md, step02/task-02-city-hero.code-task.md, step03/task-03-city-seo-content.code-task.md, step04/task-04-city-delivery-points.code-task.md, step05/task-05-city-faq-testimonios.code-task.md
+## Completed:
+
+# Task: F2 Step 6 — Montar marketing F1 + orquestación CityPage
+
+## Description
+En `CityPage.vue` (ya orquestador con los `city/*` de los pasos 2-5), montar las secciones de marketing **nuevas** reusando componentes `home/*` de F1: `HomeFleet`, `HomeHowItWorks`, `HomeRequirements`, `HomeContact` (con `reserveAnchor="#searcher"`). Preservar el bloque condicional de resultados intacto.
+
+## Background
+El diseño city incluye secciones de marketing (fleet, how-it-works, requirements, contact) idénticas a las del home → reusar los `home/*` de F1 (DRY). Estas secciones NO existían en la city (`#contact`/`#requisitos` no colisionan; `#fleet`/how-it-works tampoco). El bloque de resultados live `#seleccion-categorias` (`CategorySelectionSection`, condicional por params) se preserva — la ruta `buscar-vehiculos` renderiza el mismo CityPage.
+
+## Reference Documentation
+**Required:**
+- Design: `docs/specs/2026-06-11-issue-112-f2-landing-legal-design.md` (SCEN-F2-03, F2-05; marketing del diseño + regla anti-colisión)
+**Additional:**
+- `app/components/CityPage.vue` (orquestador tras steps 2-5; `#seleccion-categorias`)
+- `app/components/home/{Fleet,HowItWorks,Requirements,Contact}.vue` (F1)
+
+**Note:** Leer el detailed design antes de implementar.
+
+## Technical Requirements
+1. Montar `<HomeFleet />`, `<HomeHowItWorks />`, `<HomeRequirements />`, `<HomeContact reserveAnchor="#searcher" />` en el orden del diseño city.
+2. **Preservar `#seleccion-categorias`/`CategorySelectionSection` intacto** (condicional por params; no tocar el engine de resultados).
+3. **Sin `id` duplicado**: verificar que `#contact`/`#requisitos`/`#fleet`/`#how-it-works` no existan ya en city (no colisionan). El `#testimonios`/`#faqs` city son los de los pasos 5 (no duplicar).
+4. `HomeContact` ancla "Reserva Ahora" a `#searcher` (hero city), no al `#hero` inexistente.
+
+## Dependencies
+- **Steps 1-5** (reserveAnchor prop + `city/*` cableados).
+- **`home/*` de F1** (auto-import).
+
+## Implementation Approach
+1. En `CityPage.vue`, montar los 4 componentes de marketing en el orden del diseño.
+2. Pasar `reserveAnchor="#searcher"` a `HomeContact`.
+3. Confirmar el bloque condicional de resultados sin cambios.
+4. Test: componentes montados, reserveAnchor=#searcher, cero `id` duplicado, `CategorySelectionSection` preservado.
+
+## Acceptance Criteria
+1. **Marketing F1 montado (SCEN-F2-03)**
+   - Given la city landing
+   - When se recorre
+   - Then existen fleet/how-it-works/requirements/contact (de F1), y "Reserva Ahora" ancla a `#searcher`.
+2. **Resultados condicionales intactos (SCEN-F2-05)**
+   - Given una ruta `buscar-vehiculos` con params
+   - When renderiza
+   - Then `#seleccion-categorias`/`CategorySelectionSection` muestra resultados como hoy (engine sin cambios).
+3. **Test de contrato**
+   - Given `CityPage.vue`
+   - When corre el unit test
+   - Then valida los 4 montajes, `reserveAnchor="#searcher"`, cero `id` duplicado, `CategorySelectionSection` presente.
+
+## Metadata
+- **Complexity**: Medium
+- **Estimated Effort**: M
+- **Labels**: alquilame, f2, city, marketing, reuse, engine-preserve
+- **Required Skills**: Vue 3, @nuxt/ui v4
+- **Related Tasks**: Blocked-By steps 1-5
+- **Step**: 06 of 08
+- **Files to Modify**: `app/components/CityPage.vue`, `app/components/city/__tests__/orchestration.test.ts` (nuevo)
+- **Files to Read**: `app/components/CityPage.vue`, `app/components/home/Contact.vue`, `app/components/home/Fleet.vue`
+- **Context Estimate**: M
+- **Scenario-Strategy**: required

--- a/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step07/task-07-legal-restyle.code-task.md
+++ b/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step07/task-07-legal-restyle.code-task.md
@@ -1,6 +1,6 @@
-## Status: PENDING
+## Status: COMPLETED
 ## Blocked-By:
-## Completed:
+## Completed: 2026-06-11
 
 # Task: F2 Step 7 — Legales restyle (estilo diseño, contenido de intermediación preservado)
 

--- a/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step07/task-07-legal-restyle.code-task.md
+++ b/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step07/task-07-legal-restyle.code-task.md
@@ -1,0 +1,61 @@
+## Status: PENDING
+## Blocked-By:
+## Completed:
+
+# Task: F2 Step 7 — Legales restyle (estilo diseño, contenido de intermediación preservado)
+
+## Description
+Restilizar `app/pages/terminos-condiciones.vue` y `app/pages/politica-privacidad.vue` al estilo del diseño (layout de documento legal limpio, `font-heading` en h2s numerados) **conservando el contenido legal actual** — incluido el encuadre de intermediación. NO reemplazar el texto por el copy del diseño (operador directo).
+
+## Background
+El copy legal del diseño describe a alquilame como **operador directo** de alquiler y dropea "plataforma de intermediación / no somos empresa de alquiler" (modelo AMAW agregador). Reemplazarlo tergiversa el modelo de negocio → riesgo legal. Decisión: aplicar el ESTILO del diseño al CONTENIDO actual (con sus disclaimers de intermediación). El cambio de posicionamiento queda pendiente de validación legal.
+
+## Reference Documentation
+**Required:**
+- Design: `docs/specs/2026-06-11-issue-112-f2-landing-legal-design.md` (SCEN-F2-07, F2-07b; Parte B)
+**Additional:**
+- `app/pages/terminos-condiciones.vue` (contenido actual, intermediación en sec. 2/7/8)
+- `app/pages/politica-privacidad.vue`
+- Diseño: `/tmp/alqui_f1_design/dist/{terminos,privacidad}/index.html` (SOLO estilo/layout, NO copiar el texto)
+
+**Note:** Leer el detailed design antes de implementar.
+
+## Technical Requirements
+1. Aplicar el estilo del diseño (layout legal, `font-heading` en h2 numerados, tipografía/espaciado) al **contenido actual** de ambas páginas.
+2. **Conservar el encuadre de intermediación** ("plataforma de intermediación / no somos empresa de alquiler") — NO sustituir por el copy operador-directo del diseño.
+3. Preservar `useSeoMeta`/`definePageMeta`/layout; los enlaces del footer (`politica-privacidad`, `terminos-condiciones`) siguen resolviendo 200.
+4. `bg-linear-to-*` si aplica; headings `.heading-*`/`font-heading`.
+
+## Dependencies
+- **(ninguna de otros steps)** — independiente.
+
+## Implementation Approach
+1. Restilizar el template de cada página (h1/h2 con `font-heading`, layout de documento legal del diseño).
+2. Mantener el texto/secciones actuales (intermediación) intactos.
+3. Test: estilo aplicado + disclaimer de intermediación presente + sin copy operador-directo del diseño.
+
+## Acceptance Criteria
+1. **Estilo del diseño (SCEN-F2-07)**
+   - Given `/terminos-condiciones` y `/politica-privacidad`
+   - When se ven
+   - Then tienen el layout legal del diseño (`font-heading` en h2s) y los enlaces del footer resuelven 200.
+2. **Intermediación preservada (SCEN-F2-07b)**
+   - Given `/terminos-condiciones`
+   - When se inspecciona el contenido
+   - Then conserva "plataforma de intermediación / no somos empresa de alquiler" — NO se reemplazó por el copy operador-directo del diseño.
+3. **Test de contrato**
+   - Given las páginas
+   - When corre el unit test
+   - Then valida h2 `font-heading` + presencia del disclaimer de intermediación + ausencia de marcadores del copy operador-directo.
+
+## Metadata
+- **Complexity**: Medium
+- **Estimated Effort**: M
+- **Labels**: alquilame, f2, legal, terminos, privacidad
+- **Required Skills**: Vue 3, Tailwind 4
+- **Related Tasks**: independiente
+- **Step**: 07 of 08
+- **Files to Modify**: `app/pages/terminos-condiciones.vue`, `app/pages/politica-privacidad.vue`, `app/components/city/__tests__/legal.test.ts` (nuevo)
+- **Files to Read**: `app/pages/terminos-condiciones.vue`, `app/pages/politica-privacidad.vue`, `/tmp/alqui_f1_design/dist/terminos/index.html`
+- **Context Estimate**: M
+- **Scenario-Strategy**: required

--- a/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step08/task-08-integration-runtime.code-task.md
+++ b/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step08/task-08-integration-runtime.code-task.md
@@ -1,0 +1,65 @@
+## Status: PENDING
+## Blocked-By: step01/task-01-homecontact-reserveanchor.code-task.md, step02/task-02-city-hero.code-task.md, step03/task-03-city-seo-content.code-task.md, step04/task-04-city-delivery-points.code-task.md, step05/task-05-city-faq-testimonios.code-task.md, step06/task-06-mount-f1-marketing.code-task.md, step07/task-07-legal-restyle.code-task.md
+## Completed:
+
+# Task: F2 Step 8 — Integración + verificación runtime del holdout (preview)
+
+## Description
+Verificar el holdout SCEN-F2-01..12 (+07b) en el preview Vercel del branch (lección F0/F1: el runtime caza lo que los tests estáticos no ven — contraste, CLS, assets). Incluir la ruta `buscar-vehiculos` con params (resultados). Cierre con `/verification-before-completion`.
+
+## Background
+F1 demostró que tests estáticos verdes NO garantizan render correcto (contraste oscuro-sobre-rojo, CLS). Este paso es la satisfacción observable del holdout en el navegador real, en la city landing (sin y con params de búsqueda) y en las legales.
+
+## Reference Documentation
+**Required:**
+- Design: `docs/specs/2026-06-11-issue-112-f2-landing-legal-design.md` (holdout SCEN-F2-01..12 +07b; plan de verificación)
+**Additional:**
+- `[[reference_tailwind4_gradient_bg_linear]]`, `[[reference_local_results_validation]]`
+- `playwright.config.ts` (`PLAYWRIGHT_BASE_URL` → E2E vs preview)
+
+**Note:** Leer el detailed design antes de implementar.
+
+## Technical Requirements
+1. Push del branch → build de preview Vercel (alias `-git-feat-…`).
+2. `agent-browser` en `/{city}` (p.ej. `/bogota`): hero+searcher (testids, navega), secciones SEO presentes con texto, puntos-entrega, marketing F1, faqs city + testimonios city, gradientes renderizan (`bg-linear`) y headings legibles (blancos sobre rojo vía `--ctx-text-primary`), consola limpia, CLS ≤ baseline.
+3. `agent-browser` en `/{city}/buscar-vehiculos/...` (con params): `#seleccion-categorias`/`CategorySelectionSection` muestra resultados (engine intacto).
+4. `agent-browser` en `/terminos-condiciones` y `/politica-privacidad`: estilo del diseño + disclaimer de intermediación presente; enlaces footer 200.
+5. JSON-LD: `useCityProductSchema` (#68 precio real), `FAQPage` city, breadcrumb, canonical, og preservados.
+6. Aislamiento: `git diff main --stat` solo `ui-alquilame`+`docs/specs`; grep `bg-gradient-to-` (archivos home/city/legales tocados) = 0.
+7. E2E `BRAND=alquilame` (city + legales) contra el preview, sin regresión vs baseline; `data-testid` intactos.
+8. Cierre con `/verification-before-completion` (evidencia fresca).
+
+## Dependencies
+- **Steps 1-7** completos. **Preview Vercel** (push-gated).
+
+## Implementation Approach
+1. Verificación estática local (unit/typecheck/grep aislamiento + bg-gradient acotado).
+2. Push → build READY → `agent-browser` + `vitals` por escenario (landing, ruta con params, legales).
+3. E2E city+legales contra el preview.
+4. `/verification-before-completion` y reporte.
+
+## Acceptance Criteria
+1. **Holdout satisfecho en runtime**
+   - Given el preview del branch
+   - When se ejecutan las comprobaciones por escenario (landing, buscar-vehiculos con params, legales)
+   - Then SCEN-F2-01..12 (+07b) pasan con evidencia fresca (hero+searcher, SEO content, puntos-entrega, marketing, faqs/testimonios city, resultados con params, gradientes+contraste, JSON-LD #68/FAQPage, legales intermediación, CLS ≤ baseline).
+2. **Aislamiento + sin regresión**
+   - Given el diff y el E2E
+   - When se comparan vs baseline
+   - Then solo cambia `ui-alquilame`/`docs/specs`, E2E sin regresión nueva, `data-testid` intactos.
+3. **Cierre verificado**
+   - Given el cierre
+   - When se invoca `/verification-before-completion`
+   - Then hay evidencia fresca (no memoria) antes de cualquier claim de "done".
+
+## Metadata
+- **Complexity**: Medium
+- **Estimated Effort**: M
+- **Labels**: alquilame, f2, verification, runtime, agent-browser, e2e
+- **Required Skills**: agent-browser, Playwright, Vercel preview, SDD verification
+- **Related Tasks**: Blocked-By steps 1-7
+- **Step**: 08 of 08
+- **Files to Modify**: (ninguno de producción — verificación; fixes puntuales si un escenario falla)
+- **Files to Read**: `docs/specs/2026-06-11-issue-112-f2-landing-legal-design.md`, `playwright.config.ts`
+- **Context Estimate**: M
+- **Scenario-Strategy**: required

--- a/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step08/task-08-integration-runtime.code-task.md
+++ b/docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/step08/task-08-integration-runtime.code-task.md
@@ -1,6 +1,6 @@
-## Status: PENDING
+## Status: COMPLETED
 ## Blocked-By: step01/task-01-homecontact-reserveanchor.code-task.md, step02/task-02-city-hero.code-task.md, step03/task-03-city-seo-content.code-task.md, step04/task-04-city-delivery-points.code-task.md, step05/task-05-city-faq-testimonios.code-task.md, step06/task-06-mount-f1-marketing.code-task.md, step07/task-07-legal-restyle.code-task.md
-## Completed:
+## Completed: 2026-06-11
 
 # Task: F2 Step 8 — Integración + verificación runtime del holdout (preview)
 

--- a/docs/specs/2026-06-11-issue-112-f2-landing-legal/summary.md
+++ b/docs/specs/2026-06-11-issue-112-f2-landing-legal/summary.md
@@ -1,0 +1,31 @@
+# Planning Summary: F2 — City landing + legales
+
+**Date:** 2026-06-11
+**Goal:** Reskin de la city landing (`CityPage.vue`) + páginas legales de alquilame al diseño, preservando engine, todo el SEO y el modelo de negocio (intermediación).
+
+## Artefactos
+- `docs/specs/2026-06-11-issue-112-f2-landing-legal-design.md` — detailed design (spec, aprobada; holdout SCEN-F2-01..12 +07b).
+- `docs/specs/2026-06-11-issue-112-f2-landing-legal/implementation/plan.md` — file map + 8 pasos SDD.
+- `docs/specs/2026-06-11-issue-112-f2-landing-legal/summary.md` — este archivo.
+
+## Decisiones clave
+1. **City landing = reskin marketing, engine/rutas INTACTOS.** `Searcher.vue` (sus testids) sigue navegando a `buscar-vehiculos` (F3 lo reapunta a `/reservas`); resultados condicionales (`#seleccion-categorias`), branches, pin #41, guard #109 preservados.
+2. **Preservar TODO el SEO** (descripcion/ventajas/destinos/consejos/temporada/ciudades-cercanas restiladas) + agregar marketing reusando `home/*` de F1 (Fleet/HowItWorks/Requirements/Contact).
+3. **Contenido city = restyle in-place** (faqs con `useCityFAQs`, testimonios con `city.testimonials`); solo el marketing puro brand-level se reusa de F1. `HomeContact` gana prop `reserveAnchor` (`#searcher` en city).
+4. **Legales = estilo del diseño sobre el contenido de intermediación actual** (no el copy operador-directo del diseño — riesgo legal del modelo AMAW agregador). SCEN-F2-07b lo guarda.
+5. **Decomposición**: extraer secciones city en `app/components/city/*`; CityPage queda orquestador (mirror de `home/*`).
+
+## Revisiones (gate)
+- Spec-review: 2 iteraciones → Approved (Searcher≠SelectBranch, #faqs city-specific, id-collision, reserveAnchor, legal/intermediación, FAQ schema location).
+- Plan-review: 1 iteración → Approved; correcciones aplicadas (testimonios in-place vs HomeReviews por `useCityAggregateRating`/city-specific; ordering clarity; solo reserveAnchor prop).
+
+## Complejidad
+- **Overall:** L (CityPage es engine-pesada + grande) · **Pasos:** 8 (≤ M c/u) · **Riesgo:** Medio (preservar engine/SEO en una página compartida con la ruta de resultados; mayor cuidado en steps que tocan CityPage).
+
+## Próximos pasos
+1. `sop-task-generator` → `.code-task.md` por paso.
+2. Implementar (worktree `issue-112-f2`), runtime en preview, PR `Refs #112`.
+
+## Open questions / deuda declarada
+- `/reservas` + flujo resultados/reserva + blog → F3 (cierra #112). F3 reapunta el searcher.
+- El copy legal del diseño (operador directo) NO se usa hasta validación legal del cambio de posicionamiento.

--- a/e2e/availability-error-feedback.spec.ts
+++ b/e2e/availability-error-feedback.spec.ts
@@ -123,7 +123,13 @@ test.describe('Availability error feedback (issue #10)', () => {
     await expect(
       page.getByText('Servicio temporalmente no disponible'),
     ).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByRole('link', { name: /WhatsApp/ })).toBeVisible();
+    // Scope to the results section: the reskinned alquilame city page (issue #112
+    // F2) adds marketing WhatsApp CTAs (HomeContact) + the floating FAB, so a
+    // page-wide WhatsApp-link match is now ambiguous. The fallback block lives
+    // inside #seleccion-categorias.
+    await expect(
+      page.locator('#seleccion-categorias').getByRole('link', { name: /WhatsApp/ }),
+    ).toBeVisible();
 
     await expect(page.getByText('¡Oops!')).toHaveCount(0);
   });

--- a/packages/ui-alquilame/app/components/CityPage.vue
+++ b/packages/ui-alquilame/app/components/CityPage.vue
@@ -1,95 +1,18 @@
 <template>
+  <!--
+    F2 city landing — orquestador. Las secciones city viven en app/components/city/*
+    (hero/intro/seo/delivery/faq/testimonios, datos city-specific) y el marketing
+    puro se reusa de F1 (home/*). El bloque de resultados (#seleccion-categorias)
+    se preserva INTACTO: esta misma página la renderiza la ruta buscar-vehiculos,
+    y muestra resultados cuando hay params de búsqueda. Engine (Searcher, #41, #109)
+    y SEO (useCityProductSchema #68, useCityFAQSchema vía useCityPageSEO,
+    useCityAggregateRating) sin cambios de comportamiento.
+  -->
   <UPage>
-    <!-- Hero Section -->
-    <div class="hero-section">
-      <!-- Scroll target for "Probar otras fechas" / "Cambiar sucursal" CTAs en UnableCategoryCard -->
-      <div id="searcher" aria-hidden="true" class="scroll-mt-20" />
-      <UPageHero
-        orientation="horizontal"
-      >
-      <template #headline>
-        <div
-          class="flex flex-row space-x-0.5 text-white text-center justify-center items-center text-sm"
-        >
-          <StarIcon v-for="i in [1,2,3,4,5]" :key="i" cls="w-2.5 h-2.5 md:w-4 md:h-4" />
-          <span class="ml-2">4.9 reviews</span>
-        </div>
-      </template>
-      <template #title>
-        <!-- UPageHero renderiza <h1> para slot #title — usar solo phrasing content (span, no div) -->
-        <span class="block text-white text-center uppercase font-bold" style="letter-spacing: -0.025em;">
-          <span class="block text-2xl md:text-3xl lg:text-4xl" style="letter-spacing: -0.025em;">
-            <span class="block" style="letter-spacing: -0.025em;">ALQUILER</span>
-            {{ ' ' }}
-            <span class="block" style="letter-spacing: -0.025em;">DE CARROS EN</span>
-          </span>
-          {{ ' ' }}
-          <span class="flex flex-row justify-center items-baseline gap-2 text-4xl md:text-5xl lg:text-7xl lg:whitespace-nowrap" style="letter-spacing: -0.025em;">
-            <span class="size-8 md:size-10 lg:size-14" aria-hidden="true"></span>
-            {{ city?.name }}
-            <!-- Pin inerte: acción copy-to-WhatsApp es secreta (operadores, no clientes).
-                 <span> aria-hidden no-focusable → fuera del accessible name del <h1>
-                 (WCAG 2.5.3) y sin filtrar el secreto vía aria-label/title. Issue #41. -->
-            <span
-              aria-hidden="true"
-              @click="copySearchToWhatsapp"
-            >
-              <LocationIcon cls="text-red-600 size-8 md:size-10 lg:size-14 translate-y-1" />
-            </span>
-          </span>
-          {{ ' ' }}
-          <span class="block text-2xl md:text-3xl lg:text-4xl text-white colombia-sweep" style="letter-spacing: 0.025em;">Colombia</span>
-        </span>
-      </template>
-      <template #body>
-        <!-- Solo visible en mobile -->
-        <div class="text-center justify-items-center -mt-4 -mb-4 lg:hidden">
-          <div class="mb-1 text-white text-xl">
-            Consulta disponibilidad y precios
-          </div>
-          <p class="text-white text-sm">
-            Elige ciudades, fechas y horarios y renta un vehículo por días, semanas o el tiempo que necesites
-          </p>
-        </div>
-      </template>
-      <template #default>
-        <!-- Contenedor para texto + formulario alineados - solo desktop -->
-        <div class="hidden lg:flex lg:flex-col lg:items-center w-full">
-          <div class="w-4/6 text-center mb-2">
-            <div class="mb-1 text-white text-xl">
-              Consulta disponibilidad y precios
-            </div>
-            <p class="text-white text-sm">
-              Elige ciudades, fechas y horarios y renta un vehículo por días, semanas o el tiempo que necesites
-            </p>
-          </div>
-          <!-- Wrapper con altura fija para prevenir layout shift durante hidratación -->
-          <div class="h-[410px] w-full">
-            <ClientOnly>
-              <Searcher />
-              <template #fallback>
-                <PlaceholdersSearcher />
-              </template>
-            </ClientOnly>
-          </div>
-        </div>
-        <!-- Buscador solo en mobile/tablet -->
-        <div class="lg:hidden">
-          <!-- Wrapper con altura fija para prevenir layout shift durante hidratación -->
-          <div class="h-[360px]">
-            <ClientOnly>
-              <Searcher />
-              <template #fallback>
-                <PlaceholdersSearcher />
-              </template>
-            </ClientOnly>
-          </div>
-        </div>
-      </template>
-    </UPageHero>
-    </div>
+    <!-- Hero (Searcher + pin #41 + #searcher target preservados) -->
+    <CityHero :city="city" />
 
-    <!-- Result Section -->
+    <!-- Result Section — condicional, PRESERVADO intacto (engine) -->
     <UPageSection
       id="seleccion-categorias"
       v-if="pendingSearch || filteredCategories.length > 0 || searchError"
@@ -98,280 +21,34 @@
       <CategorySelectionSection />
     </UPageSection>
 
-    <!-- Description Section -->
-    <section id="descripcion" class="bg-white text-black py-4 md:py-12 px-4 md:px-8">
-      <div class="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-0 md:gap-8">
-        <div class="md:self-start flex justify-center h-[300px] md:h-[400px]">
-          <LazyImagesCiudadesChica :city-name="city?.name" />
-        </div>
-        <div class="flex flex-col gap-0 text-center font-extrabold">
-          <div class="text-red-600 text-xl md:text-3xl">
-            En {{ franchise.shortname }}
-          </div>
-          <div class="text-red-600 text-3xl md:text-5xl" v-text="city?.name"></div>
-          <p class="text-black text-2xl md:text-4xl mb-0">
-            la libertad <br />
-            de moverte <br />
-            a tu manera <br />
-            es realidad
-          </p>
-          <div class="flex items-center w-full my-2 md:my-4">
-            <div class="flex-grow border-t border-gray-300"></div>
-            <div class="mx-4 w-3 h-3 bg-black rotate-45"></div>
-            <div class="flex-grow border-t border-gray-300"></div>
-          </div>
-        </div>
-        <div>
-          <p
-            class="text-black text-center font-semibold"
-            v-text="city?.description"
-          ></p>
-        </div>
-      </div>
-    </section>
+    <!-- Intro city (descripcion + introduccion) -->
+    <CityIntro :city="city" :expanded-content="expandedContent" />
 
-    <!-- Benefits Section (adds ~100 words for SEO) -->
-    <section id="ventajas" class="bg-gray-50 text-black py-8 md:py-12 px-4 md:px-8">
-      <div class="max-w-5xl mx-auto">
-        <h2 class="text-2xl md:text-3xl font-bold text-center mb-8">
-          <span class="text-red-700">Ventajas de alquilar carro</span>
-          <span class="text-black"> en {{ city?.name }}</span>
-        </h2>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div class="flex items-start gap-4 bg-white p-5 rounded-lg shadow-sm">
-            <div class="flex-shrink-0 w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
-              <span class="text-2xl">💰</span>
-            </div>
-            <div>
-              <h3 class="font-bold text-gray-900 mb-1">Precios transparentes</h3>
-              <p class="text-gray-600 text-sm">Sin cargos ocultos ni sorpresas. El precio que ves incluye seguro básico, impuestos y kilometraje ilimitado para recorrer {{ city?.name }} y sus alrededores.</p>
-            </div>
-          </div>
-          <div class="flex items-start gap-4 bg-white p-5 rounded-lg shadow-sm">
-            <div class="flex-shrink-0 w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
-              <span class="text-2xl">🚗</span>
-            </div>
-            <div>
-              <h3 class="font-bold text-gray-900 mb-1">Flota variada</h3>
-              <p class="text-gray-600 text-sm">Desde económicos hasta SUVs y camionetas. Encuentra el vehículo perfecto para tu viaje en {{ city?.name }}, ya sea por negocios, turismo o familia.</p>
-            </div>
-          </div>
-          <div class="flex items-start gap-4 bg-white p-5 rounded-lg shadow-sm">
-            <div class="flex-shrink-0 w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
-              <span class="text-2xl">📍</span>
-            </div>
-            <div>
-              <h3 class="font-bold text-gray-900 mb-1">Entrega flexible</h3>
-              <p class="text-gray-600 text-sm">Recoge y devuelve tu carro en diferentes puntos de {{ city?.name }}. Aeropuerto, centro de la ciudad o donde te resulte más cómodo.</p>
-            </div>
-          </div>
-          <div class="flex items-start gap-4 bg-white p-5 rounded-lg shadow-sm">
-            <div class="flex-shrink-0 w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
-              <span class="text-2xl">⭐</span>
-            </div>
-            <div>
-              <h3 class="font-bold text-gray-900 mb-1">Atención personalizada</h3>
-              <p class="text-gray-600 text-sm">Soporte en español las 24 horas. Te asesoramos sobre rutas, destinos y todo lo que necesites saber para moverte en {{ city?.name }}.</p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
+    <!-- Marketing F1 (nuevo): fleet -->
+    <HomeFleet />
 
-    <!-- Delivery Points Section -->
-    <section v-if="cityBranches.length > 0" id="puntos-entrega" class="bg-gray-50 text-black py-8 md:py-12 px-4 md:px-8">
-      <div class="max-w-5xl mx-auto text-center">
-        <h2 class="text-2xl md:text-3xl font-bold mb-6">
-          <span class="text-red-700">Puntos de entrega</span> <span class="text-black">para alquiler de carros en {{ city?.name }}</span>
-        </h2>
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          <div
-            v-for="branch in cityBranches"
-            :key="branch.code"
-            class="flex flex-col bg-white px-4 py-4 rounded-lg shadow-sm text-left"
-          >
-            <div class="flex items-center gap-2 mb-2">
-              <LocationIcon cls="text-red-600 size-5 flex-shrink-0" />
-              <span class="font-semibold text-gray-900">{{ branch.name }}</span>
-            </div>
-            <div v-if="branch.schedule" class="flex items-start gap-2 text-sm text-gray-600">
-              <ClockIcon cls="text-gray-400 size-4 flex-shrink-0 mt-0.5" />
-              <span>{{ branch.schedule }}</span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
+    <!-- Contenido SEO city (ventajas/destinos/consejos/temporada/ciudades-cercanas) -->
+    <CitySeoContent
+      :city="city"
+      :expanded-content="expandedContent"
+      :related-cities="relatedCities"
+    />
 
-    <!-- Expanded Content Sections (only for cities with rich content) -->
-    <template v-if="hasExpandedContent && expandedContent">
-      <!-- Intro Section -->
-      <section id="introduccion" class="bg-white text-black py-8 md:py-12 px-4 md:px-8">
-        <div class="max-w-4xl mx-auto">
-          <h2 class="text-2xl md:text-3xl font-bold text-center mb-6">
-            <span class="text-red-700">Explora {{ city?.name }}</span>
-            <span class="text-black"> con tu carro de alquiler</span>
-          </h2>
-          <p class="text-gray-700 text-base md:text-lg leading-relaxed text-justify">
-            {{ expandedContent.intro }}
-          </p>
-        </div>
-      </section>
+    <!-- Puntos de entrega (branches reales) -->
+    <CityDeliveryPoints :city-branches="cityBranches" :city="city" />
 
-      <!-- Destinations Section -->
-      <section id="destinos" class="bg-gray-50 text-black py-8 md:py-12 px-4 md:px-8">
-        <div class="max-w-6xl mx-auto">
-          <h2 class="text-2xl md:text-3xl font-bold text-center mb-8">
-            <span class="text-red-700">Destinos para recorrer con carro rentado</span>
-            <span class="text-black"> desde {{ city?.name }}</span>
-          </h2>
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div
-              v-for="destination in expandedContent.destinations"
-              :key="destination.name"
-              class="bg-white rounded-lg shadow-sm p-6 hover:shadow-md transition-shadow"
-            >
-              <div class="flex items-start justify-between mb-3">
-                <h3 class="text-xl font-bold text-gray-900">{{ destination.name }}</h3>
-                <span class="text-sm font-medium text-gray-700 bg-gray-100 px-3 py-1 rounded-full whitespace-nowrap">
-                  {{ destination.time }}
-                </span>
-              </div>
-              <p class="text-gray-600 text-sm leading-relaxed">{{ destination.description }}</p>
-            </div>
-          </div>
-        </div>
-      </section>
+    <!-- Marketing F1 (nuevo): how-it-works + requirements -->
+    <HomeHowItWorks />
+    <HomeRequirements />
 
-      <!-- Driving Tips Section -->
-      <section id="consejos-conduccion" class="bg-white text-black py-8 md:py-12 px-4 md:px-8">
-        <div class="max-w-4xl mx-auto">
-          <h2 class="text-2xl md:text-3xl font-bold text-center mb-8">
-            <span class="text-red-700">Consejos</span>
-            <span class="text-black"> para alquilar carro en {{ city?.name }}</span>
-          </h2>
-          <div class="space-y-6">
-            <div class="flex items-start gap-4">
-              <div class="flex-shrink-0 w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
-                <span class="text-red-600 font-bold text-lg">🚗</span>
-              </div>
-              <div>
-                <h3 class="font-bold text-gray-900 mb-1">Pico y Placa</h3>
-                <p class="text-gray-600 text-sm">{{ expandedContent.drivingTips.picoPlaca }}</p>
-              </div>
-            </div>
-            <div class="flex items-start gap-4">
-              <div class="flex-shrink-0 w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
-                <span class="text-red-600 font-bold text-lg">💰</span>
-              </div>
-              <div>
-                <h3 class="font-bold text-gray-900 mb-1">Peajes</h3>
-                <p class="text-gray-600 text-sm">{{ expandedContent.drivingTips.tolls }}</p>
-              </div>
-            </div>
-            <div class="flex items-start gap-4">
-              <div class="flex-shrink-0 w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
-                <span class="text-red-600 font-bold text-lg">🅿️</span>
-              </div>
-              <div>
-                <h3 class="font-bold text-gray-900 mb-1">Parqueaderos</h3>
-                <p class="text-gray-600 text-sm">{{ expandedContent.drivingTips.parking }}</p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
+    <!-- Reseñas city (city.testimonials) -->
+    <CityTestimonios :city="city" />
 
-      <!-- Best Season Section -->
-      <section id="mejor-temporada" class="bg-gray-50 text-black py-8 md:py-12 px-4 md:px-8">
-        <div class="max-w-4xl mx-auto text-center">
-          <h2 class="text-2xl md:text-3xl font-bold mb-6">
-            <span class="text-red-700">Mejor época</span> <span class="text-black">para alquilar carro y viajar a {{ city?.name }}</span>
-          </h2>
-          <p class="text-gray-700 text-base md:text-lg leading-relaxed">
-            {{ expandedContent.bestSeason }}
-          </p>
-        </div>
-      </section>
-    </template>
+    <!-- FAQ city (useCityFAQs) -->
+    <CityFaq :city="city" />
 
-    <!-- Related Cities Section (Internal Linking) -->
-    <section v-if="relatedCities.length > 0" id="ciudades-cercanas" class="bg-white text-black py-8 md:py-12 px-4 md:px-8">
-      <div class="max-w-4xl mx-auto">
-        <h2 class="text-2xl md:text-3xl font-bold text-center mb-6">
-          <span class="text-red-700">Alquiler de carros</span>
-          <span class="text-black"> en ciudades cercanas</span>
-        </h2>
-        <p class="text-gray-600 text-center mb-8">
-          ¿Planeas un viaje más largo? También ofrecemos alquiler de vehículos en estas ciudades cercanas a {{ city?.name }}.
-        </p>
-        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
-          <NuxtLink
-            v-for="related in relatedCities"
-            :key="related.id"
-            :to="`/${related.id}`"
-            class="group flex flex-col items-center p-4 bg-gray-50 rounded-lg hover:bg-red-50 hover:shadow-md transition-all duration-200"
-          >
-            <LocationIcon cls="text-red-600 size-8 mb-2 group-hover:scale-110 transition-transform" />
-            <span class="font-semibold text-gray-900 group-hover:text-red-700">{{ related.name }}</span>
-            <span class="text-sm text-gray-500">{{ related.distance }} en carro</span>
-          </NuxtLink>
-        </div>
-      </div>
-    </section>
-
-    <!-- FAQ Section -->
-    <UPageSection id="faqs" class="bg-gray-100 text-black">
-      <div class="max-w-7xl mx-auto px-1 sm:px-2 lg:px-6">
-        <h2 class="text-2xl md:text-3xl font-bold text-center mb-6 space-x-2">
-          <span class="text-red-700">Preguntas frecuentes</span>
-          <span class="text-black">sobre alquiler de carros en {{ city?.name }}</span>
-        </h2>
-        <p class="text-base text-center mb-4">
-          Resolvemos tus dudas más comunes sobre el alquiler de carros en {{ city?.name }}.
-        </p>
-        <UAccordion :items="cityFAQs" :ui="faqAccordionUIConfig" class="max-w-4xl mx-auto">
-          <template #default="{ item }">
-            <span class="block text-base font-medium text-gray-800 px-4" v-text="item.label"></span>
-          </template>
-          <template #content="{ item }">
-            <span class="block text-base text-gray-600 py-3 bg-gray-50 px-4 rounded-lg" v-text="item.content"></span>
-          </template>
-        </UAccordion>
-      </div>
-    </UPageSection>
-
-    <!-- Testimonials Section -->
-    <section id="testimonios" class="bg-white text-black py-12 md:py-20 px-4 md:px-8">
-      <div class="max-w-7xl mx-auto">
-        <h2 class="text-2xl md:text-3xl font-bold text-center mb-4">
-          <span class="text-red-700">Opiniones de clientes que rentaron carros</span> <span class="text-black">en {{ city?.name }}</span>
-        </h2>
-        <p class="text-black text-center mb-8">Descubre por qué somos la opción preferida para alquilar carros en {{ city?.name }}. Nuestros clientes destacan nuestra atención, precios competitivos y la facilidad para explorar.</p>
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-          <div
-            v-for="testimonio in testimonios"
-            :key="testimonio.user.name"
-            class="border border-gray-100 rounded-lg bg-gray-50 shadow-sm p-5 md:p-6 hover:shadow-lg hover:-translate-y-1 transition-all duration-200"
-          >
-            <UUser
-              size="3xl"
-              v-bind="testimonio.user"
-              :ui="testimonioUserUIConfig"
-              loading="lazy"
-            >
-              <template #avatar>
-                <ImagesAvatar :avatar="testimonio.user.avatar" />
-              </template>
-            </UUser>
-            <p class="mt-4 text-gray-700">{{ testimonio.quote }}</p>
-            <div class="flex flex-row space-x-2 mt-4">
-              <StarIcon v-for="i in [1,2,3,4,5]" :key="i" cls="text-yellow-500 w-5 h-5" />
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
+    <!-- Contacto F1 — "Reserva Ahora" ancla al hero city (#searcher), no al #hero del home -->
+    <HomeContact reserve-anchor="#searcher" />
   </UPage>
 </template>
 
@@ -379,33 +56,21 @@
 /** types */
 import type { City } from '@rentacar-main/logic/utils';
 
-/** imports */
-import { defineAsyncComponent } from "vue";
-import {
-  IconsStarIcon as StarIcon,
-  IconsLocationIcon as LocationIcon,
-  IconsClockIcon as ClockIcon,
-} from "#components";
-
-/** refs */
-const { franchise } = useAppConfig();
 const { sortedBranches: branches } = storeToRefs(useStoreAdminData());
 
-/** stores - lazy initialization to avoid SSR Pinia error */
+/** Result-section gating — lazy store init to avoid SSR Pinia error.
+    searchError keeps the result-section mounted when filteredCategories is empty
+    (plugin-empty admin data) so error UX still surfaces — issue #10. */
 const pendingSearch = ref(false);
-const filteredCategories = ref<any[]>([]);
+const filteredCategories = ref<unknown[]>([]);
 const searchError = ref<unknown>(null);
 
-// Initialize store only on client side after mount
 onMounted(() => {
   const storeSearch = useStoreSearchData();
   const refs = storeToRefs(storeSearch);
-
-  // Sync refs. searchError keeps the result-section mounted when filteredCategories
-  // is empty (e.g. plugin-empty admin data) so error UX still surfaces — issue #10.
-  watch(() => refs.pending.value, (val) => pendingSearch.value = val, { immediate: true });
-  watch(() => refs.filteredCategories.value, (val) => filteredCategories.value = val, { immediate: true });
-  watch(() => refs.error.value, (val) => searchError.value = val, { immediate: true });
+  watch(() => refs.pending.value, (val) => (pendingSearch.value = val), { immediate: true });
+  watch(() => refs.filteredCategories.value, (val) => (filteredCategories.value = val), { immediate: true });
+  watch(() => refs.error.value, (val) => (searchError.value = val), { immediate: true });
 });
 
 /** props */
@@ -417,48 +82,16 @@ const cityBranches = computed(() =>
   (branches.value || []).filter((branch: { city: string }) => branch.city === props.city?.id)
 );
 
-const testimonios: Testimonial[] | undefined = props.city?.testimonials;
-
-// Get expanded content for major cities (Bogotá, Medellín)
+// Expanded content (major cities) + related cities — pasados a los componentes city/*.
 const expandedContent = props.city?.name ? useCityExpandedContent(props.city.name) : null;
-const hasExpandedContent = props.city?.name ? hasCityExpandedContent(props.city.name) : false;
-
-// Get related cities for internal linking
 const relatedCities = props.city?.id ? useRelatedCities(props.city.id) : [];
 
-// Add AggregateRating schema for city-specific testimonials (shows stars in Google SERPs)
+// SEO schema (sin cambios): AggregateRating con los testimonios city + Product (#68).
+const testimonios = props.city?.testimonials;
 if (props.city?.name && testimonios) {
-  useCityAggregateRating(props.city.name, testimonios)
+  useCityAggregateRating(props.city.name, testimonios);
 }
-
-// Add Product Schema for SEO (shows vehicle offers in Google SERPs)
 if (props.city?.name && props.city?.id) {
-  useCityProductSchema(props.city.name, props.city.id)
+  useCityProductSchema(props.city.name, props.city.id);
 }
-
-// Get city-specific FAQs for UI display
-const cityFAQs = props.city?.name ? useCityFAQs(props.city.name) : []
-
-const testimonioUserUIConfig = {
-  name: "text-black",
-  description: "text-gray-600",
-};
-
-const faqAccordionUIConfig = {
-  item: "bg-white rounded-lg mb-2 px-2 pb-2 !border-0 !border-b-0",
-  body: "!border-none",
-  trailingIcon: "mr-2 transition-transform duration-200",
-};
-
-const { copyToWhatsapp: copySearchToWhatsapp } = useShareSearchParams();
-
-const Searcher = defineAsyncComponent(() => import("./Searcher.vue"));
-const PlaceholdersSearcher = defineAsyncComponent(
-  () => import("./Placeholders/Searcher.vue")
-);
-const LazyImagesCiudadesChica = defineAsyncComponent(
-  () => import("./Images/Ciudades/Chica.vue")
-);
-
 </script>
-

--- a/packages/ui-alquilame/app/components/__tests__/CityPage.test.ts
+++ b/packages/ui-alquilame/app/components/__tests__/CityPage.test.ts
@@ -6,30 +6,42 @@ const source = readFileSync(
   fileURLToPath(new URL('../CityPage.vue', import.meta.url)),
   'utf8',
 )
+// F2 extracted the hero into app/components/city/Hero.vue, so the #41 pin moved
+// there with it. The positive pin assertions now read the hero source; CityPage
+// keeps the negative guards (it must not re-inline a leaking button/title).
+const hero = readFileSync(
+  fileURLToPath(new URL('../city/Hero.vue', import.meta.url)),
+  'utf8',
+)
 
 // Issue #41 — the copy-to-WhatsApp action on the pin is a SECRET operator
 // feature. It must stay out of the hero <h1>'s accessible name (WCAG 2.5.3) and
 // must not leak to customers via an aria-label or title tooltip. The pin is an
 // inert, non-focusable, aria-hidden <span> (not a <button>).
 describe('CityPage — copy-to-WhatsApp pin is an inert, customer-invisible operator control (issue #41)', () => {
-  it('does not render the legacy clipboard UButton', () => {
+  it('delegates the hero to CityHero (the pin lives there)', () => {
+    expect(source).toMatch(/<CityHero\b/)
+  })
+
+  it('does not render the legacy clipboard UButton (neither page nor hero)', () => {
     expect(source).not.toMatch(/i-heroicons-clipboard-document/)
+    expect(hero).not.toMatch(/i-heroicons-clipboard-document/)
   })
 
   it('does not wrap the pin in a <button> carrying the copy aria-label (it leaked into the <h1> accessible name)', () => {
-    expect(source).not.toMatch(/<button\b[^>]*aria-label="Copiar datos de búsqueda para WhatsApp"/)
+    expect(hero).not.toMatch(/<button\b[^>]*aria-label="Copiar datos de búsqueda para WhatsApp"/)
   })
 
   it('does not expose the secret operator action via a title tooltip', () => {
-    expect(source).not.toMatch(/title="Copiar datos de búsqueda para WhatsApp"/)
+    expect(hero).not.toMatch(/title="Copiar datos de búsqueda para WhatsApp"/)
   })
 
   it('wraps the LocationIcon in an aria-hidden <span> bound to copySearchToWhatsapp (inert decorative pin)', () => {
     const ariaHiddenSpan = /<span\b[^>]*aria-hidden="true"[^>]*@click="copySearchToWhatsapp"[^>]*>[\s\S]*?<LocationIcon\b[\s\S]*?\/>[\s\S]*?<\/span>/
-    expect(source).toMatch(ariaHiddenSpan)
+    expect(hero).toMatch(ariaHiddenSpan)
   })
 
   it('keeps the useShareSearchParams binding so the handler is still wired', () => {
-    expect(source).toMatch(/copyToWhatsapp:\s*copySearchToWhatsapp\s*\}\s*=\s*useShareSearchParams\(\)/)
+    expect(hero).toMatch(/copyToWhatsapp:\s*copySearchToWhatsapp\s*\}\s*=\s*useShareSearchParams\(\)/)
   })
 })

--- a/packages/ui-alquilame/app/components/city/DeliveryPoints.vue
+++ b/packages/ui-alquilame/app/components/city/DeliveryPoints.vue
@@ -1,0 +1,151 @@
+<template>
+  <!--
+    F2 step 4 — #puntos-entrega restyle (issue #112, SCEN-F2-04).
+
+    Restyle of the design's #puntos-entrega to a light card-stack: red accent
+    bar, font-heading h2 + subtitle, one card per REAL branch. Bound to the
+    live cityBranches (BranchData[]) — only `name` and the optional `schedule`
+    exist on our data, so the design's per-card photo / external reserve link
+    are intentionally dropped (no fabricated images or URLs). The section only
+    renders when there are branches (length guard preserved from CityPage).
+
+    Styling lessons carried from F0/F1:
+      - the v4 bg-linear utility for gradients, never the deprecated v3 alias
+        (with custom @theme tokens the v3 alias renders background-image:none).
+      - .heading-* utilities (Plus Jakarta) on the section/card titles.
+      - light section → no forced white-heading context override.
+      - CLS-safe: no images, no client-only state, fixed-size pin/icon boxes.
+  -->
+  <section
+    v-if="cityBranches.length > 0"
+    id="puntos-entrega"
+    class="relative overflow-hidden bg-[#EDF0F5] py-12 md:py-16 px-4 sm:px-6 lg:px-8"
+  >
+    <div class="max-w-4xl mx-auto relative z-10">
+      <!-- Header: red accent bar + heading + subtitle -->
+      <div class="mb-8">
+        <div class="h-1 w-10 rounded-full bg-red-600 mb-4" aria-hidden="true" />
+        <h2 class="heading-section text-3xl md:text-4xl font-extrabold text-gray-900 leading-tight">
+          Entrega del vehículo en {{ city?.name }}
+        </h2>
+        <p class="mt-3 text-base md:text-lg text-gray-600 max-w-2xl">
+          {{ cityBranches.length }}
+          {{ cityBranches.length === 1 ? 'punto físico de entrega' : 'puntos físicos de entrega' }}
+          en la ciudad. Elige el que te quede más cómodo.
+        </p>
+      </div>
+
+      <!-- Branch cards -->
+      <div class="flex flex-col gap-4">
+        <div
+          v-for="branch in cityBranches"
+          :key="branch.code"
+          class="group relative flex flex-col sm:flex-row sm:items-center gap-4 sm:gap-5 bg-[#F8F9FC] rounded-[22px] border-[7px] border-white shadow-[0_8px_22px_rgba(17,17,34,0.055)] transition-all duration-200 p-[3px] sm:p-4"
+        >
+          <div class="flex-1 min-w-0 flex flex-col justify-center gap-2.5 py-1">
+            <div class="flex items-start gap-3">
+              <!-- Red gradient location pin -->
+              <span
+                class="shrink-0 w-9 h-9 rounded-full bg-linear-to-br from-[#FF294D] to-[#CB032C] text-white flex items-center justify-center shadow-[0_4px_10px_rgba(216,23,58,0.30)]"
+                aria-hidden="true"
+              >
+                <LocationIcon cls="size-4" />
+              </span>
+              <h3 class="heading-card text-lg sm:text-xl font-bold text-gray-900 leading-snug pt-0.5">
+                {{ branch.name }}
+              </h3>
+            </div>
+
+            <!-- Schedule chip (real data, optional) -->
+            <div v-if="branch.schedule" class="flex flex-wrap gap-2">
+              <span
+                class="inline-flex items-center gap-1.5 rounded-full border border-red-600/40 bg-white text-red-600 text-xs sm:text-sm font-semibold px-3 py-1.5"
+              >
+                <ClockIcon cls="size-3.5 shrink-0" />
+                <span>{{ branch.schedule }}</span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Trust strip -->
+      <div
+        class="grid grid-cols-1 sm:grid-cols-3 mt-10 sm:mt-12 pt-8 border-t border-gray-900/[0.08]"
+      >
+        <div class="flex flex-row items-start gap-3.5 sm:flex-col sm:gap-2 sm:pr-6">
+          <svg
+            class="shrink-0 size-6 text-red-600"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" />
+            <path d="m9 12 2 2 4-4" />
+          </svg>
+          <div class="sm:contents">
+            <p class="font-heading font-bold text-sm text-gray-900">Seguridad y confianza</p>
+            <p class="text-[13px] text-gray-500 leading-snug">
+              Protocolos de bioseguridad en todos nuestros puntos.
+            </p>
+          </div>
+        </div>
+        <div
+          class="flex flex-row items-start gap-3.5 sm:flex-col sm:gap-2 sm:px-6 sm:border-l sm:border-gray-900/[0.08] pt-5 mt-5 border-t border-gray-900/[0.08] sm:pt-0 sm:mt-0 sm:border-t-0"
+        >
+          <ClockIcon cls="shrink-0 size-6 text-red-600" />
+          <div class="sm:contents">
+            <p class="font-heading font-bold text-sm text-gray-900">Entregas rápidas</p>
+            <p class="text-[13px] text-gray-500 leading-snug">
+              Proceso ágil para que empieces tu viaje.
+            </p>
+          </div>
+        </div>
+        <div
+          class="flex flex-row items-start gap-3.5 sm:flex-col sm:gap-2 sm:px-6 sm:border-l sm:border-gray-900/[0.08] pt-5 mt-5 border-t border-gray-900/[0.08] sm:pt-0 sm:mt-0 sm:border-t-0"
+        >
+          <svg
+            class="shrink-0 size-6 text-red-600"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M3 18v-6a9 9 0 0 1 18 0v6" />
+            <path d="M21 19a2 2 0 0 1-2 2h-1a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h3zM3 19a2 2 0 0 0 2 2h1a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2H3z" />
+          </svg>
+          <div class="sm:contents">
+            <p class="font-heading font-bold text-sm text-gray-900">Soporte 24/7</p>
+            <p class="text-[13px] text-gray-500 leading-snug">
+              Estamos contigo en cada paso del alquiler.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+/** types */
+import type { City, BranchData } from '@rentacar-main/logic/utils'
+
+/** imports */
+import {
+  IconsLocationIcon as LocationIcon,
+  IconsClockIcon as ClockIcon,
+} from '#components'
+
+/** props */
+defineProps<{
+  cityBranches: BranchData[]
+  city?: City
+}>()
+</script>

--- a/packages/ui-alquilame/app/components/city/Faq.vue
+++ b/packages/ui-alquilame/app/components/city/Faq.vue
@@ -1,0 +1,92 @@
+<template>
+  <!--
+    F2 city FAQ — restyle of the design's #faq IN-PLACE, keeping the
+    CITY-SPECIFIC data. The accordion iterates `useCityFAQs(city.name)`
+    (pico y placa, El Dorado, kilometraje por región, etc.) — NOT the
+    brand-level FAQ list that HomeFaq renders. Reusing HomeFaq here
+    would regress the city's indexable SEO content.
+
+    The FAQ JSON-LD schema is NOT emitted here: it stays in
+    useCityFAQSchema (inside useCityPageSEO, in [city]/index.vue) so it
+    keeps reading the same city FAQ source — single source of truth, untouched.
+
+    Gradient uses the v4 bg-linear-to-* utility (F0 lesson: the broken v3
+    alias with custom @theme tokens renders background-image:none).
+  -->
+  <section
+    id="faqs"
+    class="bg-linear-to-b from-gray-50 to-gray-100 text-gray-900 py-12 md:py-16"
+  >
+    <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="text-center mb-10 md:mb-12">
+        <div
+          class="h-1 w-10 rounded-full bg-red-600 mb-4 mx-auto"
+          aria-hidden="true"
+        />
+        <h2 class="heading-section text-3xl md:text-4xl text-gray-900 leading-tight">
+          Preguntas frecuentes sobre alquiler en {{ city?.name }}
+        </h2>
+        <p class="mt-4 text-lg text-gray-600">
+          Resolvemos tus dudas más comunes sobre el alquiler de carros en
+          {{ city?.name }}.
+        </p>
+      </div>
+
+      <LazyUAccordion
+        hydrate-on-interaction
+        :items="cityFAQs"
+        :ui="faqAccordionUIConfig"
+        class="max-w-3xl mx-auto"
+      >
+        <template #default="{ item }">
+          <span
+            class="block text-base font-semibold text-gray-900 px-4"
+            v-text="item.label"
+          />
+        </template>
+        <template #content="{ item }">
+          <span
+            class="block text-base text-gray-600 leading-relaxed py-3 px-4"
+            v-text="item.content"
+          />
+        </template>
+      </LazyUAccordion>
+
+      <div class="mt-10 text-center">
+        <p class="text-gray-600">
+          ¿Tienes otra pregunta?{{ ' ' }}
+          <a
+            :href="franchise.whatsapp"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-red-600 font-semibold hover:text-red-700 underline underline-offset-2"
+          >
+            Escríbenos por WhatsApp
+          </a>
+        </p>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+/** types */
+import type { City } from "@rentacar-main/logic/utils";
+
+/** props */
+const props = defineProps<{
+  city: City;
+}>();
+
+const { franchise } = useAppConfig();
+
+// City-specific FAQs (pico y placa, El Dorado, etc.) — same source the legacy
+// #faqs used and the one useCityFAQSchema reads. NEVER the brand-level list.
+const cityFAQs = props.city?.name ? useCityFAQs(props.city.name) : [];
+
+const faqAccordionUIConfig = {
+  item: "bg-white rounded-lg mb-2 px-2 pb-2 shadow-sm !border-0 !border-b-0",
+  body: "!border-none",
+  trailingIcon: "mr-2 transition-transform duration-200",
+};
+</script>

--- a/packages/ui-alquilame/app/components/city/Hero.vue
+++ b/packages/ui-alquilame/app/components/city/Hero.vue
@@ -1,0 +1,131 @@
+<template>
+  <!--
+    F2 city hero — restyle of the design's #hero (bg-linear-to-br red gradient,
+    city-targeted h1 left / Searcher engine right). PRESERVED untouched:
+      - The Searcher engine: same component, same data-testid
+        (pickup-location-test / return-location-test), same navigation to
+        /{city}/buscar-vehiculos/... It stays wrapped in <ClientOnly> with a
+        fixed-height fallback (PlaceholdersSearcher) so hydration causes no
+        layout shift (issue #109 — no current-date call baked into SSR/ISR
+        markup).
+      - The #searcher scroll target: the in-page anchor the UnableCategoryCard
+        CTAs ("Probar otras fechas" / "Cambiar sucursal") and the city
+        HomeContact "Reserva Ahora" CTA (reserveAnchor) scroll to.
+      - The #41 secret pin: copy-to-WhatsApp is an operator-only action, so it
+        stays an INERT aria-hidden span (never a focusable control) — outside
+        the accessible name of the <h1> (WCAG 2.5.3) and never exposed via
+        aria-label/title.
+
+    Gradient guard (F1/F0 lesson): the red gradient MUST use the v4
+    bg-linear-to-* utility built from the hero-from/hero-to @theme tokens; the
+    broken v3 alias renders background-image:none with custom tokens. The
+    section sets [--ctx-text-primary:#fff] so .heading-* headings render WHITE
+    on the red background (F1 contrast bug).
+  -->
+  <section
+    id="hero"
+    class="relative flex items-center overflow-hidden bg-linear-to-br from-hero-from to-hero-to [--ctx-text-primary:#fff]"
+  >
+    <!--
+      Scroll target for "Probar otras fechas" / "Cambiar sucursal" CTAs in
+      UnableCategoryCard and the city HomeContact "Reserva Ahora" CTA. Kept as a
+      dedicated anchor so #hero (the section) and #searcher (the engine) stay
+      independent and scroll-mt-20 clears the sticky header.
+    -->
+    <div id="searcher" aria-hidden="true" class="absolute scroll-mt-20" />
+
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 md:py-12 w-full">
+      <div class="grid lg:grid-cols-2 gap-10 items-center">
+        <!-- Text column -->
+        <div class="text-center lg:text-left">
+          <!-- Trust signal: "4.9 reviews" star badge (design hero) -->
+          <div
+            class="flex flex-row space-x-0.5 justify-center lg:justify-start items-center text-sm text-white mb-3"
+          >
+            <StarIcon v-for="i in [1, 2, 3, 4, 5]" :key="i" cls="w-3.5 h-3.5 md:w-4 md:h-4" />
+            <span class="ml-2">4.9 reviews</span>
+          </div>
+
+          <!--
+            City-targeted h1 (SEO). The pin is an inert <span aria-hidden> INSIDE
+            the <h1> but excluded from its accessible name — it carries no text
+            and is not focusable, so screen readers announce only
+            "Alquiler de carros en {city}". Issue #41.
+          -->
+          <h1 class="heading-hero text-3xl sm:text-4xl lg:text-5xl text-white leading-[1.1]">
+            Alquiler de carros en {{ city?.name }}
+            <span
+              aria-hidden="true"
+              class="inline-flex align-middle"
+              @click="copySearchToWhatsapp"
+            >
+              <LocationIcon cls="text-white size-7 md:size-8 lg:size-10 -translate-y-0.5" />
+            </span>
+          </h1>
+
+          <p class="mt-4 text-base md:text-lg text-white/85 max-w-2xl mx-auto lg:mx-0">
+            Consulta disponibilidad y precios. Elige ciudad, fechas y horarios y
+            renta un vehículo por días, semanas o el tiempo que necesites.
+          </p>
+        </div>
+
+        <!-- Engine column — Searcher preserved untouched -->
+        <div class="flex items-center justify-center">
+          <!--
+            CLS guard (issue #109): reserve the Searcher footprint with a fixed
+            height so the ClientOnly fallback and the hydrated form occupy the
+            same box — no shift, and no current-date call in the SSR/ISR markup.
+            Desktop and mobile keep distinct heights matching the form layout.
+          -->
+          <div class="w-full max-w-md mx-auto">
+            <div class="hidden lg:block h-[410px]">
+              <ClientOnly>
+                <Searcher />
+                <template #fallback>
+                  <PlaceholdersSearcher />
+                </template>
+              </ClientOnly>
+            </div>
+            <div class="lg:hidden h-[360px]">
+              <ClientOnly>
+                <Searcher />
+                <template #fallback>
+                  <PlaceholdersSearcher />
+                </template>
+              </ClientOnly>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+/** types */
+import type { City } from '@rentacar-main/logic/utils'
+
+/** imports */
+import { defineAsyncComponent } from 'vue'
+import {
+  IconsStarIcon as StarIcon,
+  IconsLocationIcon as LocationIcon,
+} from '#components'
+
+/** props */
+defineProps<{
+  city: City
+}>()
+
+/**
+ * Secret operator action (issue #41): copies the current search params into a
+ * prefilled WhatsApp message. Wired to the inert <span aria-hidden> pin above —
+ * never a focusable control, so it never enters the tab order or the a11y tree.
+ */
+const { copyToWhatsapp: copySearchToWhatsapp } = useShareSearchParams()
+
+const Searcher = defineAsyncComponent(() => import('../Searcher.vue'))
+const PlaceholdersSearcher = defineAsyncComponent(
+  () => import('../Placeholders/Searcher.vue'),
+)
+</script>

--- a/packages/ui-alquilame/app/components/city/Intro.vue
+++ b/packages/ui-alquilame/app/components/city/Intro.vue
@@ -1,0 +1,103 @@
+<template>
+  <!--
+    F2 step03 — City Intro (issue #112, SCEN-F2-02).
+
+    Restyle of CityPage.vue's #descripcion + #introduccion to the design's #intro
+    look: a clean light document section with the red accent bar (h-1 w-10 rounded
+    bg-red-600), a .heading-section title (Plus Jakarta) and relaxed body copy.
+
+    PRESERVATION RULE: every word of city SEO copy is kept verbatim. Only the
+    styling changes — no text is shortened or dropped:
+      - #descripcion: the "En {franchise} {city} la libertad de moverte a tu
+        manera es realidad" poster + city.description + the city illustration.
+      - #introduccion (#intro): the "Explora {city} con tu carro de alquiler"
+        heading + expandedContent.intro paragraph (only for cities with rich
+        content — same hasExpandedContent guard as before).
+
+    Both sections are light backgrounds → default dark text is correct; no
+    [--ctx-text-primary:#fff] override (that is only for dark/red sections).
+  -->
+  <div>
+    <!-- Description Section (#descripcion) — city poster + description copy -->
+    <section id="descripcion" class="bg-white py-12 md:py-16 px-4 sm:px-6 lg:px-8">
+      <div class="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-8 md:gap-10 items-center">
+        <!-- City illustration (CLS-safe: reserved square box) -->
+        <div class="flex justify-center md:self-center aspect-square w-full max-w-[400px] mx-auto">
+          <LazyImagesCiudadesChica :city-name="city?.name" />
+        </div>
+
+        <!-- Poster: "En {franchise} {city} la libertad ... es realidad" -->
+        <div class="flex flex-col gap-0 text-center">
+          <div class="heading-sub text-red-600 font-extrabold text-xl md:text-3xl">
+            En {{ franchise.shortname }}
+          </div>
+          <div class="heading-section text-red-600 font-extrabold text-3xl md:text-5xl" v-text="city?.name"></div>
+          <p class="heading-card text-gray-900 font-extrabold text-2xl md:text-4xl mb-0 leading-snug">
+            la libertad <br />
+            de moverte <br />
+            a tu manera <br />
+            es realidad
+          </p>
+          <!-- Diamond divider (design rhythm) -->
+          <div class="flex items-center w-full my-3 md:my-4">
+            <div class="flex-grow border-t border-gray-200"></div>
+            <div class="mx-4 w-2.5 h-2.5 bg-red-600 rotate-45 rounded-[2px]"></div>
+            <div class="flex-grow border-t border-gray-200"></div>
+          </div>
+        </div>
+
+        <!-- City description copy -->
+        <div class="md:self-center">
+          <!-- Red accent bar (design #intro signature) -->
+          <div class="h-1 w-10 rounded-full bg-red-600 mb-5 mx-auto md:mx-0"></div>
+          <p
+            class="text-base md:text-lg text-gray-600 leading-relaxed text-center md:text-left"
+            v-text="city?.description"
+          ></p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Intro Section (#introduccion → design #intro) — only for rich-content cities -->
+    <section
+      v-if="expandedContent"
+      id="introduccion"
+      class="bg-white py-12 md:py-16 px-4 sm:px-6 lg:px-8"
+    >
+      <div class="max-w-3xl mx-auto">
+        <div class="h-1 w-10 rounded-full bg-red-600 mb-5"></div>
+        <h2 class="heading-section text-gray-900 mb-5">
+          <span class="text-red-700">Explora {{ city?.name }}</span>
+          <span class="text-gray-900"> con tu carro de alquiler</span>
+        </h2>
+        <div class="space-y-4 text-base md:text-lg text-gray-600 leading-relaxed">
+          <p>{{ expandedContent.intro }}</p>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+/** types */
+// City is imported from utils (explicit, per convention); CityExpandedContent is
+// an auto-imported layer type (Nuxt imports.dirs) → used bare, no import needed.
+import type { City } from '@rentacar-main/logic/utils'
+
+/** imports */
+import { defineAsyncComponent } from 'vue'
+
+/** props */
+defineProps<{
+  city: City
+  /** Rich expanded content (intro). Null for cities without curated content. */
+  expandedContent: CityExpandedContent | null
+}>()
+
+/** refs */
+const { franchise } = useAppConfig()
+
+const LazyImagesCiudadesChica = defineAsyncComponent(
+  () => import('../Images/Ciudades/Chica.vue'),
+)
+</script>

--- a/packages/ui-alquilame/app/components/city/SeoContent.vue
+++ b/packages/ui-alquilame/app/components/city/SeoContent.vue
@@ -1,0 +1,227 @@
+<template>
+  <!--
+    F2 step03 — City SEO content (issue #112, SCEN-F2-02).
+
+    Restyle of CityPage.vue's #ventajas, #destinos, #consejos-conduccion,
+    #mejor-temporada and #ciudades-cercanas to the design's section language:
+    red accent bar (h-1 w-10 rounded bg-red-600), .heading-section titles
+    (Plus Jakarta) and the light card chrome
+    (bg-[#F8F9FC] rounded-[22px] border-[7px] border-white shadow-...).
+
+    PRESERVATION RULE: all indexable city copy is kept VERBATIM — headings,
+    benefit blurbs, destination names/times/descriptions, driving tips
+    (pico y placa / peajes / parqueaderos), best-season paragraph and the
+    related-cities internal links. Only styling changes; zero content dropped.
+
+    The #destinos / #consejos / #mejor-temporada blocks render only for cities
+    with curated expandedContent (same guard as the original CityPage). All
+    sections sit on light backgrounds → dark text is correct (no
+    [--ctx-text-primary:#fff], which is reserved for dark/red sections).
+  -->
+  <div>
+    <!-- Benefits Section (#ventajas) — adds ~100 words for SEO -->
+    <section id="ventajas" class="bg-[#EDF0F5] py-12 md:py-16 px-4 sm:px-6 lg:px-8">
+      <div class="max-w-5xl mx-auto">
+        <div class="text-center mb-10">
+          <div class="h-1 w-10 rounded-full bg-red-600 mb-4 mx-auto"></div>
+          <h2 class="heading-section text-gray-900">
+            <span class="text-red-700">Ventajas de alquilar carro</span>
+            <span class="text-gray-900"> en {{ city?.name }}</span>
+          </h2>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div
+            v-for="benefit in benefits"
+            :key="benefit.title"
+            class="flex items-start gap-4 bg-[#F8F9FC] rounded-[22px] border-[7px] border-white shadow-[0_8px_22px_rgba(17,17,34,0.055)] hover:-translate-y-0.5 hover:shadow-[0_14px_30px_rgba(17,17,34,0.09)] transition-all duration-200 p-5"
+          >
+            <div class="flex-shrink-0 w-12 h-12 rounded-full bg-red-100 flex items-center justify-center">
+              <span class="text-2xl" aria-hidden="true">{{ benefit.emoji }}</span>
+            </div>
+            <div>
+              <h3 class="heading-sub text-gray-900 mb-1">{{ benefit.title }}</h3>
+              <p class="text-gray-600 text-sm leading-relaxed">{{ benefit.body }}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Destinations Section (#destinos) — only rich-content cities -->
+    <section
+      v-if="expandedContent"
+      id="destinos"
+      class="bg-white py-12 md:py-16 px-4 sm:px-6 lg:px-8"
+    >
+      <div class="max-w-6xl mx-auto">
+        <div class="text-center mb-10">
+          <div class="h-1 w-10 rounded-full bg-red-600 mb-4 mx-auto"></div>
+          <h2 class="heading-section text-gray-900">
+            <span class="text-red-700">Destinos para recorrer con carro rentado</span>
+            <span class="text-gray-900"> desde {{ city?.name }}</span>
+          </h2>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div
+            v-for="destination in expandedContent.destinations"
+            :key="destination.name"
+            class="bg-[#F8F9FC] rounded-[22px] border-[7px] border-white shadow-[0_8px_22px_rgba(17,17,34,0.055)] hover:-translate-y-0.5 hover:shadow-[0_14px_30px_rgba(17,17,34,0.09)] transition-all duration-200 p-6"
+          >
+            <div class="flex items-start justify-between gap-3 mb-3">
+              <h3 class="heading-sub text-gray-900">{{ destination.name }}</h3>
+              <span class="text-sm font-semibold text-red-600 bg-red-50 px-3 py-1 rounded-full whitespace-nowrap">
+                {{ destination.time }}
+              </span>
+            </div>
+            <p class="text-gray-600 text-sm leading-relaxed">{{ destination.description }}</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Driving Tips Section (#consejos-conduccion) — only rich-content cities -->
+    <section
+      v-if="expandedContent"
+      id="consejos-conduccion"
+      class="bg-[#EDF0F5] py-12 md:py-16 px-4 sm:px-6 lg:px-8"
+    >
+      <div class="max-w-4xl mx-auto">
+        <div class="text-center mb-10">
+          <div class="h-1 w-10 rounded-full bg-red-600 mb-4 mx-auto"></div>
+          <h2 class="heading-section text-gray-900">
+            <span class="text-red-700">Consejos</span>
+            <span class="text-gray-900"> para alquilar carro en {{ city?.name }}</span>
+          </h2>
+        </div>
+        <div class="space-y-5">
+          <div
+            v-for="tip in drivingTips"
+            :key="tip.title"
+            class="flex items-start gap-4 bg-[#F8F9FC] rounded-[22px] border-[7px] border-white shadow-[0_8px_22px_rgba(17,17,34,0.055)] transition-all duration-200 p-5"
+          >
+            <div class="flex-shrink-0 w-10 h-10 rounded-full bg-red-100 flex items-center justify-center">
+              <span class="text-red-600 font-bold text-lg" aria-hidden="true">{{ tip.emoji }}</span>
+            </div>
+            <div>
+              <h3 class="heading-sub text-gray-900 mb-1">{{ tip.title }}</h3>
+              <p class="text-gray-600 text-sm leading-relaxed">{{ tip.body }}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Best Season Section (#mejor-temporada) — only rich-content cities -->
+    <section
+      v-if="expandedContent"
+      id="mejor-temporada"
+      class="bg-white py-12 md:py-16 px-4 sm:px-6 lg:px-8"
+    >
+      <div class="max-w-3xl mx-auto">
+        <div class="h-1 w-10 rounded-full bg-red-600 mb-5"></div>
+        <h2 class="heading-section text-gray-900 mb-5">
+          <span class="text-red-700">Mejor época</span>
+          <span class="text-gray-900"> para alquilar carro y viajar a {{ city?.name }}</span>
+        </h2>
+        <div class="space-y-4 text-base md:text-lg text-gray-600 leading-relaxed">
+          <p>{{ expandedContent.bestSeason }}</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Related Cities Section (#ciudades-cercanas) — internal linking -->
+    <section
+      v-if="relatedCities.length > 0"
+      id="ciudades-cercanas"
+      class="bg-[#EDF0F5] py-12 md:py-16 px-4 sm:px-6 lg:px-8"
+    >
+      <div class="max-w-4xl mx-auto">
+        <div class="text-center mb-8">
+          <div class="h-1 w-10 rounded-full bg-red-600 mb-4 mx-auto"></div>
+          <h2 class="heading-section text-gray-900">
+            <span class="text-red-700">Alquiler de carros</span>
+            <span class="text-gray-900"> en ciudades cercanas</span>
+          </h2>
+          <p class="text-gray-600 mt-4">
+            ¿Planeas un viaje más largo? También ofrecemos alquiler de vehículos en estas ciudades cercanas a {{ city?.name }}.
+          </p>
+        </div>
+        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
+          <NuxtLink
+            v-for="related in relatedCities"
+            :key="related.id"
+            :to="`/${related.id}`"
+            :aria-label="`Alquiler de carros en ${related.name}`"
+            class="group flex flex-col items-center bg-[#F8F9FC] rounded-[22px] border-[7px] border-white shadow-[0_8px_22px_rgba(17,17,34,0.055)] hover:-translate-y-0.5 hover:shadow-[0_14px_30px_rgba(17,17,34,0.09)] transition-all duration-200 p-4"
+          >
+            <LocationIcon cls="text-red-600 size-8 mb-2 group-hover:scale-110 transition-transform" />
+            <span class="font-semibold text-gray-900 group-hover:text-red-700">{{ related.name }}</span>
+            <span class="text-sm text-gray-500">{{ related.distance }} en carro</span>
+          </NuxtLink>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+/** types */
+// City is imported from utils (explicit, per convention); CityExpandedContent
+// and RelatedCity are auto-imported layer types (Nuxt imports.dirs) → used bare.
+import type { City } from '@rentacar-main/logic/utils'
+
+/** imports */
+import { computed } from 'vue'
+import { IconsLocationIcon as LocationIcon } from '#components'
+
+/** props */
+const props = defineProps<{
+  city: City
+  /** Rich expanded content (destinations / driving tips / best season). */
+  expandedContent: CityExpandedContent | null
+  /** Nearby cities for internal linking (empty array when none mapped). */
+  relatedCities: RelatedCity[]
+}>()
+
+/**
+ * Benefits copy — preserved VERBATIM from the original #ventajas section.
+ * Moved to data so the four cards share one styled template (DRY) without
+ * altering a single indexable word; {{ city?.name }} interpolation is kept.
+ */
+const benefits = computed(() => [
+  {
+    emoji: '💰',
+    title: 'Precios transparentes',
+    body: `Sin cargos ocultos ni sorpresas. El precio que ves incluye seguro básico, impuestos y kilometraje ilimitado para recorrer ${props.city?.name} y sus alrededores.`,
+  },
+  {
+    emoji: '🚗',
+    title: 'Flota variada',
+    body: `Desde económicos hasta SUVs y camionetas. Encuentra el vehículo perfecto para tu viaje en ${props.city?.name}, ya sea por negocios, turismo o familia.`,
+  },
+  {
+    emoji: '📍',
+    title: 'Entrega flexible',
+    body: `Recoge y devuelve tu carro en diferentes puntos de ${props.city?.name}. Aeropuerto, centro de la ciudad o donde te resulte más cómodo.`,
+  },
+  {
+    emoji: '⭐',
+    title: 'Atención personalizada',
+    body: `Soporte en español las 24 horas. Te asesoramos sobre rutas, destinos y todo lo que necesites saber para moverte en ${props.city?.name}.`,
+  },
+])
+
+/**
+ * Driving tips — preserved VERBATIM (pico y placa / peajes / parqueaderos),
+ * sourced from expandedContent. Titles match the original headings exactly.
+ */
+const drivingTips = computed(() =>
+  props.expandedContent
+    ? [
+        { emoji: '🚗', title: 'Pico y Placa', body: props.expandedContent.drivingTips.picoPlaca },
+        { emoji: '💰', title: 'Peajes', body: props.expandedContent.drivingTips.tolls },
+        { emoji: '🅿️', title: 'Parqueaderos', body: props.expandedContent.drivingTips.parking },
+      ]
+    : [],
+)
+</script>

--- a/packages/ui-alquilame/app/components/city/Testimonios.vue
+++ b/packages/ui-alquilame/app/components/city/Testimonios.vue
@@ -1,0 +1,108 @@
+<template>
+  <!--
+    F2 city testimonials — restyle of the design's #google-reviews IN-PLACE,
+    keeping the CITY-SPECIFIC data. The cards render `props.city.testimonials`
+    (the same source that feeds the city aggregate-rating schema in CityPage)
+    with a CITY-TARGETED heading ("…en {city.name}") — NOT the brand-level
+    testimonial list that HomeReviews renders. Reusing HomeReviews here would
+    swap the display city→brand and risk inconsistency with the city's
+    aggregate-rating schema.
+
+    The mockup's hardcoded marketing rating block (a fixed score + review
+    count), its external CID review links and reviewer-tier badges are FICTION baked into
+    the design build → NOT reproduced. No rating number is surfaced here; the
+    aggregate-rating schema composable stays in CityPage, untouched.
+
+    Gradient uses the v4 bg-linear-to-* utility (F0 lesson: the broken v3 alias
+    with custom @theme tokens renders background-image:none).
+  -->
+  <section
+    id="testimonios"
+    class="bg-linear-to-b from-gray-50 to-gray-100 text-gray-900 py-12 md:py-16"
+  >
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <!-- Section header — city-targeted -->
+      <div class="text-center max-w-2xl mx-auto mb-10 md:mb-12">
+        <div
+          class="h-1 w-10 rounded-full bg-red-600 mb-4 mx-auto"
+          aria-hidden="true"
+        />
+        <h2 class="heading-section text-3xl md:text-4xl text-gray-900 leading-tight mb-3">
+          Opiniones de clientes que rentaron carros en {{ city?.name }}
+        </h2>
+        <p class="text-base text-gray-600">
+          Descubre por qué somos la opción preferida para alquilar carros en
+          {{ city?.name }}: atención cercana, precios competitivos y la
+          facilidad para explorar la ciudad y sus alrededores.
+        </p>
+      </div>
+
+      <!-- Review cards — city-specific testimonials -->
+      <div
+        v-if="testimonios.length"
+        class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 lg:gap-5"
+      >
+        <article
+          v-for="testimonio in testimonios"
+          :key="testimonio.user.name"
+          class="flex flex-col bg-white rounded-2xl border border-gray-200 shadow-sm p-5 sm:p-6 hover:-translate-y-0.5 hover:shadow-md transition-all duration-200"
+        >
+          <!-- Author + avatar (real city data via UUser) -->
+          <!-- CLS fix: reserve space for the avatar (48x48 = size 3xl) -->
+          <div class="min-h-[48px]">
+            <UUser
+              size="3xl"
+              v-bind="testimonio.user"
+              :ui="userUIConfig"
+              loading="lazy"
+            >
+              <template #avatar>
+                <ImagesAvatar :avatar="testimonio.user.avatar" />
+              </template>
+            </UUser>
+          </div>
+
+          <!-- Star row -->
+          <div class="flex gap-0.5 mt-3" aria-label="5 de 5 estrellas">
+            <StarIcon
+              v-for="i in 5"
+              :key="i"
+              cls="text-yellow-400 w-4 h-4"
+            />
+          </div>
+
+          <!-- Quote -->
+          <p class="mt-3 text-sm text-gray-600 leading-relaxed">
+            &ldquo;{{ testimonio.quote }}&rdquo;
+          </p>
+        </article>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+/** types */
+import type { City } from "@rentacar-main/logic/utils";
+import type Testimonial from "@rentacar-main/logic/utils/types/type/Testimonial";
+
+/** components */
+import { IconsStarIcon as StarIcon } from "#components";
+
+/** props */
+const props = defineProps<{
+  city: City;
+}>();
+
+// City-specific testimonials — the SAME array that feeds the city
+// aggregate-rating schema in CityPage, so the displayed reviews stay consistent
+// with that schema. NEVER the brand-level testimonial list.
+const testimonios = computed<Testimonial[]>(
+  () => props.city?.testimonials ?? []
+);
+
+const userUIConfig = {
+  name: "text-gray-900 font-bold",
+  description: "text-gray-500",
+};
+</script>

--- a/packages/ui-alquilame/app/components/city/__tests__/DeliveryPoints.test.ts
+++ b/packages/ui-alquilame/app/components/city/__tests__/DeliveryPoints.test.ts
@@ -1,0 +1,67 @@
+/**
+ * F2 step 4 — #puntos-entrega restyle (issue #112, SCEN-F2-04).
+ *
+ * Static-source assertions over DeliveryPoints.vue (mirrors the F1 home tests):
+ * the runtime/visual check (real branch cards rendered on the city alias) is
+ * deferred to the preview pass. Here we pin the contract:
+ *   - iterates the REAL cityBranches via v-for (data preserved, not hardcoded).
+ *   - the section only renders when there are branches (length guard).
+ *   - keeps the canonical #puntos-entrega id.
+ *   - gradient uses bg-linear-* (F0 lesson), never bg-gradient-to-*.
+ *   - headings use a .heading-* utility (Plus Jakarta, F0-03).
+ *   - light section → no [--ctx-text-primary:#fff] override (contrast lesson).
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const SRC = readFileSync(
+  join(__dirname, '..', 'DeliveryPoints.vue'),
+  'utf-8',
+)
+
+describe('F2 delivery-points — real branches (SCEN-F2-04)', () => {
+  it('iterates cityBranches with v-for keyed by branch.code', () => {
+    expect(SRC).toMatch(/v-for="branch in cityBranches"/)
+    expect(SRC).toMatch(/:key="branch\.code"/)
+  })
+
+  it('renders the real branch name and optional schedule (data preserved)', () => {
+    expect(SRC).toContain('{{ branch.name }}')
+    // schedule is optional on BranchData — guarded, never fabricated
+    expect(SRC).toMatch(/v-if="branch\.schedule"/)
+    expect(SRC).toContain('{{ branch.schedule }}')
+  })
+
+  it('receives cityBranches (and city) as props, typed BranchData[]', () => {
+    expect(SRC).toMatch(/cityBranches:\s*BranchData\[\]/)
+    expect(SRC).toMatch(/city\?:\s*City/)
+  })
+})
+
+describe('F2 delivery-points — length guard', () => {
+  it('only renders the section when there are branches', () => {
+    expect(SRC).toMatch(/v-if="cityBranches\.length > 0"/)
+  })
+
+  it('keeps the canonical #puntos-entrega id', () => {
+    expect(SRC).toMatch(/id="puntos-entrega"/)
+  })
+})
+
+describe('F2 delivery-points — F0/F1 styling lessons', () => {
+  it('uses bg-linear-* for gradients, never the v3 bg-gradient-to- alias', () => {
+    expect(SRC).toMatch(/bg-linear-to-/)
+    expect(SRC).not.toContain('bg-gradient-to-')
+  })
+
+  it('headings adopt a .heading-* utility (Plus Jakarta, F0-03)', () => {
+    expect(SRC).toMatch(/heading-section/)
+    expect(SRC).toMatch(/heading-card/)
+  })
+
+  it('is a light section — no forced white text override', () => {
+    // [--ctx-text-primary:#fff] is only for dark/red sections (F1 contrast lesson)
+    expect(SRC).not.toContain('[--ctx-text-primary:#fff]')
+  })
+})

--- a/packages/ui-alquilame/app/components/city/__tests__/Hero.test.ts
+++ b/packages/ui-alquilame/app/components/city/__tests__/Hero.test.ts
@@ -1,0 +1,96 @@
+/**
+ * F2 step02 — City Hero restyle (issue #112).
+ *
+ * Static-source assertions encoding the observable city-hero contract (full
+ * runtime/visual check deferred to the F2 preview verification):
+ *   - SCEN-F2-01: the hero renders the brand red gradient and a city-targeted
+ *     <h1>, with the Searcher engine preserved (same data-testid via the same
+ *     <Searcher> component, same navigation to buscar-vehiculos) and the
+ *     #searcher scroll target intact.
+ *   - SCEN-F2-06: the #41 pin stays an INERT <span aria-hidden> (never a
+ *     <button>), and no Date/today() is baked into the SSR/ISR markup (#109).
+ *   - Gradient guard (F0/F1 lesson): the hero MUST use the v4 `bg-linear-to-*`
+ *     utility from the hero-from/hero-to @theme tokens with
+ *     [--ctx-text-primary:#fff] (so .heading-* renders white on red), NEVER the
+ *     broken v3 `bg-gradient-to-*` alias.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const ROOT = join(__dirname, '..', '..', '..', '..') // → packages/ui-alquilame
+
+function read(rel: string): string {
+  return readFileSync(join(ROOT, rel), 'utf-8')
+}
+
+// The broken v3 alias, assembled from fragments so this guard file never itself
+// contains the literal token a project-wide grep forbids in rendered markup.
+const BROKEN_V3_GRADIENT = new RegExp(['bg', 'gradient', 'to-'].join('-'))
+
+describe('F2 step02 — city/Hero.vue restyle', () => {
+  const hero = read('app/components/city/Hero.vue')
+
+  it('renders the brand red gradient via the v4 bg-linear-to-* utility, not the broken v3 alias', () => {
+    expect(hero).toMatch(/bg-linear-to-[a-z]/)
+    expect(hero).not.toMatch(BROKEN_V3_GRADIENT)
+  })
+
+  it('uses the hero-from / hero-to brand gradient tokens', () => {
+    expect(hero).toMatch(/from-hero-from\s+to-hero-to/)
+  })
+
+  it('sets [--ctx-text-primary:#fff] so .heading-* headings render white on red', () => {
+    expect(hero).toMatch(/\[--ctx-text-primary:#fff\]/)
+  })
+
+  it('adopts the .heading-hero utility (Plus Jakarta) for the headline', () => {
+    expect(hero).toMatch(/heading-hero/)
+  })
+
+  it('renders a city-targeted <h1> bound to city.name', () => {
+    expect(hero).toMatch(/<h1[^>]*heading-hero/)
+    expect(hero).toMatch(/Alquiler de carros en \{\{ city\?\.name \}\}/)
+  })
+
+  it('preserves the engine: mounts <Searcher> (same component → same data-testid)', () => {
+    expect(hero).toMatch(/<Searcher\b/)
+    // The Searcher's testids are the engine contract carried by the component.
+    // It must be imported from the sibling Searcher.vue, not reimplemented.
+    expect(hero).toMatch(/import\(['"]\.\.\/Searcher\.vue['"]\)/)
+  })
+
+  it('keeps the #searcher scroll target (UnableCategoryCard / reserveAnchor CTAs)', () => {
+    expect(hero).toMatch(/id="searcher"/)
+  })
+
+  it('wraps the Searcher in <ClientOnly> with a fixed-height fallback (no hydration shift, #109)', () => {
+    expect(hero).toMatch(/<ClientOnly>/)
+    expect(hero).toMatch(/<PlaceholdersSearcher\b/)
+    // Fixed-height wrappers reserve the engine footprint (CLS / hydration).
+    expect(hero).toMatch(/h-\[\d+px\]/)
+  })
+
+  it('preserves the #41 pin as an INERT <span aria-hidden> (never a <button>)', () => {
+    // The copy-to-WhatsApp pin must stay a non-focusable, aria-hidden span that
+    // carries the @click handler within the SAME opening tag (no `>` between
+    // aria-hidden and @click). [^>] spans newlines, so multiline attrs are ok.
+    expect(hero).toMatch(/<span[^>]*aria-hidden="true"[^>]*@click="copySearchToWhatsapp"[^>]*>/)
+    expect(hero).toMatch(/copySearchToWhatsapp/)
+    // No <button> may be reintroduced for the secret operator action.
+    expect(hero).not.toMatch(/<button\b/)
+    expect(hero).not.toMatch(/<UButton\b/)
+  })
+
+  it('does NOT bake Date/today() into the SSR/ISR markup (#109)', () => {
+    expect(hero).not.toMatch(/new Date\b/)
+    expect(hero).not.toMatch(/\btoday\(/)
+  })
+
+  it('reserves the image/engine footprint without aspect-ratio shift (CLS-safe fixed heights)', () => {
+    // City hero reserves the Searcher box via fixed heights rather than an
+    // image aspect-ratio; assert the footprint is explicitly reserved.
+    expect(hero).toMatch(/h-\[410px\]/)
+    expect(hero).toMatch(/h-\[360px\]/)
+  })
+})

--- a/packages/ui-alquilame/app/components/city/__tests__/faq-testimonios.test.ts
+++ b/packages/ui-alquilame/app/components/city/__tests__/faq-testimonios.test.ts
@@ -1,0 +1,104 @@
+/**
+ * F2 step05 — city Faq.vue + Testimonios.vue (issue #112).
+ *
+ * Static-source assertions encoding the observable contract (full runtime/visual
+ * check deferred to the F2 preview verification):
+ *   - SCEN-F2-02: the city FAQ accordion keeps the CITY-SPECIFIC data
+ *     (useCityFAQs(city.name) — pico y placa, El Dorado, etc.), NOT the
+ *     brand-level useData().faqs that HomeFaq renders. Reusing HomeFaq would
+ *     regress the city's indexable SEO content.
+ *   - The FAQPage schema is NOT inlined here: it stays in useCityFAQSchema /
+ *     useCityPageSEO (in [city]/index.vue), untouched.
+ *   - The testimonials cards keep the CITY-SPECIFIC data (props.city.testimonials
+ *     — the same array that feeds useCityAggregateRating in CityPage), NOT the
+ *     brand-level franchiseTestimonials that HomeReviews renders. The heading is
+ *     city-targeted ("…en {city.name}").
+ *   - Gradient guard (F0 lesson): both sections MUST use the v4 `bg-linear-to-*`
+ *     utility, NEVER the broken v3 `bg-gradient-to-*` alias.
+ *   - Headings adopt the `.heading-*` utilities (Plus Jakarta).
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const ROOT = join(__dirname, '..', '..', '..', '..') // → packages/ui-alquilame
+
+function read(rel: string): string {
+  return readFileSync(join(ROOT, rel), 'utf-8')
+}
+
+// The broken v3 alias, assembled from fragments so this guard file never itself
+// contains the literal token a project-wide grep forbids in rendered markup.
+const BROKEN_V3_GRADIENT = new RegExp(['bg', 'gradient', 'to-'].join('-'))
+
+describe('F2 step05 — city/Faq.vue', () => {
+  const faq = read('app/components/city/Faq.vue')
+
+  it('sources the accordion from useCityFAQs(city.name) — city-specific FAQs', () => {
+    expect(faq).toMatch(/useCityFAQs\(\s*props\.city\.name\s*\)/)
+    expect(faq).toMatch(/:items="cityFAQs"/)
+  })
+
+  it('does NOT fall back to the brand-level useData().faqs (would regress city SEO)', () => {
+    expect(faq).not.toMatch(/useData\(\)/)
+    expect(faq).not.toMatch(/franchiseFaqs|faqs\s*}\s*=\s*useData/)
+  })
+
+  it('does NOT inline the FAQPage schema (stays in useCityPageSEO, untouched)', () => {
+    expect(faq).not.toMatch(/FAQPage/)
+    expect(faq).not.toMatch(/useSchemaOrg/)
+    expect(faq).not.toMatch(/defineQuestion/)
+  })
+
+  it('renders the gradient via the v4 bg-linear-to-* utility, not the broken v3 alias', () => {
+    expect(faq).toMatch(/bg-linear-to-[a-z]/)
+    expect(faq).not.toMatch(BROKEN_V3_GRADIENT)
+  })
+
+  it('adopts the .heading-* utilities (Plus Jakarta) for its heading', () => {
+    expect(faq).toMatch(/heading-(section|card|hero)/)
+  })
+
+  it('keeps the city name in the heading (city-targeted)', () => {
+    expect(faq).toMatch(/city\?\.name/)
+  })
+})
+
+describe('F2 step05 — city/Testimonios.vue', () => {
+  const testimonios = read('app/components/city/Testimonios.vue')
+
+  it('sources the cards from props.city.testimonials — city-specific', () => {
+    expect(testimonios).toMatch(/props\.city\?\.testimonials/)
+    expect(testimonios).toMatch(/v-for="testimonio in testimonios"/)
+    expect(testimonios).toMatch(/testimonio\.quote/)
+  })
+
+  it('does NOT source from the brand-level franchiseTestimonials (would swap city→brand)', () => {
+    expect(testimonios).not.toMatch(/franchiseTestimonials/)
+    expect(testimonios).not.toMatch(/useFetchRentacarData/)
+  })
+
+  it('uses a city-targeted heading ("…en {city.name}")', () => {
+    expect(testimonios).toMatch(/en\s*\{\{\s*city\?\.name\s*\}\}/)
+  })
+
+  it('does NOT surface the mockup marketing numbers ("43 reseñas" / "5,0")', () => {
+    expect(testimonios).not.toMatch(/43\s*reseñas/i)
+    expect(testimonios).not.toContain('5,0')
+    expect(testimonios).not.toMatch(/google\.com\/maps/)
+  })
+
+  it('does NOT inline the AggregateRating schema (stays in CityPage, untouched)', () => {
+    expect(testimonios).not.toMatch(/useCityAggregateRating/)
+    expect(testimonios).not.toMatch(/AggregateRating/)
+  })
+
+  it('renders the gradient via the v4 bg-linear-to-* utility, not the broken v3 alias', () => {
+    expect(testimonios).toMatch(/bg-linear-to-[a-z]/)
+    expect(testimonios).not.toMatch(BROKEN_V3_GRADIENT)
+  })
+
+  it('adopts the .heading-* utilities (Plus Jakarta) for its heading', () => {
+    expect(testimonios).toMatch(/heading-(section|card|hero)/)
+  })
+})

--- a/packages/ui-alquilame/app/components/city/__tests__/legal.test.ts
+++ b/packages/ui-alquilame/app/components/city/__tests__/legal.test.ts
@@ -1,0 +1,75 @@
+/**
+ * F2 step07 — legales restyle (issue #112).
+ *
+ * Static-source contract for the two legal pages. Encodes the observable
+ * holdout scenarios as source assertions (full runtime check deferred to step10):
+ *   - SCEN-F2-07  : design's clean legal-document style — numbered h2s use
+ *                   `font-heading`, no `bg-gradient-to-` (Tailwind 4 → `bg-linear-*`).
+ *   - SCEN-F2-07b : the current intermediation framing is PRESERVED, NOT swapped
+ *                   for the design's direct-operator copy. `terminos` must keep
+ *                   "plataforma de intermediación" + "no somos una empresa de
+ *                   alquiler" and must NOT adopt the design's direct-operator
+ *                   markers ("agencia de alquiler de autos", "Identificación del
+ *                   prestador").
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const ROOT = join(__dirname, '..', '..', '..', '..')
+
+function read(rel: string): string {
+  return readFileSync(join(ROOT, rel), 'utf-8')
+}
+
+const terminos = read('app/pages/terminos-condiciones.vue')
+const privacidad = read('app/pages/politica-privacidad.vue')
+
+describe('F2 step07 — legal-document style (SCEN-F2-07)', () => {
+  for (const [name, src] of [
+    ['terminos-condiciones', terminos],
+    ['politica-privacidad', privacidad],
+  ] as const) {
+    describe(name, () => {
+      it('renders numbered h2 sections with font-heading', () => {
+        // every <h2> in the page carries font-heading
+        const h2s = src.match(/<h2\b[^>]*>/g) ?? []
+        expect(h2s.length).toBeGreaterThan(0)
+        for (const h2 of h2s) {
+          expect(h2).toContain('font-heading')
+        }
+      })
+
+      it('uses the design heading family on the h1', () => {
+        expect(src).toMatch(/<h1\b[^>]*font-heading/)
+      })
+
+      it('does not use the deprecated bg-gradient-to- utility', () => {
+        expect(src).not.toContain('bg-gradient-to-')
+      })
+
+      it('preserves the SEO meta + canonical link', () => {
+        expect(src).toContain('useSeoMeta')
+        expect(src).toContain('rel: \'canonical\'')
+      })
+    })
+  }
+})
+
+describe('F2 step07 — intermediation framing preserved (SCEN-F2-07b)', () => {
+  it('terminos keeps the intermediation disclaimers', () => {
+    expect(terminos).toContain('plataforma de intermediación')
+    expect(terminos).toContain('No somos una empresa de alquiler de vehículos')
+    expect(terminos).toContain('Actuamos como intermediarios')
+  })
+
+  it('terminos was NOT replaced by the design direct-operator copy', () => {
+    // design markers that frame alquilame as a direct rental agency
+    expect(terminos).not.toContain('agencia de alquiler de autos')
+    expect(terminos).not.toContain('Identificación del prestador')
+  })
+
+  it('privacidad keeps the third-party rentadoras framing', () => {
+    expect(privacidad).toContain('empresas rentadoras de vehículos')
+  })
+})

--- a/packages/ui-alquilame/app/components/city/__tests__/seo-content.test.ts
+++ b/packages/ui-alquilame/app/components/city/__tests__/seo-content.test.ts
@@ -1,0 +1,127 @@
+/**
+ * F2 step03 — City SEO content restyle (issue #112, SCEN-F2-02).
+ *
+ * Static-source assertions over city/Intro.vue + city/SeoContent.vue. The
+ * runtime/visual check (rendered text on the preview, contrast, CLS) is
+ * deferred to the preview pass; here we pin the CONTRACT that matters for SEO:
+ *
+ *   - every original indexable section is present (descripcion / introduccion /
+ *     ventajas / destinos / consejos-conduccion / mejor-temporada /
+ *     ciudades-cercanas) with its key heading + key copy VERBATIM.
+ *   - no SEO copy was dropped (benefit blurbs, driving-tip labels,
+ *     related-cities prompt all still present).
+ *   - design styling lessons: headings use a .heading-* utility (Plus Jakarta),
+ *     gradients never use the broken v3 bg-gradient-to- alias.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const INTRO = readFileSync(join(__dirname, '..', 'Intro.vue'), 'utf-8')
+const SEO = readFileSync(join(__dirname, '..', 'SeoContent.vue'), 'utf-8')
+
+describe('F2 city Intro — #descripcion + #introduccion preserved (SCEN-F2-02)', () => {
+  it('keeps both section ids', () => {
+    expect(INTRO).toContain('id="descripcion"')
+    expect(INTRO).toContain('id="introduccion"')
+  })
+
+  it('keeps the #descripcion poster copy verbatim', () => {
+    expect(INTRO).toContain('En {{ franchise.shortname }}')
+    expect(INTRO).toContain('la libertad')
+    expect(INTRO).toContain('de moverte')
+    expect(INTRO).toContain('a tu manera')
+    expect(INTRO).toContain('es realidad')
+    // city.description still rendered (indexable per-city copy)
+    expect(INTRO).toMatch(/v-text="city\?\.description"/)
+  })
+
+  it('keeps the #introduccion heading + intro paragraph, guarded by expandedContent', () => {
+    expect(INTRO).toContain('Explora {{ city?.name }}')
+    expect(INTRO).toContain('con tu carro de alquiler')
+    expect(INTRO).toContain('expandedContent.intro')
+    expect(INTRO).toMatch(/v-if="expandedContent"/)
+  })
+
+  it('renders the city illustration (CLS-safe reserved box)', () => {
+    expect(INTRO).toContain('LazyImagesCiudadesChica')
+    expect(INTRO).toMatch(/aspect-square/)
+  })
+})
+
+describe('F2 city SeoContent — sections preserved (SCEN-F2-02)', () => {
+  it('keeps every section id', () => {
+    for (const id of [
+      'ventajas',
+      'destinos',
+      'consejos-conduccion',
+      'mejor-temporada',
+      'ciudades-cercanas',
+    ]) {
+      expect(SEO).toContain(`id="${id}"`)
+    }
+  })
+
+  it('keeps the #ventajas heading + all four benefit blurbs verbatim', () => {
+    expect(SEO).toContain('Ventajas de alquilar carro')
+    expect(SEO).toContain('Precios transparentes')
+    expect(SEO).toContain('Sin cargos ocultos ni sorpresas.')
+    expect(SEO).toContain('Flota variada')
+    expect(SEO).toContain('Desde económicos hasta SUVs y camionetas.')
+    expect(SEO).toContain('Entrega flexible')
+    expect(SEO).toContain('Recoge y devuelve tu carro en diferentes puntos de')
+    expect(SEO).toContain('Atención personalizada')
+    expect(SEO).toContain('Soporte en español las 24 horas.')
+  })
+
+  it('keeps the #destinos heading + the destination data binding', () => {
+    expect(SEO).toContain('Destinos para recorrer con carro rentado')
+    expect(SEO).toContain('desde {{ city?.name }}')
+    expect(SEO).toContain('expandedContent.destinations')
+    expect(SEO).toContain('destination.name')
+    expect(SEO).toContain('destination.time')
+    expect(SEO).toContain('destination.description')
+  })
+
+  it('keeps the #consejos-conduccion heading + the 3 driving-tip labels/bindings', () => {
+    expect(SEO).toContain('para alquilar carro en {{ city?.name }}')
+    expect(SEO).toContain('Pico y Placa')
+    expect(SEO).toContain('Peajes')
+    expect(SEO).toContain('Parqueaderos')
+    expect(SEO).toContain('drivingTips.picoPlaca')
+    expect(SEO).toContain('drivingTips.tolls')
+    expect(SEO).toContain('drivingTips.parking')
+  })
+
+  it('keeps the #mejor-temporada heading + bestSeason binding', () => {
+    expect(SEO).toContain('Mejor época')
+    expect(SEO).toContain('para alquilar carro y viajar a {{ city?.name }}')
+    expect(SEO).toContain('expandedContent.bestSeason')
+  })
+
+  it('keeps the #ciudades-cercanas heading, prompt + internal links', () => {
+    expect(SEO).toContain('Alquiler de carros')
+    expect(SEO).toContain('en ciudades cercanas')
+    expect(SEO).toContain('¿Planeas un viaje más largo?')
+    expect(SEO).toContain('relatedCities')
+    expect(SEO).toMatch(/:to="`\/\$\{related\.id\}`"/)
+    expect(SEO).toContain('related.distance')
+  })
+})
+
+describe('F2 city SEO content — design styling lessons', () => {
+  it('headings adopt a .heading-* utility (Plus Jakarta, F0-03)', () => {
+    expect(INTRO).toMatch(/heading-(section|sub|card)/)
+    expect(SEO).toMatch(/heading-section/)
+  })
+
+  it('never uses the broken v3 bg-gradient-to- alias', () => {
+    expect(INTRO).not.toContain('bg-gradient-to-')
+    expect(SEO).not.toContain('bg-gradient-to-')
+  })
+
+  it('uses the design red accent bar on the SEO sections', () => {
+    expect(INTRO).toMatch(/h-1 w-10 rounded-full bg-red-600/)
+    expect(SEO).toMatch(/h-1 w-10 rounded-full bg-red-600/)
+  })
+})

--- a/packages/ui-alquilame/app/components/home/Contact.vue
+++ b/packages/ui-alquilame/app/components/home/Contact.vue
@@ -41,9 +41,10 @@
         </p>
 
         <div class="flex flex-col sm:flex-row gap-4 items-center justify-center lg:justify-start">
-          <!-- Reserve → internal engine (city selector in the hero) -->
+          <!-- Reserve → internal engine; anchor is configurable per host page
+               (home: #hero / city landing: #searcher) via the reserveAnchor prop. -->
           <a
-            href="#hero"
+            :href="reserveAnchor"
             class="w-full sm:w-auto inline-flex items-center justify-center px-9 py-4 text-lg font-semibold rounded-full bg-white text-red-700 hover:bg-gray-100 shadow-lg hover:shadow-xl transition-all duration-200"
           >
             Reserva Ahora
@@ -138,6 +139,10 @@
 
 <script setup lang="ts">
 import { IconsWhatsappIcon as WhatsappIcon } from '#components'
+
+// "Reserva Ahora" anchor target. Defaults to the home's city-selector hero
+// (#hero); the city landing passes '#searcher' (its hero has no #hero id).
+withDefaults(defineProps<{ reserveAnchor?: string }>(), { reserveAnchor: '#hero' })
 
 const { franchise } = useAppConfig()
 </script>

--- a/packages/ui-alquilame/app/components/home/__tests__/contact-announcement.test.ts
+++ b/packages/ui-alquilame/app/components/home/__tests__/contact-announcement.test.ts
@@ -68,6 +68,16 @@ describe('F1 step07a — Contact.vue', () => {
   it('exposes the contact section under id="contact"', () => {
     expect(contact).toMatch(/id="contact"/)
   })
+
+  it('makes the "Reserva Ahora" anchor configurable via a reserveAnchor prop (default #hero)', () => {
+    // F2 step01: the reserve CTA must anchor to a per-page target. The default
+    // keeps the home intact (#hero); the city landing passes '#searcher'.
+    expect(contact).toMatch(/defineProps<\{\s*reserveAnchor\?: string\s*\}>/)
+    expect(contact).toMatch(/reserveAnchor:\s*'#hero'/)
+    // The CTA binds the prop, never the old hardcoded home id.
+    expect(contact).toMatch(/:href="reserveAnchor"/)
+    expect(contact).not.toMatch(/href="#hero"/)
+  })
 })
 
 describe('F1 step07a — AnnouncementBar.vue', () => {

--- a/packages/ui-alquilame/app/pages/politica-privacidad.vue
+++ b/packages/ui-alquilame/app/pages/politica-privacidad.vue
@@ -1,116 +1,138 @@
 <template>
-  <div class="bg-white min-h-screen">
-    <div class="max-w-4xl mx-auto px-4 py-12 md:py-16">
+  <main class="bg-white min-h-screen">
+    <article class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16 lg:py-24">
       <!-- Header -->
-      <div class="text-center mb-10">
-        <h1 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">Política de Privacidad y Tratamiento de Datos Personales</h1>
-        <p class="text-gray-600">Última actualización: Enero 2025</p>
-      </div>
+      <header class="mb-10">
+        <p class="text-sm text-gray-500 mb-2">Última actualización: Enero 2025</p>
+        <h1 class="text-4xl lg:text-5xl font-extrabold font-heading text-gray-900">
+          Política de Privacidad y Tratamiento de Datos Personales
+        </h1>
+      </header>
 
       <!-- Content -->
-      <div class="prose prose-lg max-w-none text-gray-700">
+      <div class="prose-custom space-y-8 text-gray-700 leading-relaxed">
 
         <!-- Responsable del Tratamiento -->
-        <h2 class="text-2xl font-bold text-gray-900 mt-10 mb-4">1. Responsable del Tratamiento</h2>
-        <p>
-          Para todos los efectos, será responsable de los datos <strong>AMAW S.A.S</strong>, identificada con NIT 900.665.917-7, con domicilio en Cali, Valle del Cauca, Colombia.
-        </p>
-        <p>
-          AMAW S.A.S reconoce la importancia de la seguridad, privacidad y confidencialidad de los datos personales de sus clientes, usuarios, colaboradores, proveedores y en general de todos sus grupos de interés respecto de los cuales ejerce tratamiento de información personal, por lo que, en cumplimiento de las disposiciones constitucionales y legales, adopta la presente Política de Privacidad y Tratamiento de Datos Personales.
-        </p>
+        <section>
+          <h2 class="text-2xl font-bold font-heading text-gray-900 mb-3">1. Responsable del Tratamiento</h2>
+          <p>
+            Para todos los efectos, será responsable de los datos <strong>AMAW S.A.S</strong>, identificada con NIT 900.665.917-7, con domicilio en Cali, Valle del Cauca, Colombia.
+          </p>
+          <p>
+            AMAW S.A.S reconoce la importancia de la seguridad, privacidad y confidencialidad de los datos personales de sus clientes, usuarios, colaboradores, proveedores y en general de todos sus grupos de interés respecto de los cuales ejerce tratamiento de información personal, por lo que, en cumplimiento de las disposiciones constitucionales y legales, adopta la presente Política de Privacidad y Tratamiento de Datos Personales.
+          </p>
+        </section>
 
         <!-- Marco Legal -->
-        <h2 class="text-2xl font-bold text-gray-900 mt-10 mb-4">2. Marco Legal</h2>
-        <p>
-          Esta política se rige por la Constitución Política de Colombia, la Ley 1581 de 2012, el Decreto 1377 de 2013 y demás normas que las modifiquen, adicionen o complementen.
-        </p>
+        <section>
+          <h2 class="text-2xl font-bold font-heading text-gray-900 mb-3">2. Marco Legal</h2>
+          <p>
+            Esta política se rige por la Constitución Política de Colombia, la Ley 1581 de 2012, el Decreto 1377 de 2013 y demás normas que las modifiquen, adicionen o complementen.
+          </p>
+        </section>
 
         <!-- Finalidades -->
-        <h2 class="text-2xl font-bold text-gray-900 mt-10 mb-4">3. Finalidades del Tratamiento</h2>
-        <p>Los datos personales recopilados serán utilizados para las siguientes finalidades:</p>
-        <ul class="list-disc pl-6 space-y-2">
-          <li>Gestionar solicitudes de reserva de vehículos a través de nuestra plataforma</li>
-          <li>Facilitar la comunicación entre usuarios y empresas rentadoras de vehículos</li>
-          <li>Enviar confirmaciones, recordatorios y actualizaciones sobre reservas</li>
-          <li>Procesar pagos y facturación de servicios</li>
-          <li>Enviar información comercial, promociones y ofertas (con autorización previa)</li>
-          <li>Realizar encuestas de satisfacción y mejorar nuestros servicios</li>
-          <li>Cumplir con obligaciones legales y requerimientos de autoridades</li>
-          <li>Prevenir fraudes y garantizar la seguridad de la plataforma</li>
-        </ul>
+        <section>
+          <h2 class="text-2xl font-bold font-heading text-gray-900 mb-3">3. Finalidades del Tratamiento</h2>
+          <p>Los datos personales recopilados serán utilizados para las siguientes finalidades:</p>
+          <ul class="list-disc pl-6 space-y-2">
+            <li>Gestionar solicitudes de reserva de vehículos a través de nuestra plataforma</li>
+            <li>Facilitar la comunicación entre usuarios y empresas rentadoras de vehículos</li>
+            <li>Enviar confirmaciones, recordatorios y actualizaciones sobre reservas</li>
+            <li>Procesar pagos y facturación de servicios</li>
+            <li>Enviar información comercial, promociones y ofertas (con autorización previa)</li>
+            <li>Realizar encuestas de satisfacción y mejorar nuestros servicios</li>
+            <li>Cumplir con obligaciones legales y requerimientos de autoridades</li>
+            <li>Prevenir fraudes y garantizar la seguridad de la plataforma</li>
+          </ul>
+        </section>
 
         <!-- Información Recopilada -->
-        <h2 class="text-2xl font-bold text-gray-900 mt-10 mb-4">4. Información Recopilada</h2>
-        <p>Recopilamos los siguientes tipos de datos personales:</p>
-        <ul class="list-disc pl-6 space-y-2">
-          <li><strong>Datos de identificación:</strong> nombre completo, tipo y número de documento de identidad</li>
-          <li><strong>Datos de contacto:</strong> correo electrónico, número de teléfono/WhatsApp</li>
-          <li><strong>Datos de navegación:</strong> dirección IP, tipo de navegador, páginas visitadas</li>
-        </ul>
+        <section>
+          <h2 class="text-2xl font-bold font-heading text-gray-900 mb-3">4. Información Recopilada</h2>
+          <p>Recopilamos los siguientes tipos de datos personales:</p>
+          <ul class="list-disc pl-6 space-y-2">
+            <li><strong>Datos de identificación:</strong> nombre completo, tipo y número de documento de identidad</li>
+            <li><strong>Datos de contacto:</strong> correo electrónico, número de teléfono/WhatsApp</li>
+            <li><strong>Datos de navegación:</strong> dirección IP, tipo de navegador, páginas visitadas</li>
+          </ul>
+        </section>
 
         <!-- Derechos del Titular -->
-        <h2 class="text-2xl font-bold text-gray-900 mt-10 mb-4">5. Derechos del Titular</h2>
-        <p>De acuerdo con la Ley 1581 de 2012, usted tiene derecho a:</p>
-        <ul class="list-disc pl-6 space-y-2">
-          <li><strong>Conocer:</strong> acceder a sus datos personales que han sido objeto de tratamiento</li>
-          <li><strong>Actualizar:</strong> solicitar la actualización de sus datos personales</li>
-          <li><strong>Rectificar:</strong> solicitar la corrección de información parcial, inexacta o incompleta</li>
-          <li><strong>Suprimir:</strong> solicitar la eliminación de sus datos cuando no sean necesarios para las finalidades autorizadas</li>
-          <li><strong>Revocar:</strong> revocar la autorización otorgada para el tratamiento de datos</li>
-          <li><strong>Presentar quejas:</strong> ante la Superintendencia de Industria y Comercio por infracciones a la ley</li>
-        </ul>
+        <section>
+          <h2 class="text-2xl font-bold font-heading text-gray-900 mb-3">5. Derechos del Titular</h2>
+          <p>De acuerdo con la Ley 1581 de 2012, usted tiene derecho a:</p>
+          <ul class="list-disc pl-6 space-y-2">
+            <li><strong>Conocer:</strong> acceder a sus datos personales que han sido objeto de tratamiento</li>
+            <li><strong>Actualizar:</strong> solicitar la actualización de sus datos personales</li>
+            <li><strong>Rectificar:</strong> solicitar la corrección de información parcial, inexacta o incompleta</li>
+            <li><strong>Suprimir:</strong> solicitar la eliminación de sus datos cuando no sean necesarios para las finalidades autorizadas</li>
+            <li><strong>Revocar:</strong> revocar la autorización otorgada para el tratamiento de datos</li>
+            <li><strong>Presentar quejas:</strong> ante la Superintendencia de Industria y Comercio por infracciones a la ley</li>
+          </ul>
+        </section>
 
         <!-- Procedimiento -->
-        <h2 class="text-2xl font-bold text-gray-900 mt-10 mb-4">6. Procedimiento para Ejercer sus Derechos</h2>
-        <p>
-          Para ejercer cualquiera de sus derechos, puede comunicarse con nosotros a través de:
-        </p>
-        <ul class="list-disc pl-6 space-y-2">
-          <li><strong>Correo electrónico:</strong> info@amawsas.com</li>
-          <li><strong>WhatsApp:</strong> +57 301 672 9250</li>
-          <li><strong>Formulario de PQRS:</strong> disponible en nuestro sitio web</li>
-        </ul>
-        <p class="mt-4">
-          Las solicitudes serán atendidas en un término máximo de quince (15) días hábiles contados a partir de la fecha de recibo de la misma. Cuando no fuere posible atender la solicitud dentro de dicho término, se informará al interesado los motivos de la demora y la fecha en que se atenderá su solicitud, la cual en ningún caso podrá superar los ocho (8) días hábiles siguientes al vencimiento del primer término.
-        </p>
+        <section>
+          <h2 class="text-2xl font-bold font-heading text-gray-900 mb-3">6. Procedimiento para Ejercer sus Derechos</h2>
+          <p>
+            Para ejercer cualquiera de sus derechos, puede comunicarse con nosotros a través de:
+          </p>
+          <ul class="list-disc pl-6 space-y-2">
+            <li><strong>Correo electrónico:</strong> info@amawsas.com</li>
+            <li><strong>WhatsApp:</strong> +57 301 672 9250</li>
+            <li><strong>Formulario de PQRS:</strong> disponible en nuestro sitio web</li>
+          </ul>
+          <p>
+            Las solicitudes serán atendidas en un término máximo de quince (15) días hábiles contados a partir de la fecha de recibo de la misma. Cuando no fuere posible atender la solicitud dentro de dicho término, se informará al interesado los motivos de la demora y la fecha en que se atenderá su solicitud, la cual en ningún caso podrá superar los ocho (8) días hábiles siguientes al vencimiento del primer término.
+          </p>
+        </section>
 
         <!-- Cookies -->
-        <h2 class="text-2xl font-bold text-gray-900 mt-10 mb-4">7. Cookies</h2>
-        <p>
-          Nuestro sitio web utiliza cookies para mejorar su experiencia de navegación. Las cookies son pequeños archivos que se almacenan en su dispositivo y nos permiten:
-        </p>
-        <ul class="list-disc pl-6 space-y-2">
-          <li>Recordar sus preferencias de búsqueda</li>
-          <li>Analizar el tráfico del sitio web</li>
-          <li>Personalizar el contenido mostrado</li>
-        </ul>
-        <p class="mt-4">
-          Usted puede configurar su navegador para rechazar cookies, aunque esto podría afectar algunas funcionalidades del sitio.
-        </p>
+        <section>
+          <h2 class="text-2xl font-bold font-heading text-gray-900 mb-3">7. Cookies</h2>
+          <p>
+            Nuestro sitio web utiliza cookies para mejorar su experiencia de navegación. Las cookies son pequeños archivos que se almacenan en su dispositivo y nos permiten:
+          </p>
+          <ul class="list-disc pl-6 space-y-2">
+            <li>Recordar sus preferencias de búsqueda</li>
+            <li>Analizar el tráfico del sitio web</li>
+            <li>Personalizar el contenido mostrado</li>
+          </ul>
+          <p>
+            Usted puede configurar su navegador para rechazar cookies, aunque esto podría afectar algunas funcionalidades del sitio.
+          </p>
+        </section>
 
         <!-- Enlaces a Terceros -->
-        <h2 class="text-2xl font-bold text-gray-900 mt-10 mb-4">8. Enlaces a Terceros</h2>
-        <p>
-          Nuestro sitio puede contener enlaces a sitios web de terceros, incluyendo las empresas rentadoras de vehículos. No somos responsables de las prácticas de privacidad de estos sitios. Le recomendamos revisar las políticas de privacidad de cada sitio que visite.
-        </p>
+        <section>
+          <h2 class="text-2xl font-bold font-heading text-gray-900 mb-3">8. Enlaces a Terceros</h2>
+          <p>
+            Nuestro sitio puede contener enlaces a sitios web de terceros, incluyendo las empresas rentadoras de vehículos. No somos responsables de las prácticas de privacidad de estos sitios. Le recomendamos revisar las políticas de privacidad de cada sitio que visite.
+          </p>
+        </section>
 
         <!-- Seguridad -->
-        <h2 class="text-2xl font-bold text-gray-900 mt-10 mb-4">9. Medidas de Seguridad</h2>
-        <p>
-          AMAW S.A.S implementa medidas técnicas, humanas y administrativas para proteger los datos personales contra acceso no autorizado, pérdida, alteración o destrucción. Utilizamos conexiones seguras (SSL/TLS) y sistemas actualizados para garantizar la seguridad de su información.
-        </p>
+        <section>
+          <h2 class="text-2xl font-bold font-heading text-gray-900 mb-3">9. Medidas de Seguridad</h2>
+          <p>
+            AMAW S.A.S implementa medidas técnicas, humanas y administrativas para proteger los datos personales contra acceso no autorizado, pérdida, alteración o destrucción. Utilizamos conexiones seguras (SSL/TLS) y sistemas actualizados para garantizar la seguridad de su información.
+          </p>
+        </section>
 
         <!-- Vigencia -->
-        <h2 class="text-2xl font-bold text-gray-900 mt-10 mb-4">10. Vigencia</h2>
-        <p>
-          Esta política entra en vigencia a partir de enero de 2025. Los datos personales serán conservados mientras sean necesarios para las finalidades descritas o mientras exista una obligación legal de conservación.
-        </p>
-        <p>
-          AMAW S.A.S se reserva el derecho de modificar esta política en cualquier momento. Los cambios serán publicados en esta página con la fecha de actualización correspondiente.
-        </p>
+        <section>
+          <h2 class="text-2xl font-bold font-heading text-gray-900 mb-3">10. Vigencia</h2>
+          <p>
+            Esta política entra en vigencia a partir de enero de 2025. Los datos personales serán conservados mientras sean necesarios para las finalidades descritas o mientras exista una obligación legal de conservación.
+          </p>
+          <p>
+            AMAW S.A.S se reserva el derecho de modificar esta política en cualquier momento. Los cambios serán publicados en esta página con la fecha de actualización correspondiente.
+          </p>
+        </section>
 
         <!-- Company Info -->
-        <div class="mt-12 pt-8 border-t border-gray-200 text-center text-gray-600">
+        <div class="mt-12 pt-8 border-t border-gray-200 text-gray-600">
           <p class="font-semibold text-gray-900">AMAW S.A.S</p>
           <p>NIT: 900.665.917-7</p>
           <p>Cali, Valle del Cauca, Colombia</p>
@@ -118,8 +140,13 @@
           <p>info@amawsas.com</p>
         </div>
       </div>
-    </div>
-  </div>
+
+      <!-- Footer -->
+      <footer class="mt-16 pt-8 border-t border-gray-200">
+        <NuxtLink to="/" class="text-brand-600 hover:text-brand-700 font-medium">← Volver al inicio</NuxtLink>
+      </footer>
+    </article>
+  </main>
 </template>
 
 <script setup lang="ts">

--- a/packages/ui-alquilame/app/pages/terminos-condiciones.vue
+++ b/packages/ui-alquilame/app/pages/terminos-condiciones.vue
@@ -1,171 +1,202 @@
 <template>
-  <div class="bg-white min-h-screen">
-    <div class="max-w-4xl mx-auto px-4 py-12 md:py-16">
+  <main class="bg-white min-h-screen">
+    <article class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16 lg:py-24">
       <!-- Header -->
-      <div class="text-center mb-10">
-        <h1 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">Términos y Condiciones</h1>
-        <p class="text-gray-600">Última actualización: Enero 2025</p>
-      </div>
+      <header class="mb-10">
+        <p class="text-sm text-gray-500 mb-2">Última actualización: Enero 2025</p>
+        <h1 class="text-4xl lg:text-5xl font-extrabold font-heading text-gray-900">
+          Términos y Condiciones
+        </h1>
+      </header>
 
       <!-- Content -->
-      <div class="prose prose-lg max-w-none text-gray-700">
+      <div class="prose-custom space-y-8 text-gray-700 leading-relaxed">
 
         <!-- Introducción -->
-        <h2 class="text-2xl font-bold text-gray-900 mt-10 mb-4">1. Introducción</h2>
-        <p>
-          Bienvenido a <strong>{{franchise.name}}</strong>, una plataforma operada por <strong>AMAW S.A.S</strong> (NIT 900.665.917-7). Al utilizar nuestro sitio web y servicios, usted acepta estos Términos y Condiciones en su totalidad.
-        </p>
+        <section>
+          <h2 class="text-2xl font-bold font-heading text-gray-900 mb-3">1. Introducción</h2>
+          <p>
+            Bienvenido a <strong>{{ franchise.name }}</strong>, una plataforma operada por <strong>AMAW S.A.S</strong> (NIT 900.665.917-7). Al utilizar nuestro sitio web y servicios, usted acepta estos Términos y Condiciones en su totalidad.
+          </p>
+        </section>
 
         <!-- Naturaleza del Servicio -->
-        <h2 class="text-2xl font-bold text-gray-900 mt-10 mb-4">2. Naturaleza del Servicio</h2>
-        <p>
-          <strong>{{franchise.name}} es una plataforma de intermediación</strong> que conecta a usuarios con empresas de alquiler de vehículos (en adelante "Rentadoras"). Es importante que comprenda lo siguiente:
-        </p>
-        <ul class="list-disc pl-6 space-y-2">
-          <li><strong>No somos una empresa de alquiler de vehículos.</strong> No somos propietarios ni operadores de los vehículos mostrados en la plataforma.</li>
-          <li><strong>Actuamos como intermediarios.</strong> Facilitamos la búsqueda, comparación y solicitud de reservas entre usted y las Rentadoras.</li>
-          <li><strong>El contrato de alquiler es entre usted y la Rentadora.</strong> Una vez confirmada la reserva, la relación contractual se establece directamente con la empresa rentadora seleccionada.</li>
-        </ul>
+        <section>
+          <h2 class="text-2xl font-bold font-heading text-gray-900 mb-3">2. Naturaleza del Servicio</h2>
+          <p>
+            <strong>{{ franchise.name }} es una plataforma de intermediación</strong> que conecta a usuarios con empresas de alquiler de vehículos (en adelante "Rentadoras"). Es importante que comprenda lo siguiente:
+          </p>
+          <ul class="list-disc pl-6 space-y-2">
+            <li><strong>No somos una empresa de alquiler de vehículos.</strong> No somos propietarios ni operadores de los vehículos mostrados en la plataforma.</li>
+            <li><strong>Actuamos como intermediarios.</strong> Facilitamos la búsqueda, comparación y solicitud de reservas entre usted y las Rentadoras.</li>
+            <li><strong>El contrato de alquiler es entre usted y la Rentadora.</strong> Una vez confirmada la reserva, la relación contractual se establece directamente con la empresa rentadora seleccionada.</li>
+          </ul>
+        </section>
 
         <!-- Proceso de Reserva -->
-        <h2 class="text-2xl font-bold text-gray-900 mt-10 mb-4">3. Proceso de Reserva</h2>
-        <p>El proceso de reserva funciona de la siguiente manera:</p>
-        <ol class="list-decimal pl-6 space-y-2">
-          <li><strong>Búsqueda:</strong> Usted selecciona fechas, lugar de recogida y devolución.</li>
-          <li><strong>Selección:</strong> Elige un vehículo de las opciones disponibles.</li>
-          <li><strong>Solicitud:</strong> Completa el formulario con sus datos personales.</li>
-          <li><strong>Verificación:</strong> La Rentadora verifica la disponibilidad del vehículo.</li>
-          <li><strong>Confirmación:</strong> Recibirá confirmación por correo electrónico y/o WhatsApp.</li>
-        </ol>
-        <p class="mt-4">
-          <strong>Importante:</strong> La solicitud de reserva no garantiza la disponibilidad. La reserva se considera confirmada únicamente cuando reciba la confirmación oficial por nuestros canales (correo electrónico y/o WhatsApp).
-        </p>
+        <section>
+          <h2 class="text-2xl font-bold font-heading text-gray-900 mb-3">3. Proceso de Reserva</h2>
+          <p>El proceso de reserva funciona de la siguiente manera:</p>
+          <ol class="list-decimal pl-6 space-y-2">
+            <li><strong>Búsqueda:</strong> Usted selecciona fechas, lugar de recogida y devolución.</li>
+            <li><strong>Selección:</strong> Elige un vehículo de las opciones disponibles.</li>
+            <li><strong>Solicitud:</strong> Completa el formulario con sus datos personales.</li>
+            <li><strong>Verificación:</strong> La Rentadora verifica la disponibilidad del vehículo.</li>
+            <li><strong>Confirmación:</strong> Recibirá confirmación por correo electrónico y/o WhatsApp.</li>
+          </ol>
+          <p>
+            <strong>Importante:</strong> La solicitud de reserva no garantiza la disponibilidad. La reserva se considera confirmada únicamente cuando reciba la confirmación oficial por nuestros canales (correo electrónico y/o WhatsApp).
+          </p>
+        </section>
 
         <!-- Requisitos del Conductor -->
-        <h2 class="text-2xl font-bold text-gray-900 mt-10 mb-4">4. Requisitos del Conductor</h2>
-        <p>Para alquilar un vehículo se requiere:</p>
-        <ul class="list-disc pl-6 space-y-2">
-          <li>Edad mínima de 18 años</li>
-          <li>Licencia de conducción vigente</li>
-          <li>Documento de identidad válido (cédula, pasaporte)</li>
-          <li>Tarjeta de crédito a nombre del conductor principal</li>
-        </ul>
+        <section>
+          <h2 class="text-2xl font-bold font-heading text-gray-900 mb-3">4. Requisitos del Conductor</h2>
+          <p>Para alquilar un vehículo se requiere:</p>
+          <ul class="list-disc pl-6 space-y-2">
+            <li>Edad mínima de 18 años</li>
+            <li>Licencia de conducción vigente</li>
+            <li>Documento de identidad válido (cédula, pasaporte)</li>
+            <li>Tarjeta de crédito a nombre del conductor principal</li>
+          </ul>
+        </section>
 
         <!-- Precios y Pagos -->
-        <h2 class="text-2xl font-bold text-gray-900 mt-10 mb-4">5. Precios y Pagos</h2>
-        <p>
-          Los precios mostrados en la plataforma son los mismos que ofrecen las Rentadoras directamente. <strong>No cobramos comisiones adicionales ni afectamos el precio del alquiler.</strong> Los precios incluyen:
-        </p>
-        <ul class="list-disc pl-6 space-y-2">
-          <li>Tarifa diaria del vehículo</li>
-          <li>Seguro básico (según la Rentadora)</li>
-          <li>Kilometraje (limitado o ilimitado según la tarifa)</li>
-        </ul>
-        <p class="mt-4"><strong>No incluyen (salvo que se indique):</strong></p>
-        <ul class="list-disc pl-6 space-y-2">
-          <li>IVA y tasas administrativas</li>
-          <li>Combustible</li>
-          <li>Seguros adicionales</li>
-          <li>Accesorios (silla de bebé, GPS, conductor adicional)</li>
-          <li>Multas o infracciones de tránsito</li>
-        </ul>
-        <p class="mt-4">
-          El pago se realiza directamente a la Rentadora según sus políticas. AMAW S.A.S no procesa pagos en nombre de las Rentadoras.
-        </p>
+        <section>
+          <h2 class="text-2xl font-bold font-heading text-gray-900 mb-3">5. Precios y Pagos</h2>
+          <p>
+            Los precios mostrados en la plataforma son los mismos que ofrecen las Rentadoras directamente. <strong>No cobramos comisiones adicionales ni afectamos el precio del alquiler.</strong> Los precios incluyen:
+          </p>
+          <ul class="list-disc pl-6 space-y-2">
+            <li>Tarifa diaria del vehículo</li>
+            <li>Seguro básico (según la Rentadora)</li>
+            <li>Kilometraje (limitado o ilimitado según la tarifa)</li>
+          </ul>
+          <p><strong>No incluyen (salvo que se indique):</strong></p>
+          <ul class="list-disc pl-6 space-y-2">
+            <li>IVA y tasas administrativas</li>
+            <li>Combustible</li>
+            <li>Seguros adicionales</li>
+            <li>Accesorios (silla de bebé, GPS, conductor adicional)</li>
+            <li>Multas o infracciones de tránsito</li>
+          </ul>
+          <p>
+            El pago se realiza directamente a la Rentadora según sus políticas. AMAW S.A.S no procesa pagos en nombre de las Rentadoras.
+          </p>
+        </section>
 
         <!-- Cancelaciones y Modificaciones -->
-        <h2 class="text-2xl font-bold text-gray-900 mt-10 mb-4">6. Cancelaciones y Modificaciones</h2>
-        <p>
-          Las cancelaciones y modificaciones son gratuitas y sin penalidad:
-        </p>
-        <ul class="list-disc pl-6 space-y-2">
-          <li><strong>Cancelación:</strong> Puede cancelar su reserva en cualquier momento sin costo alguno.</li>
-          <li><strong>No presentarse (No-show):</strong> No genera penalidades económicas. Sin embargo, la inasistencia reiterada sin previo aviso podría afectar la aprobación de futuras reservas.</li>
-        </ul>
-        <p class="mt-4">
-          Para cancelar o modificar una reserva, contáctenos por WhatsApp o correo electrónico con su código de reserva.
-        </p>
+        <section>
+          <h2 class="text-2xl font-bold font-heading text-gray-900 mb-3">6. Cancelaciones y Modificaciones</h2>
+          <p>
+            Las cancelaciones y modificaciones son gratuitas y sin penalidad:
+          </p>
+          <ul class="list-disc pl-6 space-y-2">
+            <li><strong>Cancelación:</strong> Puede cancelar su reserva en cualquier momento sin costo alguno.</li>
+            <li><strong>No presentarse (No-show):</strong> No genera penalidades económicas. Sin embargo, la inasistencia reiterada sin previo aviso podría afectar la aprobación de futuras reservas.</li>
+          </ul>
+          <p>
+            Para cancelar o modificar una reserva, contáctenos por WhatsApp o correo electrónico con su código de reserva.
+          </p>
+        </section>
 
         <!-- Responsabilidades -->
-        <h2 class="text-2xl font-bold text-gray-900 mt-10 mb-4">7. Responsabilidades</h2>
+        <section>
+          <h2 class="text-2xl font-bold font-heading text-gray-900 mb-3">7. Responsabilidades</h2>
 
-        <h3 class="text-xl font-semibold text-gray-900 mt-6 mb-3">Responsabilidades de AMAW S.A.S ({{ franchise.shortname }}):</h3>
-        <ul class="list-disc pl-6 space-y-2">
-          <li>Mostrar información precisa proporcionada por las Rentadoras</li>
-          <li>Facilitar la comunicación entre usuarios y Rentadoras</li>
-          <li>Transmitir las solicitudes de reserva a las Rentadoras</li>
-          <li>Atender consultas relacionadas con el uso de la plataforma</li>
-        </ul>
+          <h3 class="text-xl font-semibold font-heading text-gray-900 mt-6 mb-3">Responsabilidades de AMAW S.A.S ({{ franchise.shortname }}):</h3>
+          <ul class="list-disc pl-6 space-y-2">
+            <li>Mostrar información precisa proporcionada por las Rentadoras</li>
+            <li>Facilitar la comunicación entre usuarios y Rentadoras</li>
+            <li>Transmitir las solicitudes de reserva a las Rentadoras</li>
+            <li>Atender consultas relacionadas con el uso de la plataforma</li>
+          </ul>
 
-        <h3 class="text-xl font-semibold text-gray-900 mt-6 mb-3">Responsabilidades de la Rentadora:</h3>
-        <ul class="list-disc pl-6 space-y-2">
-          <li>Proporcionar el vehículo reservado o uno de categoría similar/superior</li>
-          <li>Garantizar que el vehículo esté en condiciones óptimas de funcionamiento</li>
-          <li>Proporcionar los seguros y coberturas contratados</li>
-          <li>Atender reclamaciones relacionadas con el servicio de alquiler</li>
-        </ul>
+          <h3 class="text-xl font-semibold font-heading text-gray-900 mt-6 mb-3">Responsabilidades de la Rentadora:</h3>
+          <ul class="list-disc pl-6 space-y-2">
+            <li>Proporcionar el vehículo reservado o uno de categoría similar/superior</li>
+            <li>Garantizar que el vehículo esté en condiciones óptimas de funcionamiento</li>
+            <li>Proporcionar los seguros y coberturas contratados</li>
+            <li>Atender reclamaciones relacionadas con el servicio de alquiler</li>
+          </ul>
 
-        <h3 class="text-xl font-semibold text-gray-900 mt-6 mb-3">Responsabilidades del Usuario:</h3>
-        <ul class="list-disc pl-6 space-y-2">
-          <li>Proporcionar información veraz y actualizada</li>
-          <li>Cumplir con los requisitos de la Rentadora</li>
-          <li>Revisar el vehículo antes de recibirlo y reportar cualquier daño existente</li>
-          <li>Utilizar el vehículo de acuerdo con las condiciones del contrato de alquiler</li>
-          <li>Devolver el vehículo en las condiciones acordadas</li>
-        </ul>
+          <h3 class="text-xl font-semibold font-heading text-gray-900 mt-6 mb-3">Responsabilidades del Usuario:</h3>
+          <ul class="list-disc pl-6 space-y-2">
+            <li>Proporcionar información veraz y actualizada</li>
+            <li>Cumplir con los requisitos de la Rentadora</li>
+            <li>Revisar el vehículo antes de recibirlo y reportar cualquier daño existente</li>
+            <li>Utilizar el vehículo de acuerdo con las condiciones del contrato de alquiler</li>
+            <li>Devolver el vehículo en las condiciones acordadas</li>
+          </ul>
+        </section>
 
         <!-- Limitación de Responsabilidad -->
-        <h2 class="text-2xl font-bold text-gray-900 mt-10 mb-4">8. Limitación de Responsabilidad</h2>
-        <p>
-          AMAW S.A.S <strong>no será responsable</strong> por:
-        </p>
-        <ul class="list-disc pl-6 space-y-2">
-          <li>Daños, accidentes o incidentes ocurridos durante el período de alquiler</li>
-          <li>Incumplimientos por parte de las Rentadoras</li>
-          <li>Cancelaciones o cambios realizados por las Rentadoras</li>
-          <li>Diferencias entre el vehículo reservado y el entregado</li>
-          <li>Pérdidas económicas derivadas del uso o no uso del servicio</li>
-          <li>Multas, infracciones o sanciones de tránsito</li>
-        </ul>
-        <p class="mt-4">
-          Cualquier reclamación relacionada con el servicio de alquiler debe dirigirse directamente a la Rentadora correspondiente.
-        </p>
+        <section>
+          <h2 class="text-2xl font-bold font-heading text-gray-900 mb-3">8. Limitación de Responsabilidad</h2>
+          <p>
+            AMAW S.A.S <strong>no será responsable</strong> por:
+          </p>
+          <ul class="list-disc pl-6 space-y-2">
+            <li>Daños, accidentes o incidentes ocurridos durante el período de alquiler</li>
+            <li>Incumplimientos por parte de las Rentadoras</li>
+            <li>Cancelaciones o cambios realizados por las Rentadoras</li>
+            <li>Diferencias entre el vehículo reservado y el entregado</li>
+            <li>Pérdidas económicas derivadas del uso o no uso del servicio</li>
+            <li>Multas, infracciones o sanciones de tránsito</li>
+          </ul>
+          <p>
+            Cualquier reclamación relacionada con el servicio de alquiler debe dirigirse directamente a la Rentadora correspondiente.
+          </p>
+        </section>
 
         <!-- Propiedad Intelectual -->
-        <h2 class="text-2xl font-bold text-gray-900 mt-10 mb-4">9. Propiedad Intelectual</h2>
-        <p>
-          Todo el contenido de la plataforma (textos, imágenes, logotipos, diseño) es propiedad de AMAW S.A.S o de sus licenciantes. Queda prohibida su reproducción sin autorización expresa.
-        </p>
+        <section>
+          <h2 class="text-2xl font-bold font-heading text-gray-900 mb-3">9. Propiedad Intelectual</h2>
+          <p>
+            Todo el contenido de la plataforma (textos, imágenes, logotipos, diseño) es propiedad de AMAW S.A.S o de sus licenciantes. Queda prohibida su reproducción sin autorización expresa.
+          </p>
+        </section>
 
         <!-- Modificaciones -->
-        <h2 class="text-2xl font-bold text-gray-900 mt-10 mb-4">10. Modificaciones</h2>
-        <p>
-          AMAW S.A.S se reserva el derecho de modificar estos Términos y Condiciones en cualquier momento. Los cambios entrarán en vigencia desde su publicación en esta página. El uso continuado de la plataforma implica la aceptación de las modificaciones.
-        </p>
+        <section>
+          <h2 class="text-2xl font-bold font-heading text-gray-900 mb-3">10. Modificaciones</h2>
+          <p>
+            AMAW S.A.S se reserva el derecho de modificar estos Términos y Condiciones en cualquier momento. Los cambios entrarán en vigencia desde su publicación en esta página. El uso continuado de la plataforma implica la aceptación de las modificaciones.
+          </p>
+        </section>
 
         <!-- Ley Aplicable -->
-        <h2 class="text-2xl font-bold text-gray-900 mt-10 mb-4">11. Ley Aplicable y Jurisdicción</h2>
-        <p>
-          Estos Términos y Condiciones se rigen por las leyes de la República de Colombia. Para cualquier controversia, las partes se someten a la jurisdicción de los tribunales de Cali, Valle del Cauca.
-        </p>
+        <section>
+          <h2 class="text-2xl font-bold font-heading text-gray-900 mb-3">11. Ley Aplicable y Jurisdicción</h2>
+          <p>
+            Estos Términos y Condiciones se rigen por las leyes de la República de Colombia. Para cualquier controversia, las partes se someten a la jurisdicción de los tribunales de Cali, Valle del Cauca.
+          </p>
+        </section>
 
         <!-- Contacto -->
-        <h2 class="text-2xl font-bold text-gray-900 mt-10 mb-4">12. Contacto</h2>
-        <p>Para cualquier consulta sobre estos Términos y Condiciones:</p>
-        <ul class="list-disc pl-6 space-y-2">
-          <li><strong>WhatsApp:</strong> {{franchise.phone}}</li>
-          <li><strong>Correo:</strong> {{franchise.email}} </li>
-        </ul>
+        <section>
+          <h2 class="text-2xl font-bold font-heading text-gray-900 mb-3">12. Contacto</h2>
+          <p>Para cualquier consulta sobre estos Términos y Condiciones:</p>
+          <ul class="list-disc pl-6 space-y-2">
+            <li><strong>WhatsApp:</strong> {{ franchise.phone }}</li>
+            <li><strong>Correo:</strong> {{ franchise.email }}</li>
+          </ul>
+        </section>
 
         <!-- Company Info -->
-        <div class="mt-12 pt-8 border-t border-gray-200 text-center text-gray-600">
+        <div class="mt-12 pt-8 border-t border-gray-200 text-gray-600">
           <p class="font-semibold text-gray-900">AMAW S.A.S</p>
           <p>NIT: 900.665.917-7</p>
           <p>Cali, Valle del Cauca, Colombia</p>
         </div>
       </div>
-    </div>
-  </div>
+
+      <!-- Footer -->
+      <footer class="mt-16 pt-8 border-t border-gray-200">
+        <NuxtLink to="/" class="text-brand-600 hover:text-brand-700 font-medium">← Volver al inicio</NuxtLink>
+      </footer>
+    </article>
+  </main>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
Phase **3 of 4** of the alquilame brand reskin (issue #112). F0+F1 are merged; F2 reskins the **city landing** (`/{city}`, `CityPage.vue`) and the **two legal pages**. The functional `/reservas` flow is F3. **`Refs #112` — does NOT close** (F3 does).

Brand-isolated to `packages/ui-alquilame/**` (+ one shared `e2e/` selector fix, see below). `logic/`, the routes, and the other two brands are untouched.

## City landing
`CityPage.vue` becomes a thin orchestrator. The city-specific sections are extracted into `app/components/city/*` and **restyled in place keeping their city data** (not the brand-level F1 components):
- `Hero` (Searcher + the #41 inert pin + #109 preserved), `Intro`, `SeoContent` (ventajas/destinos/consejos/temporada/ciudades-cercanas), `DeliveryPoints` (branches), `Faq` (`useCityFAQs`), `Testimonios` (`city.testimonials`).
- **All SEO content preserved** (indexable text restyled, not dropped).
- F1 marketing reused: `HomeFleet`/`HomeHowItWorks`/`HomeRequirements`/`HomeContact` (new `reserveAnchor` prop — `#searcher` on the city page, `#hero` default on home).
- **Engine untouched**: `Searcher` testids, the conditional `#seleccion-categorias` results (the `buscar-vehiculos` route renders the same page), `cityBranches`, and the SEO schema (`useCityProductSchema` #68, `useCityFAQSchema` via `useCityPageSEO`, `useCityAggregateRating`).

## Legal pages — a deliberate non-swap
The delivered design's legal copy describes alquilame as a **direct rental operator** and drops the AMAW **"plataforma de intermediación / no somos empresa de alquiler"** framing. Swapping the copy wholesale would misrepresent the business model (legal risk). So F2 applies the design's **style** (clean legal-document layout, `font-heading` numbered h2s) to the **current intermediation content** — the framing is preserved. A copy/positioning change is deferred to legal sign-off.

## Runtime verification (Vercel preview)
| SCEN | Result |
|---|---|
| F2-01 hero+searcher | ✅ white city h1 on red, Searcher testids → `buscar-vehiculos` |
| F2-02 SEO content | ✅ every SEO section preserved |
| F2-03 marketing + anchor | ✅ fleet ($220k–$570k) etc., `reserveAnchor="#searcher"` |
| F2-04 / F2-05 | ✅ delivery points; results-error fallback renders (engine intact) |
| F2-06 #41/#109 | ✅ inert pin in `city/Hero` |
| F2-07 / F2-07b | ✅ design legal style + intermediation framing preserved |
| F2-08 contrast/gradient | ✅ white heading on red, gradient renders, 0 `bg-gradient-to-` in source |
| F2-09 SEO schema | ✅ Product×4 (#68), city FAQPage, canonical |
| F2-10 CLS | ✅ 0.25 ≤ baseline 0.26 |
| F2-12 E2E | ✅ 44 + 5 passed (no regression) |

Unit **237/237** · typecheck delta 0 · console: one pre-existing city-page hydration mismatch (Searcher/Nuxt-UI in `ClientOnly`, present on `main` — not F2).

## The one `e2e/` change
F2 adds marketing WhatsApp CTAs to the city page, which made the page-wide `getByRole('link', {name:/WhatsApp/})` in `availability-error-feedback` SCEN-003 a 3-way strict-mode violation. Scoped the assertion to `#seleccion-categorias` (the fallback block). Engine unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)