### PR TITLE
feat(alquilatucarro): WhatsApp attribution — GA4 + connector click beacon

### DIFF
--- a/packages/ui-alquilatucarro/nuxt.config.ts
+++ b/packages/ui-alquilatucarro/nuxt.config.ts
@@ -420,6 +420,32 @@ export default defineNuxtConfig({
         },
       ],
       link: [],
+      script: [
+        // Google Analytics 4 — base gtag.js. `async` so it never blocks render
+        // (keeps the CLS / vitalizer budget intact). The inline config below
+        // defines window.gtag synchronously so the WhatsApp click beacon can read
+        // the GA4 client_id immediately on click.
+        {
+          src: 'https://www.googletagmanager.com/gtag/js?id=G-1G7MWTDK71',
+          async: true,
+        },
+        {
+          innerHTML:
+            "window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-1G7MWTDK71');",
+        },
+        // WhatsApp attribution click beacon (shared connector). Event delegation
+        // over wa.me anchors — fires a ping on every WhatsApp click without
+        // touching the button. data-ga4 lets it use the GA4 client_id as
+        // visitor_id (falls back to a localStorage UUID if GA4 is blocked).
+        // data-tenant MUST match the three connector gates for
+        // static_co_alquilatucarro (tenants/origin-allowlist/CLICK_MATCH_TENANTS).
+        {
+          src: 'https://backend-production-95f5f.up.railway.app/wa-click-track.js',
+          'data-tenant': 'static_co_alquilatucarro',
+          'data-ga4': 'G-1G7MWTDK71',
+          defer: true,
+        },
+      ],
     },
   },
 

--- a/packages/ui-alquilatucarro/public/keyword-map.json
+++ b/packages/ui-alquilatucarro/public/keyword-map.json
@@ -1,0 +1,11 @@
+{
+  "groups": {
+    "bogota": {
+      "landing": "/bogota",
+      "keywords": {
+        "alquiler de carros bogota": "quiero"
+      }
+    }
+  },
+  "organic_landings": {}
+}


### PR DESCRIPTION
## Qué
Instala el stack de atribución de WhatsApp en la marca **alquilatucarro**, para que sus leads se atribuyan (canal + página) vía el conector compartido.

## Cambios (solo 2 archivos, aislados a alquilatucarro)
- **`nuxt.config.ts`** (`app.head.script`):
  - **GA4** base (`G-1G7MWTDK71`, `async` → no bloquea render).
  - **Beacon** central del conector (`data-tenant=static_co_alquilatucarro`, `data-ga4`). Delegación de eventos sobre anclas `wa.me` — **no toca los botones** ni la función de conversión del sitio.
- **`public/keyword-map.json`**: grupo `bogota` (1 keyword activa) para el bootstrap del conector. Capa de reescritura de mensaje orgánico **diferida** a follow-up.

## Verificación (dev server local)
- `window.gtag` = `function`, `dataLayer` poblado, `google_tag_manager` = object.
- gtag.js + beacon presentes en el DOM; **0 errores** de consola/página.
- `keyword-map.json` → 200; tags presentes en home **y** /bogota.

## Notas
- Tenant del conector se da de alta aparte: `conector-whatsapp` **PR #26**.
- GA4 queda vivo al mergear (Vercel despliega alquilatucarro) → permite crear la acción de conversión de Google Ads (`AW-...`), que se agrega después.
- Smoke de prod del beacon (POST → 204) se corre **post-deploy** (origin localhost da 403).