### PR TITLE
feat(alquilatucarro): fire GA4 clic_boton_whatsapp on WhatsApp click (Ads conversion)

### DIFF
--- a/packages/ui-alquilatucarro/nuxt.config.ts
+++ b/packages/ui-alquilatucarro/nuxt.config.ts
@@ -433,6 +433,16 @@ export default defineNuxtConfig({
           innerHTML:
             "window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-1G7MWTDK71');",
         },
+        // Google Ads conversion — fires the GA4 event `clic_boton_whatsapp` on
+        // every WhatsApp click via event delegation (same pattern as the beacon).
+        // No per-button onclick and no delayed navigation: all WA buttons are
+        // target=_blank (current tab never unloads) and gtag uses sendBeacon
+        // transport, so the event always reaches GA4 before any navigation.
+        // Capture phase, never preventDefault → native nav + the beacon both run.
+        {
+          innerHTML:
+            "(function(){document.addEventListener('click',function(e){try{var t=e.target;if(!t||typeof t.closest!=='function')return;var a=t.closest('a[href*=\"wa.me\"],a[href*=\"api.whatsapp.com\"],a[href*=\"web.whatsapp.com\"]');if(!a||typeof window.gtag!=='function')return;window.gtag('event','clic_boton_whatsapp');}catch(_e){}},true);})();",
+        },
         // WhatsApp attribution click beacon (shared connector). Event delegation
         // over wa.me anchors — fires a ping on every WhatsApp click without
         // touching the button. data-ga4 lets it use the GA4 client_id as


### PR DESCRIPTION
## Qué
La acción de conversión de Google Ads es un evento GA4 (`clic_boton_whatsapp`). Este PR lo dispara en **cada clic a WhatsApp** mediante un listener de **delegación de eventos** (capture phase) sobre anclas `wa.me` — mismo patrón que el beacon, sin tocar botones.

## Por qué así (no el helper `gtagSendEvent` de Google)
- Los 3 botones WA son `target="_blank"` → la pestaña actual no se descarga → el evento siempre alcanza a enviarse (gtag usa `sendBeacon`). No hace falta retrasar la navegación.
- Sin `onclick` por botón, sin romper `target="_blank"`, sin `preventDefault` → navegación nativa **y** beacon de atribución siguen corriendo.

## Verificación (dev local)
Clic en WhatsApp → `POST google-analytics.com/g/collect?...&en=clic_boton_whatsapp&tid=G-1G7MWTDK71` → **204**. 0 errores de consola.

## Contexto
Sigue a #130 (GA4 + beacon + keyword-map). Solo +10 líneas en `nuxt.config.ts`.