### PR TITLE
tech-debt(images): NUXT_IMAGE_DOMAINS env con fallback en las 3 marcas

### DIFF
--- a/docs/specs/2026-06-12-image-domains-env/scenarios/image-domains-env.scenarios.md
+++ b/docs/specs/2026-06-12-image-domains-env/scenarios/image-domains-env.scenarios.md
@@ -1,0 +1,51 @@
+---
+name: image-domains-env
+created_by: claude
+created_at: 2026-06-12T00:00:00Z
+issue: 73
+references: [48, 72, "amaw-sas/rentacar-reservas#12"]
+---
+
+# Mover host de Blob de `image.domains` a `NUXT_IMAGE_DOMAINS` (env) — 3 marcas (#73)
+
+En #72 (fix de #48) el host del Blob compartido quedó hardcodeado en `image.domains` de los 3
+`nuxt.config.ts`. Este cambio lo lee desde `NUXT_IMAGE_DOMAINS` (CSV) **con fallback** al host actual,
+para sacarlo del build y poder rotarlo sin tocar el repo — sin perder la red de seguridad de #48
+(si la env falta en un target de Vercel, el fallback impide que las imágenes vuelvan a salir crudas).
+
+Alcance: SOLO `image.domains` (allowlist build-time de `@nuxt/image`). El `remotePatterns` del hook
+`nitro:config` ya es regex host-agnóstico (`^[a-z0-9-]+\.public\.blob\.vercel-storage\.com$`) — no se toca.
+
+Host del Blob (compartido por las 3 marcas): `9grznib0czdjtk77.public.blob.vercel-storage.com`.
+
+Los scenarios autoritativos son runtime (preview/prod). SCEN-73-01/02 son guardas locales.
+
+## SCEN-73-01: cada marca resuelve `image.domains` desde env con fallback (regression guard)
+**Given**: cada uno de los 3 brand configs (`ui-alquilatucarro`, `ui-alquilame`, `ui-alquicarros`)
+**When**: se inspecciona el bloque `image.domains` de su `nuxt.config.ts`
+**Then**: lee `process.env.NUXT_IMAGE_DOMAINS` con el host Blob como fallback (`|| '…'`) parseado por
+`.split(',')` — y NO conserva la forma hardcodeada de única fuente `domains: ['9grznib0…']`
+**Evidence**: unit test config-hygiene (`packages/ui-alquilame/tests/image-domains.test.ts`, patrón
+static-source de `f0-assets.test.ts`) sobre los 3 configs; falla antes del fix, pasa después
+
+## SCEN-73-02: la expresión rinde fallback con env ausente y override con env presente
+**Given**: la expresión `(process.env.NUXT_IMAGE_DOMAINS || '<host>').split(',').map(trim).filter(Boolean)`
+**When**: se evalúa con `NUXT_IMAGE_DOMAINS` **ausente** y luego con `'a.com, b.com'`
+**Then**: ausente → `['9grznib0czdjtk77.public.blob.vercel-storage.com']` (fallback);
+presente → `['a.com','b.com']` (override, split por coma + trim, sin vacíos)
+**Evidence**: eval local en node de la expresión en ambos estados de env
+
+## SCEN-73-03: imágenes de modelo siguen optimizadas en preview (AUTORITATIVO, por marca)
+**Given**: una página de resultados real (post búsqueda de disponibilidad) en el preview de cada marca,
+con `NUXT_IMAGE_DOMAINS` seteado en el target Preview del proyecto Vercel
+**When**: renderiza un `<img>` de modelo (slide del `Carrusel`) y se audita `document.images`
+**Then**: su `currentSrc` es `/_vercel/image?url=…&w=…&q=80` con `w ≤ 768`, `content-type: image/webp`,
+`cache-control: max-age ≥ 2678400`; y el conteo de `currentSrc` crudos
+`*.blob.vercel-storage.com/*.jpeg` es **0**
+**Evidence**: auditoría agent-browser de #72 — `viaOptimizer == total` (imgs de modelo), `rawBlob == 0`
+
+## SCEN-73-04: mismo gate en producción (por marca)
+**Given**: el deploy de producción de cada marca con `NUXT_IMAGE_DOMAINS` en el target Production
+**When**: se audita una página de resultados real en el dominio/preview-de-prod
+**Then**: idéntico a SCEN-73-03 — todo modelo vía `/_vercel/image` webp `max-age=2678400`, `rawBlob == 0`
+**Evidence**: auditoría agent-browser tras promover el deploy

--- a/packages/ui-alquicarros/nuxt.config.ts
+++ b/packages/ui-alquicarros/nuxt.config.ts
@@ -423,7 +423,11 @@ export default defineNuxtConfig({
     // Whitelist del host Blob compartido (modelos de vehículos en Supabase, las 3 marcas).
     // Sin esto, @nuxt/image NO optimiza URLs externas y las imágenes salen como JPEG ~412KB crudo
     // en vez de enrutarse por el optimizador Vercel (/_vercel/image → webp ~45KB).
-    domains: ['9grznib0czdjtk77.public.blob.vercel-storage.com'],
+    // Configurable vía NUXT_IMAGE_DOMAINS (lista CSV) con FALLBACK al host actual: si la env falta
+    // en cualquier target de Vercel, la red de seguridad de #48/#72 se mantiene (no hay fallo
+    // silencioso → las imágenes nunca vuelven a salir crudas). La env solo habilita rotar el host.
+    domains: (process.env.NUXT_IMAGE_DOMAINS || '9grznib0czdjtk77.public.blob.vercel-storage.com')
+      .split(',').map((d) => d.trim()).filter(Boolean),
     screens: {
       xs: 320,
       sm: 640,

--- a/packages/ui-alquilame/app/components/__tests__/model-image-optimization.test.ts
+++ b/packages/ui-alquilame/app/components/__tests__/model-image-optimization.test.ts
@@ -24,14 +24,18 @@ const carrusel = readFileSync(
 )
 
 describe('model-image-optimization — nuxt.config image.domains (SCEN-004)', () => {
-  it('declares an image.domains array', () => {
-    expect(nuxtConfig).toMatch(/image:\s*\{[\s\S]*?domains:\s*\[/)
+  // #73 moved the host from a hardcoded array to NUXT_IMAGE_DOMAINS with a fallback.
+  // Cross-brand env-fallback invariant lives in tests/image-domains.test.ts; here we
+  // keep the brand-local guarantee that the Blob host is still the effective default.
+  it('declares an image.domains entry', () => {
+    expect(nuxtConfig).toMatch(/image:\s*\{[\s\S]*?domains:/)
   })
 
-  it('whitelists the shared Blob host so external model images route through the optimizer', () => {
-    // domains entry, not just the comment / remotePatterns hook
+  it('keeps the shared Blob host as the env fallback so external model images route through the optimizer', () => {
+    // host reachable by @nuxt/image even if NUXT_IMAGE_DOMAINS is unset — not just the
+    // comment / remotePatterns hook
     expect(nuxtConfig).toMatch(
-      new RegExp(`domains:\\s*\\[[^\\]]*['"]${BLOB_HOST.replace(/\./g, '\\.')}['"]`),
+      new RegExp(`NUXT_IMAGE_DOMAINS\\s*\\|\\|\\s*['"]${BLOB_HOST.replace(/\./g, '\\.')}['"]`),
     )
   })
 })

--- a/packages/ui-alquilame/nuxt.config.ts
+++ b/packages/ui-alquilame/nuxt.config.ts
@@ -437,7 +437,11 @@ export default defineNuxtConfig({
     // Whitelist del host Blob compartido (modelos de vehículos en Supabase, las 3 marcas).
     // Sin esto, @nuxt/image NO optimiza URLs externas y las imágenes salen como JPEG ~412KB crudo
     // en vez de enrutarse por el optimizador Vercel (/_vercel/image → webp ~45KB).
-    domains: ['9grznib0czdjtk77.public.blob.vercel-storage.com'],
+    // Configurable vía NUXT_IMAGE_DOMAINS (lista CSV) con FALLBACK al host actual: si la env falta
+    // en cualquier target de Vercel, la red de seguridad de #48/#72 se mantiene (no hay fallo
+    // silencioso → las imágenes nunca vuelven a salir crudas). La env solo habilita rotar el host.
+    domains: (process.env.NUXT_IMAGE_DOMAINS || '9grznib0czdjtk77.public.blob.vercel-storage.com')
+      .split(',').map((d) => d.trim()).filter(Boolean),
     screens: {
       xs: 320,
       sm: 640,

--- a/packages/ui-alquilame/tests/image-domains.test.ts
+++ b/packages/ui-alquilame/tests/image-domains.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Issue #73 — `image.domains` desde `NUXT_IMAGE_DOMAINS` (env) con fallback, en las 3 marcas.
+ *
+ * Invariante COMPARTIDO por las 3 brand configs (no solo alquilame): el host del Blob ya no está
+ * hardcodeado como única fuente; se lee de la env con fallback al host actual. Este test vive en
+ * alquilame (única marca cableada a vitest) pero audita los 3 `nuxt.config.ts` por static-source,
+ * mismo patrón que `f0-assets.test.ts`.
+ *
+ *   - SCEN-73-01: cada config lee `process.env.NUXT_IMAGE_DOMAINS` con el host Blob como fallback
+ *                 (`|| '…'`) parseado por `.split(',')`, y NO conserva `domains: ['9grznib0…']`.
+ *   - SCEN-73-02: la expresión rinde el fallback con env ausente y el override (split+trim) con env
+ *                 presente.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const PKGS = join(__dirname, '..', '..') // packages/
+const BRANDS = ['ui-alquilatucarro', 'ui-alquilame', 'ui-alquicarros'] as const
+const BLOB_HOST = '9grznib0czdjtk77.public.blob.vercel-storage.com'
+
+function readConfig(brand: string): string {
+  return readFileSync(join(PKGS, brand, 'nuxt.config.ts'), 'utf-8')
+}
+
+describe('SCEN-73-01 — image.domains desde NUXT_IMAGE_DOMAINS con fallback (3 marcas)', () => {
+  for (const brand of BRANDS) {
+    describe(brand, () => {
+      const cfg = readConfig(brand)
+
+      it('lee process.env.NUXT_IMAGE_DOMAINS', () => {
+        expect(cfg).toContain('process.env.NUXT_IMAGE_DOMAINS')
+      })
+
+      it('usa el host Blob como fallback (|| \'…\')', () => {
+        expect(cfg).toMatch(
+          new RegExp(`process\\.env\\.NUXT_IMAGE_DOMAINS\\s*\\|\\|\\s*['"]${BLOB_HOST.replace(/\./g, '\\.')}['"]`),
+        )
+      })
+
+      it('parsea la lista CSV con split(\',\')', () => {
+        expect(cfg).toMatch(/NUXT_IMAGE_DOMAINS[\s\S]{0,120}\.split\(\s*['"],['"]\s*\)/)
+      })
+
+      it('ya NO hardcodea el host como única fuente (domains: [\'9grznib0…\'])', () => {
+        expect(cfg).not.toMatch(/domains:\s*\[\s*['"]9grznib0czdjtk77/)
+      })
+    })
+  }
+})
+
+describe('SCEN-73-02 — semántica de la expresión env-con-fallback', () => {
+  // Réplica de la expresión exacta usada en los 3 configs (verificada por SCEN-73-01).
+  const resolve = (env: string | undefined): string[] =>
+    (env || BLOB_HOST).split(',').map((d) => d.trim()).filter(Boolean)
+
+  it('env ausente → fallback al host Blob', () => {
+    expect(resolve(undefined)).toEqual([BLOB_HOST])
+  })
+
+  it('env vacío → fallback al host Blob (no array vacío)', () => {
+    expect(resolve('')).toEqual([BLOB_HOST])
+  })
+
+  it('env presente → override con split por coma + trim, sin vacíos', () => {
+    expect(resolve(' a.example.com , b.example.com ,')).toEqual(['a.example.com', 'b.example.com'])
+  })
+})

--- a/packages/ui-alquilatucarro/nuxt.config.ts
+++ b/packages/ui-alquilatucarro/nuxt.config.ts
@@ -468,7 +468,11 @@ export default defineNuxtConfig({
     // Whitelist del host Blob compartido (modelos de vehículos en Supabase, las 3 marcas).
     // Sin esto, @nuxt/image NO optimiza URLs externas y las imágenes salen como JPEG ~412KB crudo
     // en vez de enrutarse por el optimizador Vercel (/_vercel/image → webp ~45KB).
-    domains: ['9grznib0czdjtk77.public.blob.vercel-storage.com'],
+    // Configurable vía NUXT_IMAGE_DOMAINS (lista CSV) con FALLBACK al host actual: si la env falta
+    // en cualquier target de Vercel, la red de seguridad de #48/#72 se mantiene (no hay fallo
+    // silencioso → las imágenes nunca vuelven a salir crudas). La env solo habilita rotar el host.
+    domains: (process.env.NUXT_IMAGE_DOMAINS || '9grznib0czdjtk77.public.blob.vercel-storage.com')
+      .split(',').map((d) => d.trim()).filter(Boolean),
     screens: {
       xs: 320,
       sm: 640,


### PR DESCRIPTION
Closes #73

Mueve el host del Blob compartido de `image.domains` hardcodeado a la env `NUXT_IMAGE_DOMAINS` (CSV) en las 3 marcas, **con fallback al host actual**.

El fallback es el punto clave: si la env falta o queda vacía en un target de Vercel, la expresión `(process.env.NUXT_IMAGE_DOMAINS || host)` cae al host y las imágenes de modelo siguen optimizándose — no se reintroduce el fallo silencioso de #48 (JPEG crudo ~412KB). La env solo habilita rotar el host sin tocar el repo.

Esto no resultó teórico: al revisar Vercel, los tres targets **Production** tenían `NUXT_IMAGE_DOMAINS=""` (vacío). El fallback los cubre; además corregí los 6 valores (3 proyectos × Prod/Preview) al host correcto.

Alcance: solo `image.domains`. El `remotePatterns` del hook `nitro:config` ya es regex host-agnóstico (`^[a-z0-9-]+\.public\.blob\.vercel-storage\.com$`), no se toca ni se desincroniza.

### Cambios
- 3 `nuxt.config.ts`: `domains` lee la env con fallback + split CSV.
- `tests/image-domains.test.ts`: invariante env-fallback en las 3 marcas (SCEN-73-01/02).
- `model-image-optimization.test.ts` (#72): SCEN-004 actualizado a la forma env-fallback.
- `docs/specs/2026-06-12-image-domains-env/...`: SCEN-73-01..04.

### Verificación local
- `pnpm --filter ui-alquilame test` → 252 passed (incluye los nuevos).
- Red-green de la guarda: config viejo falla, config nuevo pasa, en las 3 marcas.
- Vercel env: 6/6 valores = host (los 3 Production corregidos desde vacío).
- Typecheck: sin errores nuevos (solo baseline rojo pre-existente, no relacionado).

### Pendiente (runtime gate, post-deploy)
- SCEN-73-03: auditar agent-browser cada preview deploy (modelo vía `/_vercel/image` webp, `cache-control max-age=2678400`, `rawBlob==0`).
- SCEN-73-04: ídem en prod tras promover.