### PR TITLE
fix(alquilatucarro): keep city in WhatsApp prefill across the search flow

### DIFF
--- a/packages/ui-alquilatucarro/app/plugins/wa-message.client.ts
+++ b/packages/ui-alquilatucarro/app/plugins/wa-message.client.ts
@@ -15,35 +15,42 @@
 // free-form for the human reading the chat — it does NOT need to match the
 // connector's parse templates.
 
-// Display names (with accents) for the 19 city landing routes. Any other path
-// (home, blog, gana, …) falls back to the generic message.
-const CITY_BY_PATH: Record<string, string> = {
-  '/armenia': 'Armenia',
-  '/barranquilla': 'Barranquilla',
-  '/bogota': 'Bogotá',
-  '/bucaramanga': 'Bucaramanga',
-  '/cali': 'Cali',
-  '/cartagena': 'Cartagena',
-  '/cucuta': 'Cúcuta',
-  '/ibague': 'Ibagué',
-  '/manizales': 'Manizales',
-  '/medellin': 'Medellín',
-  '/monteria': 'Montería',
-  '/neiva': 'Neiva',
-  '/pereira': 'Pereira',
-  '/santa-marta': 'Santa Marta',
-  '/valledupar': 'Valledupar',
-  '/villavicencio': 'Villavicencio',
-  '/floridablanca': 'Floridablanca',
-  '/palmira': 'Palmira',
-  '/soledad': 'Soledad',
+// Display names (with accents) keyed by city id (the FIRST path segment). The
+// city id leads every city route — both the bare landing (`/bogota`) and the
+// whole search flow (`/bogota/buscar-vehiculos/lugar-recogida/…/categoria/…`).
+// Matching on the first segment (not the full path) keeps the city in the
+// message as the user advances the search; it only changes when they switch
+// cities. Other top-level routes (home, blog, gana, seo, tarifas, …) are not
+// city ids, so they fall through to the generic message.
+const CITY_BY_ID: Record<string, string> = {
+  armenia: 'Armenia',
+  barranquilla: 'Barranquilla',
+  bogota: 'Bogotá',
+  bucaramanga: 'Bucaramanga',
+  cali: 'Cali',
+  cartagena: 'Cartagena',
+  cucuta: 'Cúcuta',
+  ibague: 'Ibagué',
+  manizales: 'Manizales',
+  medellin: 'Medellín',
+  monteria: 'Montería',
+  neiva: 'Neiva',
+  pereira: 'Pereira',
+  'santa-marta': 'Santa Marta',
+  valledupar: 'Valledupar',
+  villavicencio: 'Villavicencio',
+  floridablanca: 'Floridablanca',
+  palmira: 'Palmira',
+  soledad: 'Soledad',
 }
 
 const WA_NUMBER = '573016729250'
 
 function buildMessage(): string {
-  const path = window.location.pathname.replace(/\/+$/, '') || '/'
-  const city = CITY_BY_PATH[path]
+  // First non-empty path segment = city id, for both the landing and the
+  // search flow. Extra segments (dates, locations, category) are ignored.
+  const firstSegment = window.location.pathname.split('/').filter(Boolean)[0] ?? ''
+  const city = CITY_BY_ID[firstSegment]
   const base = 'Hola, vi su página de alquiler de carros'
   return city
     ? `${base} en ${city} y quiero saber los requisitos`


### PR DESCRIPTION
## Problema

El mensaje de WhatsApp prellenado solo incluía la ciudad en la landing desnuda (`/bogota`). En todo el flujo de búsqueda (`/bogota/buscar-vehiculos/lugar-recogida/.../categoria/...`) el mensaje caía al genérico, **perdiendo la ciudad en las páginas de mayor intención de conversión**.

## Causa raíz

`buildMessage()` hacía match **exacto** de `window.location.pathname` contra el mapa de ciudades. Las URLs de búsqueda llevan segmentos extra → el lookup fallaba → mensaje genérico.

## Fix

Indexar el mapa por **id de ciudad** y resolver desde el **primer segmento** del path. La ciudad persiste mientras el usuario avanza la búsqueda (fechas, lugar, categoría) y solo cambia cuando cambia de ciudad.

## Verificación (runtime, replicando la lógica nueva)

| Ruta | Mensaje | |
|---|---|---|
| `/bogota` | "...en **Bogotá**..." | ✅ |
| `/bogota/buscar-vehiculos/.../categoria/C` | "...en **Bogotá**..." | ✅ antes fallaba |
| misma búsqueda, otra fecha/carro | "...en **Bogotá**..." | ✅ no se borra |
| cambia a `/cartagena/...` | "...en **Cartagena**..." | ✅ se actualiza |
| `/` (home) | genérico | ✅ |
| `/blog/...` | genérico | ✅ |

**Blast radius:** un solo archivo (`packages/ui-alquilatucarro/app/plugins/wa-message.client.ts`). Sin consumidores ni tests afectados.