### PR TITLE
fix(alquilatucarro): open sede footer links in same tab via SPA nav

### DIFF
--- a/packages/ui-alquilatucarro/app/layouts/default.vue
+++ b/packages/ui-alquilatucarro/app/layouts/default.vue
@@ -90,8 +90,6 @@
             v-for="city in cities"
             :key="city.id"
             :to="getCityReservationURL(city)"
-            :external="true"
-            target="_blank"
             class="text-white justify-center bg-blue-600 hover:bg-blue-800 rounded-lg py-3 w-full md:w-fit font-normal transition-colors"
           >
             Alquiler de carros en <span class="font-bold">{{ city.name }}</span>


### PR DESCRIPTION
## Problema

Los 19 links de sede en el footer (`#sedes`) usaban `target="_blank"` + `:external="true"` → abrían **pestaña nueva** con **recarga completa**, para navegación interna a nuestras propias páginas de ciudad.

- Anti-patrón UX (desorienta, rompe "atrás", acumula pestañas — peor en móvil)
- Cero beneficio SEO
- Pierde la navegación instantánea SPA de Nuxt
- Inconsistente con los links de "ciudades cercanas", que ya navegan en la misma pestaña

## Fix

Quitar ambos atributos → los links usan navegación SPA de `NuxtLink`. Hidratación (Issue #109) preservada: `buildCityReservationURL` devuelve `/${city.id}` estable en servidor y primera hidratación; el deep-link con fecha se aplica tras `onMounted`.

**Blast radius:** un solo archivo (`packages/ui-alquilatucarro/app/layouts/default.vue`), footer `#sedes`.