### PR TITLE
fix(unable-card): legible matching buttons, rename 2nd CTA (#136)

### DIFF
--- a/e2e/unable-cards-on-empty-inventory.spec.ts
+++ b/e2e/unable-cards-on-empty-inventory.spec.ts
@@ -123,9 +123,9 @@ test.describe('Unable cards on empty inventory', () => {
 
     // Both CTAs render — the user has two routes back to the searcher.
     const probarFechas = firstCard.getByRole('button', { name: 'Probar otras fechas' });
-    const cambiarSucursal = firstCard.getByRole('button', { name: 'Cambiar sucursal' });
+    const otraSucursal = firstCard.getByRole('button', { name: 'Probar otra sucursal cercana' });
     await expect(probarFechas).toBeVisible();
-    await expect(cambiarSucursal).toBeVisible();
+    await expect(otraSucursal).toBeVisible();
 
     // No "Solicitar / Reservar / Cotizar" CTA inside the card — unavailable means
     // unbookable, surfacing those would be a contract regression.

--- a/packages/ui-alquicarros/app/components/CityPage.vue
+++ b/packages/ui-alquicarros/app/components/CityPage.vue
@@ -2,7 +2,7 @@
   <UPage>
     <!-- Hero Section -->
     <div class="hero-section">
-      <!-- Scroll target for "Probar otras fechas" / "Cambiar sucursal" CTAs en UnableCategoryCard -->
+      <!-- Scroll target for "Probar otras fechas" / "Probar otra sucursal cercana" CTAs en UnableCategoryCard -->
       <div id="searcher" aria-hidden="true" class="scroll-mt-20" />
       <UPageHero
         orientation="horizontal"

--- a/packages/ui-alquicarros/app/components/Placeholders/UnableCategoryCard.vue
+++ b/packages/ui-alquicarros/app/components/Placeholders/UnableCategoryCard.vue
@@ -33,9 +33,9 @@
       <div class="space-y-2 mt-4">
         <UButton
           color="neutral"
-          size="lg"
+          size="xl"
           block
-          class="bg-gray-900 hover:bg-black text-white"
+          class="bg-gray-900 hover:bg-black text-white py-4"
           @click="scrollToSearcher"
         >
           <template #trailing>
@@ -46,16 +46,15 @@
 
         <UButton
           color="neutral"
-          variant="outline"
-          size="lg"
+          size="xl"
           block
-          class="text-gray-800 ring-1 ring-gray-300 hover:bg-gray-50"
+          class="bg-gray-900 hover:bg-black text-white py-4"
           @click="scrollToSearcher"
         >
           <template #trailing>
             <ChevronRightIcon cls="size-5" />
           </template>
-          Cambiar sucursal
+          Probar otra sucursal cercana
         </UButton>
       </div>
     </div>

--- a/packages/ui-alquilame/app/components/Placeholders/UnableCategoryCard.vue
+++ b/packages/ui-alquilame/app/components/Placeholders/UnableCategoryCard.vue
@@ -33,9 +33,9 @@
       <div class="space-y-2 mt-4">
         <UButton
           color="neutral"
-          size="lg"
+          size="xl"
           block
-          class="bg-gray-900 hover:bg-black text-white"
+          class="bg-gray-900 hover:bg-black text-white py-4"
           @click="scrollToSearcher"
         >
           <template #trailing>
@@ -46,16 +46,15 @@
 
         <UButton
           color="neutral"
-          variant="outline"
-          size="lg"
+          size="xl"
           block
-          class="text-gray-800 ring-1 ring-gray-300 hover:bg-gray-50"
+          class="bg-gray-900 hover:bg-black text-white py-4"
           @click="scrollToSearcher"
         >
           <template #trailing>
             <ChevronRightIcon cls="size-5" />
           </template>
-          Cambiar sucursal
+          Probar otra sucursal cercana
         </UButton>
       </div>
     </div>

--- a/packages/ui-alquilame/app/components/city/Hero.vue
+++ b/packages/ui-alquilame/app/components/city/Hero.vue
@@ -9,8 +9,8 @@
         layout shift (issue #109 — no current-date call baked into SSR/ISR
         markup).
       - The #searcher scroll target: the in-page anchor the UnableCategoryCard
-        CTAs ("Probar otras fechas" / "Cambiar sucursal") and the city
-        HomeContact "Reserva Ahora" CTA (reserveAnchor) scroll to.
+        CTAs ("Probar otras fechas" / "Probar otra sucursal cercana") and the
+        city HomeContact "Reserva Ahora" CTA (reserveAnchor) scroll to.
       - The #41 secret pin: copy-to-WhatsApp is an operator-only action, so it
         stays an INERT aria-hidden span (never a focusable control) — outside
         the accessible name of the <h1> (WCAG 2.5.3) and never exposed via
@@ -27,8 +27,8 @@
     class="relative flex items-center overflow-hidden bg-linear-to-br from-hero-from to-hero-to [--ctx-text-primary:#fff]"
   >
     <!--
-      Scroll target for "Probar otras fechas" / "Cambiar sucursal" CTAs in
-      UnableCategoryCard and the city HomeContact "Reserva Ahora" CTA. Kept as a
+      Scroll target for "Probar otras fechas" / "Probar otra sucursal cercana"
+      CTAs in UnableCategoryCard and the city HomeContact "Reserva Ahora" CTA. Kept as a
       dedicated anchor so #hero (the section) and #searcher (the engine) stay
       independent and scroll-mt-20 clears the sticky header.
     -->

--- a/packages/ui-alquilatucarro/app/components/CityPage.vue
+++ b/packages/ui-alquilatucarro/app/components/CityPage.vue
@@ -2,7 +2,7 @@
   <UPage>
     <!-- Hero Section -->
     <div class="hero-section">
-      <!-- Scroll target for "Probar otras fechas" / "Cambiar sucursal" CTAs en UnableCategoryCard -->
+      <!-- Scroll target for "Probar otras fechas" / "Probar otra sucursal cercana" CTAs en UnableCategoryCard -->
       <div id="searcher" aria-hidden="true" class="scroll-mt-20" />
       <UPageHero
         orientation="horizontal"

--- a/packages/ui-alquilatucarro/app/components/Placeholders/UnableCategoryCard.vue
+++ b/packages/ui-alquilatucarro/app/components/Placeholders/UnableCategoryCard.vue
@@ -33,9 +33,9 @@
       <div class="space-y-2 mt-4">
         <UButton
           color="neutral"
-          size="lg"
+          size="xl"
           block
-          class="bg-gray-900 hover:bg-black text-white"
+          class="bg-gray-900 hover:bg-black text-white py-4"
           @click="scrollToSearcher"
         >
           <template #trailing>
@@ -46,16 +46,15 @@
 
         <UButton
           color="neutral"
-          variant="outline"
-          size="lg"
+          size="xl"
           block
-          class="text-gray-800 ring-1 ring-gray-300 hover:bg-gray-50"
+          class="bg-gray-900 hover:bg-black text-white py-4"
           @click="scrollToSearcher"
         >
           <template #trailing>
             <ChevronRightIcon cls="size-5" />
           </template>
-          Cambiar sucursal
+          Probar otra sucursal cercana
         </UButton>
       </div>
     </div>

--- a/packages/ui-alquilatucarro/app/components/__tests__/UnableCategoryCard.mount.test.ts
+++ b/packages/ui-alquilatucarro/app/components/__tests__/UnableCategoryCard.mount.test.ts
@@ -217,7 +217,7 @@ describe('UnableCategoryCard mount — observable behavior', () => {
     const wrapper = mountCard();
     const labels = wrapper.findAll('button').map((b) => b.text().trim());
     expect(labels.some((l) => l.includes('Probar otras fechas'))).toBe(true);
-    expect(labels.some((l) => l.includes('Cambiar sucursal'))).toBe(true);
+    expect(labels.some((l) => l.includes('Probar otra sucursal cercana'))).toBe(true);
   });
 
   it('does NOT render the legacy red pill (bg-red-100)', () => {

--- a/packages/ui-alquilatucarro/app/components/__tests__/UnableCategoryCard.test.ts
+++ b/packages/ui-alquilatucarro/app/components/__tests__/UnableCategoryCard.test.ts
@@ -37,7 +37,7 @@ describe('UnableCategoryCard — redesigned unavailable state', () => {
 
   it('SCEN-U1[d]: two CTA labels present', () => {
     expect(source).toMatch(/Probar otras fechas/)
-    expect(source).toMatch(/Cambiar sucursal/)
+    expect(source).toMatch(/Probar otra sucursal cercana/)
   })
 
   it('SCEN-U2: scrollToSearcher handler wired', () => {


### PR DESCRIPTION
Closes #136

## Problema

El 2º botón (`Cambiar sucursal`) de `UnableCategoryCard` usaba `variant="outline"` (fondo transparente) + `text-gray-800` hardcodeado → sin fondo propio, quedaba **texto oscuro sobre oscuro e ilegible** en la página de resultados. Además ambos botones eran `size="lg"` (`text-sm`, `py-2`), más bajos y con letra más chica que el CTA primario `Solicitar este vehículo` (`size="xl"`, `text-base`, `py-4`).

## Cambios

- **Ambos botones negros sólidos** (`bg-gray-900 hover:bg-black text-white`) — mismo color, contraste garantizado en cualquier contexto.
- **`size="xl"` + `py-4`** → tamaño de letra (`text-base`) y alto **iguales al botón `Solicitar este vehículo`**.
- **Renombrar 2º botón:** `Cambiar sucursal` → `Probar otra sucursal cercana`.
- Aplicado en las **3 marcas**; actualizados tests unit + e2e y los comentarios del scroll-target.

## Verificación

- ✅ Unit tests `UnableCategoryCard` (14/14) pasan localmente.
- Pendiente en preview: confirmar visualmente legibilidad, color, alto y texto en la página de resultados.

**Decisión pendiente (no incluida aquí):** ambos botones siguen llamando a `scrollToSearcher` (solo bajan al buscador). Si `Probar otra sucursal cercana` debe navegar a una sucursal cercana real, es trabajo aparte — ver issue #136.