### PR TITLE
fix(unable-card): align typography with available card, add body bg, dedupe banner city

### DIFF
--- a/packages/logic/src/composables/__tests__/useUnavailabilityContext.test.ts
+++ b/packages/logic/src/composables/__tests__/useUnavailabilityContext.test.ts
@@ -121,22 +121,23 @@ describe('useUnavailabilityContext', () => {
   })
 
   describe('locationLabel', () => {
-    it('formato "{ciudad} · {nombre sucursal}" con city capitalizada', () => {
+    it('cuando el nombre de sucursal ya empieza con la ciudad, no la duplica', () => {
       const formStore = useStoreReservationForm()
       formStore.lugarRecogida = 'AABOT'
 
       const { locationLabel } = useUnavailabilityContext()
 
-      expect(locationLabel.value).toBe('Bogotá · Bogotá Aeropuerto')
+      // 'Bogotá Aeropuerto' ya lleva la ciudad → sin prefijo redundante.
+      expect(locationLabel.value).toBe('Bogotá Aeropuerto')
     })
 
-    it('capitaliza cada segmento de un slug de ciudad con guión (#30)', () => {
+    it('slug de ciudad con guión cuyo nombre ya lo incluye no se duplica (#30)', () => {
       const formStore = useStoreReservationForm()
       formStore.lugarRecogida = 'POBLADO'
 
       const { locationLabel } = useUnavailabilityContext()
 
-      expect(locationLabel.value).toBe('El Poblado · El Poblado')
+      expect(locationLabel.value).toBe('El Poblado')
     })
 
     it('city solo-whitespace cae al nombre de la sucursal, sin separador malformado (#32)', () => {
@@ -148,12 +149,13 @@ describe('useUnavailabilityContext', () => {
       expect(locationLabel.value).toBe('Sucursal Centro')
     })
 
-    it('city con espacios alrededor se normaliza vía el mapa (#32)', () => {
+    it('nombre suffix-only conserva el contexto de ciudad: "Bogotá · Sucursal Norte" (#32)', () => {
       const formStore = useStoreReservationForm()
       formStore.lugarRecogida = 'UNTRIM'
 
       const { locationLabel } = useUnavailabilityContext()
 
+      // 'Sucursal Norte' NO empieza con la ciudad → se conserva el prefijo.
       expect(locationLabel.value).toBe('Bogotá · Sucursal Norte')
     })
 
@@ -177,7 +179,7 @@ describe('useUnavailabilityContext', () => {
       const { bannerText, isSpecific } = useUnavailabilityContext()
 
       expect(bannerText.value).toBe(
-        'No disponible para el 12-15 mayo en Bogotá · Bogotá Aeropuerto',
+        'No disponible para el 12-15 mayo en Bogotá Aeropuerto',
       )
       expect(isSpecific.value).toBe(true)
     })

--- a/packages/logic/src/composables/useUnavailabilityContext.ts
+++ b/packages/logic/src/composables/useUnavailabilityContext.ts
@@ -121,7 +121,16 @@ export default function useUnavailabilityContext(): UnavailabilityContext {
     // fixed at the source, not patched defensively here.
     const city = formatCity(branch.city);
     if (!city) return branch.name;
-    return `${city} · ${branch.name}`;
+    // Branch names already lead with the city in the admin data ("Bogotá
+    // Aeropuerto", "Floridablanca"), so prefixing it again reads as the
+    // redundant "Bogotá · Bogotá Aeropuerto". Only prepend the city when the
+    // name does NOT already start with it, so suffix-only branches ("Sucursal
+    // Norte") keep their city context.
+    const nameStartsWithCity = branch.name
+      .trim()
+      .toLowerCase()
+      .startsWith(city.toLowerCase());
+    return nameStartsWithCity ? branch.name : `${city} · ${branch.name}`;
   });
 
   const isSpecific = computed<boolean>(() =>

--- a/packages/ui-alquicarros/app/components/Placeholders/UnableCategoryCard.vue
+++ b/packages/ui-alquicarros/app/components/Placeholders/UnableCategoryCard.vue
@@ -4,10 +4,10 @@
     <div class="bg-red-50 border-l-4 border-red-500 px-4 py-3 flex items-start gap-2">
       <UIcon name="i-lucide-alert-triangle" class="w-5 h-5 text-red-600 mt-0.5 shrink-0" />
       <div>
-        <div class="text-sm font-semibold text-red-800">No disponible</div>
+        <div class="text-2xl font-semibold text-red-800 leading-tight">No disponible</div>
         <div
           v-if="isSpecific"
-          class="text-xs text-red-700 mt-0.5"
+          class="text-sm text-red-700 mt-0.5"
         >
           {{ bannerText }}
         </div>
@@ -23,40 +23,42 @@
       />
     </div>
 
-    <!-- Bloque inferior: titulo + CTAs -->
-    <div class="contenedor-descripcion-carro px-5 py-4">
-      <div class="text-gray-600 text-sm">Grupo {{ categoryCode }}</div>
+    <!-- Bloque inferior: titulo de categoria -->
+    <div class="contenedor-descripcion-carro px-5 pt-4 pb-3">
+      <div class="categoria-carro text-gray-700">Grupo {{ categoryCode }}</div>
       <h3 class="text-2xl font-semibold mt-1 text-gray-800">
         {{ vehicleCategory?.descripcion_corta }}
       </h3>
+    </div>
 
-      <div class="space-y-2 mt-4">
-        <UButton
-          color="neutral"
-          size="xl"
-          block
-          class="bg-gray-900 hover:bg-black text-white py-4"
-          @click="scrollToSearcher"
-        >
-          <template #trailing>
-            <ChevronRightIcon cls="size-5" />
-          </template>
-          Probar otras fechas
-        </UButton>
+    <!-- Cuerpo de CTAs: fondo difuminado (sutil-fondo) que separa los botones
+         del titulo, espejo del cuerpo de precios de la tarjeta disponible -->
+    <div class="sutil-fondo px-5 py-4 rounded-b-lg space-y-2">
+      <UButton
+        color="neutral"
+        size="xl"
+        block
+        class="bg-gray-900 hover:bg-black text-white py-4"
+        @click="scrollToSearcher"
+      >
+        <template #trailing>
+          <ChevronRightIcon cls="size-5" />
+        </template>
+        Probar otras fechas
+      </UButton>
 
-        <UButton
-          color="neutral"
-          size="xl"
-          block
-          class="bg-gray-900 hover:bg-black text-white py-4"
-          @click="scrollToSearcher"
-        >
-          <template #trailing>
-            <ChevronRightIcon cls="size-5" />
-          </template>
-          Probar otra sucursal cercana
-        </UButton>
-      </div>
+      <UButton
+        color="neutral"
+        size="xl"
+        block
+        class="bg-gray-900 hover:bg-black text-white py-4"
+        @click="scrollToSearcher"
+      >
+        <template #trailing>
+          <ChevronRightIcon cls="size-5" />
+        </template>
+        Probar otra sucursal cercana
+      </UButton>
     </div>
   </div>
 </template>

--- a/packages/ui-alquilame/app/components/Placeholders/UnableCategoryCard.vue
+++ b/packages/ui-alquilame/app/components/Placeholders/UnableCategoryCard.vue
@@ -4,10 +4,10 @@
     <div class="bg-red-50 border-l-4 border-red-500 px-4 py-3 flex items-start gap-2">
       <UIcon name="i-lucide-alert-triangle" class="w-5 h-5 text-red-600 mt-0.5 shrink-0" />
       <div>
-        <div class="text-sm font-semibold text-red-800">No disponible</div>
+        <div class="text-2xl font-semibold text-red-800 leading-tight">No disponible</div>
         <div
           v-if="isSpecific"
-          class="text-xs text-red-700 mt-0.5"
+          class="text-sm text-red-700 mt-0.5"
         >
           {{ bannerText }}
         </div>
@@ -23,40 +23,42 @@
       />
     </div>
 
-    <!-- Bloque inferior: titulo + CTAs -->
-    <div class="contenedor-descripcion-carro px-5 py-4">
-      <div class="text-gray-600 text-sm">Grupo {{ categoryCode }}</div>
+    <!-- Bloque inferior: titulo de categoria -->
+    <div class="contenedor-descripcion-carro px-5 pt-4 pb-3">
+      <div class="categoria-carro text-gray-700">Grupo {{ categoryCode }}</div>
       <h3 class="text-2xl font-semibold mt-1 text-gray-800">
         {{ vehicleCategory?.descripcion_corta }}
       </h3>
+    </div>
 
-      <div class="space-y-2 mt-4">
-        <UButton
-          color="neutral"
-          size="xl"
-          block
-          class="bg-gray-900 hover:bg-black text-white py-4"
-          @click="scrollToSearcher"
-        >
-          <template #trailing>
-            <ChevronRightIcon cls="size-5" />
-          </template>
-          Probar otras fechas
-        </UButton>
+    <!-- Cuerpo de CTAs: fondo difuminado (sutil-fondo) que separa los botones
+         del titulo, espejo del cuerpo de precios de la tarjeta disponible -->
+    <div class="sutil-fondo px-5 py-4 rounded-b-lg space-y-2">
+      <UButton
+        color="neutral"
+        size="xl"
+        block
+        class="bg-gray-900 hover:bg-black text-white py-4"
+        @click="scrollToSearcher"
+      >
+        <template #trailing>
+          <ChevronRightIcon cls="size-5" />
+        </template>
+        Probar otras fechas
+      </UButton>
 
-        <UButton
-          color="neutral"
-          size="xl"
-          block
-          class="bg-gray-900 hover:bg-black text-white py-4"
-          @click="scrollToSearcher"
-        >
-          <template #trailing>
-            <ChevronRightIcon cls="size-5" />
-          </template>
-          Probar otra sucursal cercana
-        </UButton>
-      </div>
+      <UButton
+        color="neutral"
+        size="xl"
+        block
+        class="bg-gray-900 hover:bg-black text-white py-4"
+        @click="scrollToSearcher"
+      >
+        <template #trailing>
+          <ChevronRightIcon cls="size-5" />
+        </template>
+        Probar otra sucursal cercana
+      </UButton>
     </div>
   </div>
 </template>

--- a/packages/ui-alquilatucarro/app/components/Placeholders/UnableCategoryCard.vue
+++ b/packages/ui-alquilatucarro/app/components/Placeholders/UnableCategoryCard.vue
@@ -4,10 +4,10 @@
     <div class="bg-red-50 border-l-4 border-red-500 px-4 py-3 flex items-start gap-2">
       <UIcon name="i-lucide-alert-triangle" class="w-5 h-5 text-red-600 mt-0.5 shrink-0" />
       <div>
-        <div class="text-sm font-semibold text-red-800">No disponible</div>
+        <div class="text-2xl font-semibold text-red-800 leading-tight">No disponible</div>
         <div
           v-if="isSpecific"
-          class="text-xs text-red-700 mt-0.5"
+          class="text-sm text-red-700 mt-0.5"
         >
           {{ bannerText }}
         </div>
@@ -23,40 +23,42 @@
       />
     </div>
 
-    <!-- Bloque inferior: titulo + CTAs -->
-    <div class="contenedor-descripcion-carro px-5 py-4">
-      <div class="text-gray-600 text-sm">Grupo {{ categoryCode }}</div>
+    <!-- Bloque inferior: titulo de categoria -->
+    <div class="contenedor-descripcion-carro px-5 pt-4 pb-3">
+      <div class="categoria-carro text-gray-700">Grupo {{ categoryCode }}</div>
       <h3 class="text-2xl font-semibold mt-1 text-gray-800">
         {{ vehicleCategory?.descripcion_corta }}
       </h3>
+    </div>
 
-      <div class="space-y-2 mt-4">
-        <UButton
-          color="neutral"
-          size="xl"
-          block
-          class="bg-gray-900 hover:bg-black text-white py-4"
-          @click="scrollToSearcher"
-        >
-          <template #trailing>
-            <ChevronRightIcon cls="size-5" />
-          </template>
-          Probar otras fechas
-        </UButton>
+    <!-- Cuerpo de CTAs: fondo difuminado (sutil-fondo) que separa los botones
+         del titulo, espejo del cuerpo de precios de la tarjeta disponible -->
+    <div class="sutil-fondo px-5 py-4 rounded-b-lg space-y-2">
+      <UButton
+        color="neutral"
+        size="xl"
+        block
+        class="bg-gray-900 hover:bg-black text-white py-4"
+        @click="scrollToSearcher"
+      >
+        <template #trailing>
+          <ChevronRightIcon cls="size-5" />
+        </template>
+        Probar otras fechas
+      </UButton>
 
-        <UButton
-          color="neutral"
-          size="xl"
-          block
-          class="bg-gray-900 hover:bg-black text-white py-4"
-          @click="scrollToSearcher"
-        >
-          <template #trailing>
-            <ChevronRightIcon cls="size-5" />
-          </template>
-          Probar otra sucursal cercana
-        </UButton>
-      </div>
+      <UButton
+        color="neutral"
+        size="xl"
+        block
+        class="bg-gray-900 hover:bg-black text-white py-4"
+        @click="scrollToSearcher"
+      >
+        <template #trailing>
+          <ChevronRightIcon cls="size-5" />
+        </template>
+        Probar otra sucursal cercana
+      </UButton>
     </div>
   </div>
 </template>

--- a/packages/ui-alquilatucarro/app/components/__tests__/UnableCategoryCard.mount.test.ts
+++ b/packages/ui-alquilatucarro/app/components/__tests__/UnableCategoryCard.mount.test.ts
@@ -41,9 +41,9 @@ const ADMIN_PAYLOAD = {
 // beforeEach (alongside useState/useToast) — `vi.unstubAllGlobals` in afterEach
 // would otherwise blow away a top-level stub after the first test.
 const stubbedUnavailabilityContext = () => ({
-  bannerText: ref('No disponible para el 12-15 mayo en Bogotá · Bogotá Aeropuerto'),
+  bannerText: ref('No disponible para el 12-15 mayo en Bogotá Aeropuerto'),
   dateRangeLabel: ref('12-15 mayo'),
-  locationLabel: ref('Bogotá · Bogotá Aeropuerto'),
+  locationLabel: ref('Bogotá Aeropuerto'),
   isSpecific: ref(true),
 });
 
@@ -210,7 +210,7 @@ describe('UnableCategoryCard mount — observable behavior', () => {
     expect(banner.exists()).toBe(true);
     expect(banner.text()).toContain('No disponible');
     expect(banner.text()).toContain('12-15 mayo');
-    expect(banner.text()).toContain('Bogotá · Bogotá Aeropuerto');
+    expect(banner.text()).toContain('Bogotá Aeropuerto');
   });
 
   it('renders both CTAs by accessible label', () => {


### PR DESCRIPTION
Pulido visual de la tarjeta "No disponible" para que sea espejo de la tarjeta disponible.

## Cambios

1. **"Grupo {code}"** ahora usa el estilo compartido `.categoria-carro` (`font-light text-lg`) en vez de `text-sm` → mismo tamaño/tipo que la tarjeta disponible.
2. **"No disponible"** sube a `text-2xl` para igualar el título de categoría ("Camioneta mecánica 4x4"); la línea de razón del banner sube `text-xs → text-sm` para igualar el label "Seguro Básico".
3. **CTAs dentro de un cuerpo `.sutil-fondo`** (el mismo degradado sutil del cuerpo de precios de la tarjeta disponible), que además separa los botones del título en vez de quedar pegados.
4. **Banner sin ciudad duplicada:** los nombres de sucursal ya empiezan con la ciudad ("Bogotá Aeropuerto"), así que `locationLabel` deja de anteponerla; solo conserva "Ciudad · Nombre" para sucursales suffix-only ("Sucursal Norte"). `...en Bogotá · Bogotá Aeropuerto` → `...en Bogotá Aeropuerto`.

Aplicado en las **3 marcas**; actualizados tests del composable (13/13) y de mount (14/14).

## Verificación
- ✅ Tests logic + componente pasan localmente.
- Pendiente en preview: confirmar visualmente tipografía, fondo difuminado, separación de botones y texto del banner.

**Blast radius:** `useUnavailabilityContext.ts` (+ test) y `Placeholders/UnableCategoryCard.vue` ×3 (+ mount test).