### PR TITLE
fix(seo): emit og:image on city landing pages + Blob audit (#49)

### DIFF
--- a/docs/specs/issue-49-seo-blob-audit/audit-seo-blob.md
+++ b/docs/specs/issue-49-seo-blob-audit/audit-seo-blob.md
@@ -1,0 +1,59 @@
+# Auditoría SEO — impacto del source Vercel Blob en JSON-LD y og:image
+
+**Issue:** #49 · **Fecha:** 2026-06-12 · **Marca de referencia:** alquilatucarro.com (única en prod sobre la app nueva)
+
+## Veredicto
+
+El riesgo que motivó el issue (que el cutover a Vercel Blob rompiera el JSON-LD o el og:image de páginas indexables) **no se materializó**. Todas las URLs de Blob en el JSON-LD renderizado resuelven HTTP 200, y el og:image de las páginas de marketing son assets estáticos de marca que el cutover no tocó.
+
+La auditoría sí encontró un gap preexistente, sin relación con Blob: las páginas de ciudad no emitían ningún `og:image` ni `twitter:image`. Se corrige en este mismo cambio.
+
+## Qué se revisó
+
+Las imágenes de modelo viajan así hacia el JSON-LD: admin API / Supabase → `transformers.ts` (`image_url` → `image`) → `useProductSchema` / `useCityProductSchema` → grafo de nuxt-schema-org. El og:image es una vía separada: assets estáticos por marca (`franchise.ogImage`), absolutizados por nuxt-seo vía `site.url`.
+
+Validación sobre HTML **renderizado** (no sobre el source), que es lo que ve un crawler.
+
+## Hallazgos
+
+| Check del issue | Estado | Evidencia |
+|---|---|---|
+| URLs de imagen legacy hardcodeadas | ✅ Cero | grep sin resultados; los `googleapis.com` son OAuth de GSC |
+| JSON-LD model images (Blob) | ✅ Resuelven | `/bogota` ImageObject → Blob, HEAD 200 `image/jpeg`+`image/avif` |
+| og:image páginas de marketing | ✅ Intacto | `/img/og-*.jpg`, absoluto, 200, ajeno a Blob |
+| og:image páginas de ciudad | 🔴→✅ Corregido | `useCityPageSEO` no emitía og:image; ahora sí |
+| GSC 404 re-validation | ⏳ Manual | requiere OAuth de Search Console |
+| FB / X card validators | ⚠️ Sustituido | validadores nativos no viables; ver abajo |
+
+### El gap de og:image y su corrección
+
+`useCityPageSEO` —compartido por las 3 marcas vía el layer `logic`— seteaba `ogDescription` y `twitterDescription` pero nunca `ogImage`/`twitterImage`. Una página de ciudad compartida en redes salía sin imagen: tarjeta de solo texto.
+
+La corrección agrega `ogImage`/`twitterImage` apuntando a `franchise.ogImage` (el asset estático por marca, el mismo que ya usa el home), más un `alt` contextual por ciudad. Deliberadamente **no** se usa una imagen de modelo de Blob: así el caché social no se rompe cuando rota el catálogo de vehículos.
+
+### Validadores sociales
+
+El Twitter/X Card Validator se dio de baja en 2022 y el Facebook Sharing Debugger exige login. Como sustituto se usó un inspector OG público que hace fetch tipo-crawler. Contra prod (pre-deploy) confirmó:
+
+- **`/bogota`**: "Image is missing" + "X image is missing" — la tarjeta de Facebook renderiza sin imagen. Es el gap que cierra este cambio.
+- **Post de blog**: el og:image renderiza bien (200); única observación menor, el aspect ratio 1200×800 frente al 1.91:1 ideal, preexistente y fuera del scope de #49.
+
+Post-deploy, la verificación correcta del checklist es correr el Facebook Sharing Debugger sobre una URL de ciudad para forzar el re-scrape del og:image nuevo.
+
+## Cómo reproducir
+
+```bash
+# og:image de ciudad (post-deploy: debe aparecer og:image absoluto 200)
+curl -s https://alquilatucarro.com/bogota | grep -oiE '<meta property="og:image[^>]*>'
+
+# JSON-LD model images resuelven
+curl -s https://alquilatucarro.com/bogota | grep -oE '"contentUrl":"https://[^"]*blob[^"]*"'
+# → HEAD cada URL: curl -sI <url> | head -1   (esperado: 200 image/*)
+
+# sin hosts legacy en el HTML renderizado
+curl -s https://alquilatucarro.com/bogota | grep -ciE 'firebasestorage|cloudinary|imgix'   # → 0
+```
+
+## Scenarios
+
+Holdout en `scenarios/city-og-image.scenarios.md` (SCEN-001…005). Test de regresión: `packages/logic/src/composables/__tests__/useCityPageSEO.ogImage.test.ts`. Suite de logic verde (362/362).

--- a/docs/specs/issue-49-seo-blob-audit/scenarios/city-og-image.scenarios.md
+++ b/docs/specs/issue-49-seo-blob-audit/scenarios/city-og-image.scenarios.md
@@ -1,0 +1,54 @@
+---
+name: issue-49-seo-blob-audit
+created_by: pablo
+created_at: 2026-06-12T00:00:00Z
+issue: 49
+---
+
+# Issue #49 — SEO audit: Vercel Blob source impact on JSON-LD & og:image
+
+Audit goal: confirm the model-image source cutover to Vercel Blob did not break
+JSON-LD or og:image on indexable pages, and close the one actionable gap found
+(city landing pages emit no `og:image`/`twitter:image`).
+
+The fix lives in `packages/logic/src/composables/useCityPageSEO.ts`, so it
+propagates to all three brands.
+
+## SCEN-001: city landing page emits a social share image
+**Given**: an indexable city landing page rendered by `useCityPageSEO` (e.g. `/bogota`)
+**When**: the composable runs and the `<head>` meta is inspected
+**Then**: `useSeoMeta` is called with both `ogImage` and `twitterImage` set to a
+non-empty value (the brand's `franchise.ogImage`), so the page is no longer
+shared image-less on social networks
+**Evidence**: captured `useSeoMeta` payload (unit) + `<meta property="og:image">`
+present in rendered HTML of `/bogota` (runtime curl)
+
+## SCEN-002: the share image is a stable brand asset, never a volatile Blob model image
+**Given**: the city page og:image
+**When**: its content URL is inspected
+**Then**: it resolves to the brand's own static asset (`/img/og-<brand>.jpg`,
+absolutized by nuxt-seo to the brand `site.url`) and returns HTTP 200 — it must
+NOT point to a `*.public.blob.vercel-storage.com` model image, so social caches
+never break when the vehicle catalog churns
+**Evidence**: og:image content host is the brand domain (not blob) + HEAD 200 on the asset
+
+## SCEN-003: JSON-LD model images use the Blob source and resolve (regression guard)
+**Given**: a live city page with available categories (`/bogota`)
+**When**: the rendered `application/ld+json` graph is parsed
+**Then**: each model `ImageObject` `contentUrl`/`url` points to
+`*.public.blob.vercel-storage.com` and returns HTTP 200 with an `image/*`
+content-type — the Blob cutover did not strand JSON-LD images
+**Evidence**: ld+json ImageObject nodes from `/bogota` + HEAD 200 image/* on each sampled URL
+
+## SCEN-004: no legacy image host survives the cutover (regression guard)
+**Given**: rendered HTML of the home and a city page
+**When**: scanned for legacy image hosts (firebasestorage, old CDNs) in image positions
+**Then**: none are present; every image URL is either a same-origin brand asset
+or the Vercel Blob CDN
+**Evidence**: grep over rendered HTML returns zero legacy-host matches
+
+## SCEN-005: existing per-brand og:image contract stays satisfied (regression guard)
+**Given**: the three brands' home og:image (issue #108 holdout)
+**When**: the existing `seo-og-image-per-brand` suite runs
+**Then**: each brand still serves its own distinct, existing 1200×630 JPEG
+**Evidence**: `pnpm --filter @rentacar-main/logic test` green for that suite

--- a/packages/logic/src/composables/__tests__/useCityPageSEO.ogImage.test.ts
+++ b/packages/logic/src/composables/__tests__/useCityPageSEO.ogImage.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Issue #49 holdout (SCEN-001 / SCEN-002): city landing pages were rendered
+// with NO og:image / twitter:image — shared image-less on social. useCityPageSEO
+// must emit a social share image pointing to the STABLE per-brand asset
+// (franchise.ogImage), never a volatile Vercel Blob model image.
+//
+// Sub-composables are mocked to no-ops so we observe ONLY the og/twitter image
+// meta this composable is responsible for. Auto-imported Nuxt globals are stubbed.
+
+vi.mock('../useBaseSEO', () => ({ useBaseSEO: () => {} }))
+vi.mock('../useBreadcrumbs', () => ({ useCityBreadcrumbs: () => {} }))
+vi.mock('../useCityFAQs', () => ({ useCityFAQSchema: () => {} }))
+vi.mock('../useData', () => ({
+  useData: () => ({
+    getCityById: (slug: string) => ({ name: 'Bogotá', description: `Alquiler en ${slug}` }),
+  }),
+}))
+
+import { useCityPageSEO } from '../useCityPageSEO'
+
+let seoMeta: Record<string, unknown> = {}
+
+const stub = (ogImage = '/img/og-alquilatucarro.jpg') => {
+  vi.stubGlobal('useAppConfig', () => ({
+    franchise: {
+      website: 'https://alquilatucarro.com',
+      description: 'Alquiler de carros en Colombia',
+      title: 'Alquilatucarro',
+      ogImage,
+    },
+    organization: { brand: 'Alquilatucarro' },
+  }))
+  vi.stubGlobal('useRoute', () => ({ params: { city: 'bogota' }, path: '/bogota' }))
+  vi.stubGlobal('useSeoMeta', (meta: Record<string, unknown>) => {
+    seoMeta = { ...seoMeta, ...meta }
+  })
+  vi.stubGlobal('useHead', () => {})
+}
+
+beforeEach(() => {
+  seoMeta = {}
+})
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('useCityPageSEO og:image (issue #49)', () => {
+  // SCEN-001: city page emits a social share image
+  it('sets both ogImage and twitterImage so the page is not shared image-less', () => {
+    stub('/img/og-alquilatucarro.jpg')
+    useCityPageSEO()
+    expect(seoMeta.ogImage).toBe('/img/og-alquilatucarro.jpg')
+    expect(seoMeta.twitterImage).toBe('/img/og-alquilatucarro.jpg')
+  })
+
+  // SCEN-002: the share image is the stable brand asset, never a Blob model image
+  it('uses the per-brand franchise.ogImage, never a volatile Blob model image', () => {
+    stub('/img/og-alquilame.jpg')
+    useCityPageSEO()
+    expect(seoMeta.ogImage).toBe('/img/og-alquilame.jpg')
+    expect(seoMeta.twitterImage).toBe('/img/og-alquilame.jpg')
+    expect(String(seoMeta.ogImage)).not.toContain('blob.vercel-storage.com')
+    expect(String(seoMeta.twitterImage)).not.toContain('blob.vercel-storage.com')
+  })
+})

--- a/packages/logic/src/composables/useCityPageSEO.ts
+++ b/packages/logic/src/composables/useCityPageSEO.ts
@@ -34,6 +34,14 @@ export const useCityPageSEO = () => {
         ? `Alquiler de Carros en ${city.name} desde $32/día`
         : franchise.title
 
+    // Social share image: the per-brand static asset (franchise.ogImage,
+    // absolutized by nuxt-seo via site.url), NOT a Blob model image — so social
+    // caches never break when the vehicle catalog churns. Without this, city
+    // landing pages rendered with no og:image/twitter:image (issue #49).
+    const cityShareImageAlt = city
+        ? `Alquiler de carros en ${city.name} — ${franchise.name}`
+        : franchise.name
+
     useHead({
         title: cityTitle,
         htmlAttrs: {
@@ -51,6 +59,10 @@ export const useCityPageSEO = () => {
         description: cityDescription,
         ogDescription: cityDescription,
         twitterDescription: cityDescription,
+        ogImage: franchise.ogImage,
+        ogImageAlt: cityShareImageAlt,
+        twitterImage: franchise.ogImage,
+        twitterImageAlt: cityShareImageAlt,
     })
 
     if (city) {


### PR DESCRIPTION
## Auditoría #49 + fix

Cierra la auditoría SEO del cutover de imágenes de modelo a Vercel Blob.

**Veredicto:** el riesgo del issue (que el cutover rompiera JSON-LD u og:image en páginas indexables) **no se materializó**. Todas las URLs de Blob en el JSON-LD renderizado resuelven HTTP 200, y el og:image de las páginas de marketing son assets estáticos de marca, ajenos al cutover.

**Único accionable encontrado → corregido:** las páginas de ciudad (`useCityPageSEO`, compartido por las 3 marcas) seteaban `ogDescription`/`twitterDescription` pero nunca `ogImage`/`twitterImage`. Una URL de ciudad compartida en redes salía como tarjeta de solo texto, sin imagen.

### Cambio
`useCityPageSEO.ts` ahora emite `ogImage`/`twitterImage` = `franchise.ogImage` (el asset estático por marca, el mismo que ya usa el home, absolutizado por nuxt-seo vía `site.url`) + un `alt` contextual por ciudad. Deliberadamente **no** se usa una imagen de modelo de Blob: así el caché social no se rompe cuando rota el catálogo.

### Evidencia
- **Runtime (dev `/bogota`):** ahora renderiza `<meta property="og:image" content="https://alquilatucarro.com/img/og-alquilatucarro.jpg">` + `twitter:image` + alt.
- **"Before" (prod):** inspector OG confirmó tarjeta sin imagen en `/bogota` ("Image is missing" / "X image is missing").
- **JSON-LD (prod):** model images Blob → HEAD 200 `image/jpeg`. Cero hosts legacy.
- **Tests:** suite logic 362/362; test de regresión `useCityPageSEO.ogImage.test.ts` (red-green verificado, 3× estable).
- **Scenarios:** 5/5 satisfechos (holdout en `docs/specs/issue-49-seo-blob-audit/scenarios/`).
- **Review:** code-reviewer + edge-case-detector → aprobado, cero hallazgos materiales.

Reporte completo: `docs/specs/issue-49-seo-blob-audit/audit-seo-blob.md`.

### Pendiente (externo, manual — documentado en el reporte)
- [ ] GSC 404 re-validation (requiere OAuth de Search Console).
- [ ] Facebook Sharing Debugger re-scrape **post-deploy** sobre una URL de ciudad (forzar refresh del og:image nuevo). El Twitter/X Card Validator fue dado de baja en 2022.

Closes #49
