### PR TITLE
feat(alquilame): F4 — blog reskin to brand (presentation-only; SEO/data preserved)

### DIFF
--- a/docs/specs/2026-06-12-issue-112-f4-blog-design.md
+++ b/docs/specs/2026-06-12-issue-112-f4-blog-design.md
@@ -1,0 +1,87 @@
+# Issue #112 — F4: Blog reskin (fase de cierre)
+
+**Fecha:** 2026-06-12
+**Branch:** `feat/issue-112-f4-blog` · worktree `.worktrees/issue-112-f4-blog` · base `origin/main` (f4a9d66, con F0+F1+F2+F3)
+**Cierre:** esta fase cierra #112 con `Closes #112`.
+
+## Objetivo
+
+Reskin de marca alquilame (rojo #CC022B, Plus Jakarta Sans headings + DM Sans body, tokens F0-F3) sobre las **dos páginas del blog**, hoy en estilo mayormente genérico (escala gris + `red-*` default + botón Facebook azul + gradiente v3 `bg-gradient-to-*`). Aislado a `packages/ui-alquilame`. Cero regresión en data, SEO/schema, comportamiento y E2E.
+
+## No-objetivos
+
+- NO tocar `packages/logic` ni las otras 2 marcas.
+- NO cambiar el data contract (`BlogPost`), endpoints (`/api/blog/posts`, `/api/blog/post/[slug]`), ni el transform Valibot.
+- NO cambiar el schema JSON-LD (`BlogPosting` + `BreadcrumbList`) ni los campos `useSeoMeta` (article meta).
+- NO cambiar el comportamiento (filtros de categoría, navegación, MDC render, TOC, reading progress, ISR 3600s).
+- NO crear directorio `app/components/blog/` nuevo salvo que un bloque inline justifique extracción (preferir restyle in-place).
+
+## Decisiones de diseño (aprobadas por usuario 2026-06-12)
+
+1. **CTAs de reserva → `/reservas`.** Hoy existen **3** CTAs de reserva, todos apuntando a `to="/"` (HOME, no a reserva): `index.vue:155` (footer), `[...slug].vue:143` (caja sidebar), `[...slug].vue:175` (bio del autor). Los **3** se retargetean a `/reservas` con copy de reserva. `<NuxtLink to="/reservas">`. **Anti-reward-hack: ningún CTA de reserva del blog puede seguir apuntando a `to="/"`** — el target viejo debe desaparecer, no solo agregarse el nuevo.
+2. **Hero del index: oscuro restyleado sobre el ground del layout.** El `UPageHero` NO tiene fondo propio; el oscuro lo aporta `layouts/default.vue` (`bg-linear-to-b from-brand-900 to-brand-950`, F0, **fuera de scope**) y la página fuerza `colorMode:'light'` con texto blanco. "Oscuro restyleado" = renderizar el contenido del hero sobre ese ground rojo-oscuro heredado (ya on-brand, distinto de los heroes brillantes `hero-from/hero-to`), **sin agregar wrapper de fondo ni gradiente brillante**. Solo se restylea el CONTENIDO: h1 → `font-heading` conservando `text-white` (NO usar `.heading-*` crudo: su color oscuro haría el título invisible sobre el ground oscuro — si se usa, exige `[--ctx-text-primary:#fff]` en el contenedor); acento `text-red-500` → tono brand legible sobre oscuro. El hero del **detalle** sigue siendo imagen con overlay (convertir el único `bg-gradient-to-t` de `[...slug].vue:19` → `bg-linear-to-t` por la regla Tailwind 4).
+3. **Share buttons: colores de plataforma.** 4 botones × 2 ubicaciones (sidebar `:109-134` + barra móvil `:242-269`). Conservar WhatsApp verde (`bg-green-500`) / Facebook azul (`bg-blue-600`) / X negro (`bg-black`) — convención UX de reconocibilidad, igual que el verde "confirmar" de F3. El azul de FB se acepta como color de plataforma, NO de marca. Solo el botón "copiar enlace" gris (`bg-gray-600`, ambas ubicaciones) pasa a token de marca.
+4. **Chrome sin marca también entra al reskin** (mandato general "blog a marca"): back-to-blog button (`[...slug].vue:230`, `bg-gray-200 text-black`), bloque 404 (`[...slug].vue:275-285`, grises + `bg-red-700`), card de bio del autor (`[...slug].vue:158`, `bg-gray-50`). A tokens de marca/surface.
+
+   **Política de superficies (aplica a TODA superficie estructural, no solo las 3 nombradas):** ningún `gray-*` crudo sobrevive como chrome. Mapeo con tokens F0:
+   - Grounds de sección `bg-gray-100` (`index:19`, `slug:196`) → `bg-surface-soft` (#edf0f5).
+   - Paneles/cards claros `bg-gray-50` (los **3 paneles sidebar** `slug:65/:90/:104` + bio `:158`) y cards `bg-white` → `bg-surface-softer`/`bg-surface-softest` (cards pueden quedar `bg-white` si necesitan contraste sobre el ground soft).
+   - Pills `bg-gray-200` (`slug:96`, back button `:230`) → `bg-surface-soft` (back button: superficie soft + acento brand en hover/texto).
+   - Panel CTA oscuro `bg-gray-900` (`index:146`) → `bg-brand-900` (#7a001a) con `[--ctx-text-primary:#fff]` para headings blancos.
+   - **Excepción legibilidad:** el TEXTO neutro gris sobre superficies claras (`text-gray-600/700/900` de body/meta/títulos de card) se permite — es texto legible, NO chrome de marca. Solo backgrounds estructurales + acentos rojos rebrandean. No reemplazar texto gris por brand salvo los acentos (hover `text-red-700`→`text-brand-700`, etc.).
+5. **`red-*` default → `brand-*`.** Todo el blog usa rojos Tailwind por defecto (`red-500/700/100`, p.ej. `rgb(185,28,28)`=red-700) que ≠ marca #CC022B. Los acentos rojos (badges categoría, filtro activo, hovers, links de prose, borde blockquote, code) pasan a la escala `brand-*`.
+
+## Patrones heredados (F0-F3, no se re-deciden)
+
+- Escala `brand-*` (600=#CC022B, 800=#94001E); usar tokens, no `red-*`/`gray-*` crudos para chrome de marca.
+- `bg-linear-to-*` NUNCA `bg-gradient-to-*` (con `@theme` custom da `background-image:none`). Ver `reference_tailwind4_gradient_bg_linear`.
+- `.heading-*` traen color OSCURO + tamaño; sobre fondo oscuro/rojo añadir `[--ctx-text-primary:#fff]` en el contenedor.
+- Body hereda DM Sans global; headings → `font-heading`/`.heading-*`. Sin `<link>` Google Fonts (vía @nuxt/fonts).
+- Preservar selectores E2E (el blog usa text/href, sin `data-testid`).
+
+## Alcance por archivo (file structure)
+
+| Archivo | Responsabilidad | Cambio |
+|---|---|---|
+| `app/pages/blog/index.vue` (283 L) | Listado: hero, featured, filtros categoría, grid, empty, CTA footer | Restyle in-place: hero contenido brand (font-heading+white), cards brand-*, filtros activo brand, footer CTA `:155`→/reservas |
+| `app/pages/blog/[...slug].vue` (670 L) | Detalle: progress bar, hero img, meta, MDC, sidebar (TOC/tags/share/CTA), share bar móvil, bio autor, relacionados, back, 404, **`<style>` prose** | Restyle in-place: tokens brand-*, `bg-linear-to-t` (`:19`), share platform+debrand gris copy, CTAs `:143`+`:175`→/reservas, bio card surface (`:158`), back button (`:230`), 404 (`:275`); **`<style>` block `:526-670` = dueño del prose MDC** (h2/p/a/code/table/blockquote): red-700 `rgb(185,28,28)`→brand #CC022B |
+| `app/assets/css/rentacar-main/blog.css` (34 L) | **Dueño de callouts/admonitions** del MDC (`.prose div.bg-muted`, `.prose div.text-default`, `article.prose > div.group`) — selectores DISJUNTOS del `<style>` de la página, sin conflicto | Ampliar acentos a tokens brand, callouts legibles |
+| `app/pages/blog/__tests__/index.test.ts` (NEW) | Guard de marca del index | Asserts: hero `text-white`+`font-heading`, cero `bg-gradient-to-`, footer CTA `to="/reservas"` y **cero `to="/"` de reserva**, filtros |
+| `app/pages/blog/__tests__/slug.test.ts` (NEW) | Guard de marca del detalle | Asserts: tokens brand, share platform (green/blue/black) preservados + copy debrandado, ambos CTAs `to="/reservas"` y **cero `to="/"`**, `bg-linear-to-t`, schema fields presentes |
+
+## Estrategia de satisfacción
+
+- **Unit (vitest, desde el WORKTREE root):** tests de marca nuevos asercionan clases/tokens sobre el markup renderizado (cero `bg-gradient-to-`, cero `text-blue-*` salvo el FB share intencional documentado, CTA `to="/reservas"`, `.heading-*`/`font-heading` en títulos, share platform colors presentes, copy-button debrandado). NO debilitar: si un assert falla, arreglar el componente, no el test.
+- **Typecheck:** `ionice -c3 nice -n19 pnpm --filter ui-alquilame typecheck` desde el worktree — delta 0 vs baseline (apples-to-apples con `.nuxt` fresco).
+- **Aislamiento:** `git diff main --stat` = solo `packages/ui-alquilame/**` + `docs/specs/**`; `packages/logic` y las otras 2 marcas vacías.
+- **Runtime (Vercel preview, /agent-browser):** /blog y un /blog/[slug] real — hero oscuro texto blanco legible, gradiente detalle renderiza (`background-image != none`), cards brand, filtros funcionan, CTA→/reservas navega, share buttons visibles, cero errores de consola nuevos, cero requests fallidos, CLS ≤ baseline.
+- **SEO:** curl+grep del HTML renderizado — `BlogPosting` + `BreadcrumbList` JSON-LD presentes, article meta (published/modified/author/section/tags) intactos. URL absoluta de og:image. Ver `reference_nuxt_seo_og_image_absolute`.
+- **E2E:** `BRAND=alquilame` `e2e/blog.spec.ts` contra el preview — delta 0 net-new failures vs baseline main (los fallos remotos flaky preexistentes no cuentan).
+
+## Holdout — escenarios observables (SCEN-F4)
+
+- **SCEN-F4-01** — Index hero oscuro: dado `/blog`, el h1/heading rinde en blanco Plus Jakarta sobre fondo oscuro (texto NO invisible), shortname con acento rojo de marca.
+- **SCEN-F4-02** — Cards del listado (featured + grid): usan tokens brand (acento rojo, `font-heading`), cero `bg-gradient-to-*`, cero gris-como-color-de-marca.
+- **SCEN-F4-03** — Filtros de categoría: estado activo en rojo de marca, inactivo neutro; click filtra los posts (comportamiento preservado).
+- **SCEN-F4-04** — CTA footer del index enlaza a `/reservas` con copy de reserva, Y ningún CTA de reserva del index sigue apuntando a `to="/"` (target viejo eliminado).
+- **SCEN-F4-05** — Detalle hero: imagen + overlay `bg-linear-to-t` renderiza; título `.heading-*` blanco sobre imagen; fila de meta (autor/fecha/tiempo) intacta.
+- **SCEN-F4-06** — Cuerpo MDC: prose estilado a marca (blog.css), callouts legibles (contraste correcto).
+- **SCEN-F4-07** — Sidebar: TOC + tags brand; caja CTA del sidebar Y CTA de bio del autor → `/reservas`; ningún CTA de reserva del detalle sigue en `to="/"`.
+- **SCEN-F4-08** — Share buttons: WhatsApp verde / FB azul / X negro preservados (plataforma); botón copiar gris → token de marca; barra share móvil presente.
+- **SCEN-F4-09** — Sección bio del autor: estilada a marca (token surface, no `gray-50` crudo).
+- **SCEN-F4-10** — Relacionados: cards brand, enlazan a `/blog/[slug]`.
+- **SCEN-F4-11** — SEO preservado: `BlogPosting` + `BreadcrumbList` JSON-LD intactos en el HTML; article meta (published/modified/author/section/tags) presentes.
+- **SCEN-F4-12** — E2E `blog.spec.ts` (BRAND=alquilame): index carga, 7 slugs cargan, navegación, meta SEO, HTTP 200 — delta 0 vs baseline.
+- **SCEN-F4-13** — Aislamiento: `git diff main` = solo `packages/ui-alquilame` + docs; logic + otras 2 marcas vacías; typecheck delta 0.
+- **SCEN-F4-14** — Chrome sin marca rebrandeado: back-to-blog button, bloque 404 y card de bio del autor usan tokens de marca/surface (no `bg-gray-200 text-black`, no `bg-gray-50` crudo); prose MDC con links/blockquote/code en brand #CC022B (no red-700 `rgb(185,28,28)`).
+
+## Riesgos
+
+- **Hero del index (fondo lo da el layout):** el `UPageHero` no tiene fondo; el oscuro viene de `default.vue` (fuera de scope). NO agregar wrapper de fondo en la página (rompería el patrón y duplicaría el ground). El título es `text-white` explícito hoy y debe seguir legible — añadir `font-heading` SIN cambiar a `.heading-*` crudo (su color oscuro lo volvería invisible); si se usa `.heading-*`, exige `[--ctx-text-primary:#fff]`. B1 cazado en F0/F1.
+- **Gradiente del overlay del detalle:** el único `bg-gradient-to-t from-gray-900/80` (`:19`) usa color directo (no @theme) así que técnicamente renderiza, pero se convierte a `bg-linear-to-t` por consistencia de regla — verificar en runtime que el overlay sigue visible sobre la imagen.
+- **Doble dueño del prose:** `<style>` de la página (`:526-670`, elementos MDC) y `blog.css` (callouts `div.bg-muted`) tienen selectores disjuntos — confirmar que el rebrand de acentos (red-700→#CC022B) en ambos no introduce solape; acotar selectores, no usar `.prose *` amplio.
+- **og:image / schema:** no tocar los campos (`BlogPosting`, `BreadcrumbList`, article meta); solo estilo. Verificar en HTML renderizado (curl+grep), no en source. Ver `reference_nuxt_seo_og_image_absolute`.
+- **E2E selectores text/href:** `blog.spec.ts` usa `getByText`/`href*=/blog/` sin testids — el reskin no debe cambiar textos visibles ni los `href` de navegación a posts.
+
+---
+*F4 cierra el reskin de marca alquilame (#112). Cadena: F0 fundación → F1 home → F2 city+legales → F3 funcional/reservas → **F4 blog**.*

--- a/docs/specs/2026-06-12-issue-112-f4-blog/implementation/plan.md
+++ b/docs/specs/2026-06-12-issue-112-f4-blog/implementation/plan.md
@@ -1,0 +1,36 @@
+# F4 Blog reskin — Implementation Plan
+
+**Spec:** `docs/specs/2026-06-12-issue-112-f4-blog-design.md` (APPROVE-WITH-FIXES, gaps cerrados)
+**Worktree:** `.worktrees/issue-112-f4-blog` · branch `feat/issue-112-f4-blog`
+
+## File structure (dueños)
+
+| Archivo | Dueño de | Step |
+|---|---|---|
+| `app/pages/blog/index.vue` | Listado completo (hero, featured, filtros, grid, empty, CTA footer) | 01 |
+| `app/pages/blog/__tests__/index.test.ts` (NEW) | Guard de marca del listado (source-text asserts) | 01 |
+| `app/pages/blog/[...slug].vue` | Detalle completo + `<style>` prose MDC | 02 |
+| `app/assets/css/rentacar-main/blog.css` | Callouts/admonitions del MDC | 02 |
+| `app/pages/blog/__tests__/slug.test.ts` (NEW) | Guard de marca del detalle (source-text asserts) | 02 |
+
+Tests = **source-text assertions** (leer el `.vue`/`.css` como string y asercionar regex), patrón F0 `tests/f0-chrome.test.ts` — sin montar componentes, sin mockear `$fetch`/composables. Entorno node, solo vitest.
+
+## Steps
+
+1. **Step 01 — Reskin `blog/index.vue` + guard** | Size: M | Dependencies: none
+   Establece el patrón de card de marca (reusado en relacionados del detalle). Hero contenido brand (font-heading+white), featured/grid cards a tokens brand, badges/filtro-activo/hovers `red-*`→`brand-*`, grounds `bg-gray-100`→`bg-surface-soft`, panel CTA footer `bg-gray-900`→`bg-brand-900`+`[--ctx-text-primary:#fff]`, CTA `:155` `to="/"`→`/reservas`. Preservar comportamiento de filtros, SEO, schema, textos/href. + `index.test.ts`.
+
+2. **Step 02 — Reskin `blog/[...slug].vue` + `blog.css` + guard** | Size: M | Dependencies: Step 01 (reusa patrón de card)
+   Hero overlay `bg-gradient-to-t`→`bg-linear-to-t` (`:19`), título `.heading-*`/white sobre imagen, meta intacta. Sidebar (TOC/tags/share/CTA): 3 paneles `bg-gray-50`→surface, share platform preservado + copy gris→brand, CTA `:143`→`/reservas`. Bio card `:158`→surface + CTA `:175`→`/reservas`. Relacionados (reusa card brand). Back button `:230`→surface+acento. 404 `:275`→brand. `<style>` prose `:526-670`: red-700 `rgb(185,28,28)`→brand #CC022B (links/blockquote/code). `blog.css`: acentos callout→brand. Preservar BlogPosting/BreadcrumbList/article-meta, TOC, reading-progress, MDC render. + `slug.test.ts`.
+
+## Testing Strategy
+
+- **Unit:** `pnpm --filter ui-alquilame exec vitest run app/pages/blog` (desde worktree) — guards de marca verdes.
+- **Typecheck:** delta 0 vs baseline (`/tmp/f4-baseline-tc.log`).
+- **Aislamiento:** `git diff main --stat` solo `packages/ui-alquilame` + docs.
+- **Runtime (Vercel preview, agent-browser):** /blog + /blog/[slug] real — SCEN-F4-01..14.
+- **E2E:** `BRAND=alquilame e2e/blog.spec.ts` vs preview, delta 0.
+
+## Rollout
+
+Push branch → Vercel preview auto → runtime verify → verification-before-completion → PR `Closes #112` (gh auth switch pabloandi).

--- a/docs/specs/2026-06-12-issue-112-f4-blog/implementation/step01/task-01-reskin-blog-index.code-task.md
+++ b/docs/specs/2026-06-12-issue-112-f4-blog/implementation/step01/task-01-reskin-blog-index.code-task.md
@@ -1,0 +1,59 @@
+## Status: PENDING
+## Blocked-By:
+## Completed:
+
+# Task: Reskin `blog/index.vue` (listado) a marca alquilame + guard de marca
+
+## Description
+Reskin de la página de listado del blog a la marca alquilame (rojo #CC022B, Plus Jakarta Sans / DM Sans, tokens F0). Establece el patrón de card de marca que el detalle (step02) reusa en "relacionados". Preserva comportamiento, SEO, schema, textos y href.
+
+## Background
+F4 cierra el reskin de marca #112 (F0 fundación → F1 home → F2 city → F3 funcional → **F4 blog**). El blog está hoy en estilo genérico (grises + `red-*` default + sin font-heading). Tokens F0 en `app/assets/css/theme.css`: `brand-50..950` (600=#CC022B, 800=#94001E, 900=#7a001a), `surface-soft #edf0f5`, `surface-softer #f4f5f9`, `surface-softest #f8f9fc`. Regla Tailwind 4: NUNCA `bg-gradient-to-*` (usar `bg-linear-to-*`); `.heading-*` trae color oscuro (sobre oscuro requiere `[--ctx-text-primary:#fff]`).
+
+## Reference Documentation
+**Required:**
+- Design: `docs/specs/2026-06-12-issue-112-f4-blog-design.md` (decisiones 1-5, holdout SCEN-F4)
+- Plan: `docs/specs/2026-06-12-issue-112-f4-blog/implementation/plan.md`
+
+## Technical Requirements
+1. **Hero (`:4-16`)**: contenido sobre el ground oscuro del layout (NO agregar fondo). h1 mantiene `text-white` + añade `font-heading`. Acento `text-red-500` (`:7`) → tono brand legible sobre oscuro (`text-brand-300`/`text-brand-400`). Descripción `text-white` se mantiene.
+2. **Grounds de sección**: `bg-gray-100` (`:19`) → `bg-surface-soft`.
+3. **Featured card (`:28-59`)** y **grid cards (`:92-123`)**: títulos `font-heading`; hover `text-red-700` → `text-brand-700`; badge categoría `text-red-700 bg-red-100` → `text-brand-700 bg-brand-100` (`:38`) y `bg-red-700` → `bg-brand-600` (`:100`). Texto neutro de body/meta (`text-gray-600/500/900`) se mantiene (legibilidad, NO chrome). Cards `bg-white` pueden quedar `bg-white`.
+4. **Filtros (`:67-80`)**: activo `bg-red-700` → `bg-brand-600`; inactivo `bg-white ... border-gray-200` puede mantenerse o `bg-surface-softest`. Comportamiento de filtrado (`setCategory`, query `categoria`) INTACTO.
+5. **Empty state (`:128-141`)**: acento `text-red-700` → `text-brand-700`.
+6. **CTA footer (`:145-161`)**: panel `bg-gray-900` → `bg-brand-900` + `[--ctx-text-primary:#fff]` para heading blanco; botón `bg-red-700 hover:bg-red-800` → `bg-brand-600 hover:bg-brand-700`; **`to="/"` (`:155`) → `to="/reservas"`**. Texto `text-gray-300` puede mantenerse o `text-brand-100`.
+7. **NO tocar**: `<script setup>` (SEO `useHead`/`useSeoMeta`/`useSchemaOrg`, data `useAsyncData`/`$fetch`, computeds de filtro), `definePageMeta({colorMode:'light'})`, textos visibles, href de navegación a posts.
+
+## Implementation Approach
+1. Editar el `<template>` aplicando los mapeos de arriba; no tocar `<script>`.
+2. Crear `app/pages/blog/__tests__/index.test.ts` — **source-text asserts** (patrón F0 `tests/f0-chrome.test.ts`: leer el `.vue` como string con `readFileSync`, asercionar regex). Sin montar componente.
+
+## Acceptance Criteria
+1. **Hero brand (SCEN-F4-01)**
+   - Given el source de `index.vue`
+   - When se lee el bloque hero
+   - Then h1 contiene `text-white` y `font-heading`, y el acento usa `text-brand-*` (no `text-red-500`).
+2. **CTA centralizado + anti-reward-hack (SCEN-F4-04)**
+   - Given el source
+   - When se busca el target del CTA de reserva
+   - Then contiene `to="/reservas"` y NO contiene ningún `to="/"` de reserva.
+3. **Sin gradiente v3 + cards brand (SCEN-F4-02)**
+   - Given el source
+   - When se busca `bg-gradient-to-`
+   - Then no hay coincidencias; y badges/hover/filtro-activo usan `brand-*` (no `red-700` crudo).
+4. **Guard verde**
+   - Given `vitest run app/pages/blog/__tests__/index.test.ts`
+   - When corre
+   - Then pasa; si falla, se corrige el componente, no el test.
+5. **Comportamiento + typecheck preservados**
+   - Given el diff
+   - When se inspecciona `<script>` y typecheck
+   - Then `<script>` sin cambios funcionales y `index.vue` con 0 errores TS (baseline 0).
+
+## Metadata
+- **Complexity**: Medium
+- **Estimated Effort**: M
+- **Files to Modify**: `app/pages/blog/index.vue`, `app/pages/blog/__tests__/index.test.ts` (NEW)
+- **Files to Read**: design spec, `app/assets/css/theme.css`, `tests/f0-chrome.test.ts` (patrón de test)
+- **Step**: 01 of 02
+- **Scenario-Strategy**: required

--- a/docs/specs/2026-06-12-issue-112-f4-blog/implementation/step02/task-02-reskin-blog-detail.code-task.md
+++ b/docs/specs/2026-06-12-issue-112-f4-blog/implementation/step02/task-02-reskin-blog-detail.code-task.md
@@ -1,0 +1,68 @@
+## Status: PENDING
+## Blocked-By: step01/task-01-reskin-blog-index.code-task.md
+## Completed:
+
+# Task: Reskin `blog/[...slug].vue` (detalle) + `blog.css` a marca + guard
+
+## Description
+Reskin de la página de detalle del post + el CSS de callouts a la marca alquilame. Reusa el patrón de card de marca de step01 en "relacionados". Preserva data contract, JSON-LD (BlogPosting + BreadcrumbList), article meta, TOC, reading-progress, render MDC, textos y href.
+
+## Background
+Ver step01. El detalle (`[...slug].vue`, 670 L) tiene un `<style>` global (`:526-670`) dueño del prose MDC con acentos red-700 `rgb(185,28,28)`, y `blog.css` (34 L) dueño de callouts (`div.bg-muted`, `article.prose > div.group`). Selectores DISJUNTOS — confirmado. Share buttons: 4×2 ubicaciones (sidebar `:109-134` + barra móvil `:242-269`), colores de plataforma se CONSERVAN (verde/azul/negro), solo copy gris rebrandea.
+
+## Reference Documentation
+**Required:**
+- Design: `docs/specs/2026-06-12-issue-112-f4-blog-design.md` (decisiones 1-5, holdout SCEN-F4)
+- Plan: `docs/specs/2026-06-12-issue-112-f4-blog/implementation/plan.md`
+- Patrón de card: `app/pages/blog/index.vue` ya reskineado en step01 (reusar clases exactas en relacionados)
+
+## Technical Requirements
+1. **Hero overlay (`:19`)**: `bg-gradient-to-t from-gray-900/80` → `bg-linear-to-t from-gray-900/80` (overlay sobre imagen, debe seguir visible). Título sobre imagen: `font-heading` + blanco (si usa `.heading-*`, con `[--ctx-text-primary:#fff]`). Meta autor/fecha/tiempo INTACTA.
+2. **Reading progress bar**: si usa `bg-red-700` → `bg-brand-600`.
+3. **Sidebar**: 3 paneles `bg-gray-50` (`:65/:90/:104`) → `bg-surface-softer`. TOC + tags brand (hover/acentos `red-*`→`brand-*`; pills `bg-gray-200`→`bg-surface-soft`). **Share**: WhatsApp `bg-green-500`, FB `bg-blue-600`, X `bg-black` se CONSERVAN; copy `bg-gray-600 hover:bg-gray-700` (`:130` y `:265`) → token brand (`bg-brand-600 hover:bg-brand-700`). **CTA sidebar (`:138-148`)**: caja `bg-red-700` → `bg-brand-600`; texto `text-red-100`→`text-brand-100`; botón `text-red-700`→`text-brand-700`; **`to="/"` (`:143`) → `to="/reservas"`**.
+4. **Bio autor (`:155-193`)**: card `bg-gray-50` (`:158`) → `bg-surface-softer`; botón CTA `bg-red-700 hover:bg-red-800` → `bg-brand-600 hover:bg-brand-700`; **`to="/"` (`:175`) → `to="/reservas"`**; link "Más artículos" hover `text-red-700`→`text-brand-700`; `to="/blog"` INTACTO.
+5. **Relacionados (`:195-223`)**: ground `bg-gray-100`→`bg-surface-soft`; cards **reusan el patrón brand de step01** (título `font-heading`, hover `text-brand-700`).
+6. **Back button (`:225-236`)**: `bg-gray-200 hover:bg-gray-300 text-black` → `bg-surface-soft` + texto/acento brand; `to="/blog"` INTACTO.
+7. **404 (`:274-286`)**: ground `bg-gray-100`→`bg-surface-soft`; botón `bg-red-700 hover:bg-red-800`→`bg-brand-600 hover:bg-brand-700`; `to="/blog"` INTACTO.
+8. **`<style>` prose (`:526-670`)**: acentos red-700 → brand #CC022B — `.prose a` `rgb(185,28,28)`→`#cc022b`, `.prose a:hover` `rgb(153,27,27)`→`#94001e`, `.prose blockquote` border `rgb(185,28,28)`→`#cc022b`, `.prose code` color `rgb(185,28,28)`→`#cc022b`. Headings/texto neutro se mantienen (legibilidad).
+9. **`blog.css`**: acentos de callout a brand donde aplique; mantener legibilidad (bg claro, texto oscuro). Selectores siguen disjuntos del `<style>`.
+10. **NO tocar**: `<script setup>` (SEO `useSeoMeta`/`useSchemaOrg` BlogPosting+BreadcrumbList, article meta, `copyLink`/share fns, TOC/reading-progress logic, fetch), textos visibles, href de navegación.
+
+## Implementation Approach
+1. Editar `<template>` + `<style>` de `[...slug].vue` con los mapeos; no tocar `<script>`.
+2. Editar `blog.css` acentos.
+3. Crear `app/pages/blog/__tests__/slug.test.ts` — source-text asserts (leer `[...slug].vue` + `blog.css` como string).
+
+## Acceptance Criteria
+1. **Overlay Tailwind 4 + prose brand (SCEN-F4-05/06/14)**
+   - Given el source de `[...slug].vue`
+   - When se busca `bg-gradient-to-` y los acentos prose
+   - Then no hay `bg-gradient-to-` (sí `bg-linear-to-t`), y `.prose a`/`blockquote`/`code` usan `#cc022b` (no `rgb(185, 28, 28)`).
+2. **Share platform preservado + copy debrandado (SCEN-F4-08)**
+   - Given el source
+   - When se inspeccionan los share buttons
+   - Then `bg-green-500`, `bg-blue-600`, `bg-black` siguen presentes (ambas ubicaciones) y el botón copy usa `bg-brand-*` (no `bg-gray-600`).
+3. **CTAs centralizados + anti-reward-hack (SCEN-F4-07)**
+   - Given el source
+   - When se buscan los CTAs de reserva (sidebar + bio)
+   - Then ambos `to="/reservas"` y NO queda ningún `to="/"` de reserva. (`to="/blog"` permitido.)
+4. **Chrome rebrandeado (SCEN-F4-14)**
+   - Given el source
+   - When se inspeccionan back button, 404 y bio card
+   - Then no usan `bg-gray-200 text-black` ni `bg-gray-50` crudos (usan tokens surface/brand).
+5. **SEO preservado (SCEN-F4-11)**
+   - Given el `<script setup>`
+   - When se compara con baseline
+   - Then `defineBlogPosting`/`BlogPosting`, `defineBreadcrumb` y todos los `articleXxx`/`og`/`twitter` meta intactos.
+6. **Guard verde + typecheck**
+   - Given `vitest run app/pages/blog/__tests__/slug.test.ts` y typecheck
+   - When corren
+   - Then guard pasa y `[...slug].vue` con 0 errores TS (baseline 0).
+
+## Metadata
+- **Complexity**: Medium
+- **Estimated Effort**: M
+- **Files to Modify**: `app/pages/blog/[...slug].vue`, `app/assets/css/rentacar-main/blog.css`, `app/pages/blog/__tests__/slug.test.ts` (NEW)
+- **Files to Read**: design spec, `app/pages/blog/index.vue` (step01, patrón card), `app/assets/css/theme.css`
+- **Step**: 02 of 02
+- **Scenario-Strategy**: required

--- a/packages/ui-alquilame/app/assets/css/rentacar-main/blog.css
+++ b/packages/ui-alquilame/app/assets/css/rentacar-main/blog.css
@@ -1,7 +1,10 @@
-/* Blog callout styling - sobrescribir tema oscuro en área de contenido */
+/* Blog callout styling - sobrescribir tema oscuro en área de contenido.
+   Callouts legibles: fondo claro + texto oscuro; acento de marca alquilame
+   (#cc022b) en el borde izquierdo para alinear con el prose del detalle. */
 .prose div.bg-muted {
   background-color: rgb(243, 244, 246) !important;
   border-color: rgb(209, 213, 219) !important;
+  border-left: 4px solid #cc022b !important;
 }
 
 .prose div.bg-muted,
@@ -21,6 +24,7 @@
 article.prose > div.group {
   background-color: rgb(243, 244, 246) !important;
   border-color: rgb(209, 213, 219) !important;
+  border-left: 4px solid #cc022b !important;
   color: rgb(55, 65, 81) !important;
 }
 

--- a/packages/ui-alquilame/app/pages/blog/[...slug].vue
+++ b/packages/ui-alquilame/app/pages/blog/[...slug].vue
@@ -1,9 +1,9 @@
 <template>
   <UPage v-if="post">
     <!-- Reading Progress Bar -->
-    <div class="fixed top-0 left-0 right-0 h-1 bg-gray-200 z-50">
+    <div class="fixed top-0 left-0 right-0 h-1 bg-surface-soft z-50">
       <div
-        class="h-full bg-red-700 transition-all duration-150 ease-out"
+        class="h-full bg-brand-600 transition-all duration-150 ease-out"
         :style="{ width: `${readingProgress}%` }"
       />
     </div>
@@ -16,14 +16,14 @@
         class="w-full h-full object-cover"
         fetchpriority="high"
       >
-      <div class="absolute inset-0 bg-gradient-to-t from-gray-900/80 to-transparent" />
+      <div class="absolute inset-0 bg-linear-to-t from-gray-900/80 to-transparent" />
       <div class="absolute bottom-0 left-0 right-0 p-6 md:p-12">
         <div class="max-w-4xl mx-auto">
-          <span class="inline-flex items-center gap-1.5 px-3 py-1 text-xs font-semibold text-white bg-red-700 rounded-full mb-4">
+          <span class="inline-flex items-center gap-1.5 px-3 py-1 text-xs font-semibold text-white bg-brand-600 rounded-full mb-4">
             <UIcon :name="getCategoryIcon(post.category)" class="size-3.5" />
             {{ formatCategory(post.category) }}
           </span>
-          <h1 class="text-2xl md:text-4xl font-bold text-white mb-4">
+          <h1 class="text-2xl md:text-4xl font-bold font-heading text-white mb-4">
             {{ post.title }}
           </h1>
           <div class="flex flex-wrap items-center gap-4 text-sm text-gray-300">
@@ -62,13 +62,13 @@
           <aside class="lg:w-1/3">
             <div class="sticky top-24 space-y-8">
               <!-- Table of Contents -->
-              <nav v-if="post.body?.toc?.links?.length" class="bg-gray-50 rounded-xl p-6">
+              <nav v-if="post.body?.toc?.links?.length" class="bg-surface-softer rounded-xl p-6">
                 <h3 class="font-bold text-gray-900 mb-4">Contenido</h3>
                 <ul class="space-y-2">
                   <li v-for="link in post.body.toc.links" :key="link.id">
                     <a
                       :href="`#${link.id}`"
-                      class="text-sm text-gray-600 hover:text-red-700 underline underline-offset-2 transition-colors"
+                      class="text-sm text-gray-600 hover:text-brand-700 underline underline-offset-2 transition-colors"
                     >
                       {{ link.text }}
                     </a>
@@ -76,7 +76,7 @@
                       <li v-for="child in link.children" :key="child.id">
                         <a
                           :href="`#${child.id}`"
-                          class="text-xs text-gray-500 hover:text-red-700 underline underline-offset-2 transition-colors"
+                          class="text-xs text-gray-500 hover:text-brand-700 underline underline-offset-2 transition-colors"
                         >
                           {{ child.text }}
                         </a>
@@ -87,13 +87,13 @@
               </nav>
 
               <!-- Tags -->
-              <div v-if="post.tags?.length" class="bg-gray-50 rounded-xl p-6">
+              <div v-if="post.tags?.length" class="bg-surface-softer rounded-xl p-6">
                 <h3 class="font-bold text-gray-900 mb-4">Etiquetas</h3>
                 <div class="flex flex-wrap gap-2">
                   <span
                     v-for="tag in post.tags"
                     :key="tag"
-                    class="px-3 py-1 text-xs bg-gray-200 text-gray-700 rounded-full"
+                    class="px-3 py-1 text-xs bg-surface-soft text-gray-700 rounded-full"
                   >
                     {{ tag }}
                   </span>
@@ -101,7 +101,7 @@
               </div>
 
               <!-- Share Buttons (Desktop) -->
-              <div class="hidden lg:block bg-gray-50 rounded-xl p-6">
+              <div class="hidden lg:block bg-surface-softer rounded-xl p-6">
                 <h3 class="font-bold text-gray-900 mb-4">Compartir</h3>
                 <div class="flex gap-3">
                   <button
@@ -127,7 +127,7 @@
                   </button>
                   <button
                     @click="copyLink"
-                    class="flex items-center justify-center w-10 h-10 bg-gray-600 hover:bg-gray-700 text-white rounded-full transition-colors"
+                    class="flex items-center justify-center w-10 h-10 bg-brand-600 hover:bg-brand-700 text-white rounded-full transition-colors"
                     aria-label="Copiar enlace"
                   >
                     <UIcon :name="linkCopied ? 'i-lucide-check' : 'i-lucide-link'" class="size-5" />
@@ -136,12 +136,12 @@
               </div>
 
               <!-- CTA -->
-              <div class="bg-red-700 rounded-xl p-6 text-white">
+              <div class="bg-brand-600 rounded-xl p-6 text-white">
                 <h3 class="font-bold mb-2">¿Listo para reservar?</h3>
-                <p class="text-sm text-red-100 mb-4">Sin anticipos, sin compromisos</p>
+                <p class="text-sm text-brand-100 mb-4">Sin anticipos, sin compromisos</p>
                 <NuxtLink
-                  to="/"
-                  class="block text-center bg-white text-red-700 px-4 py-2 rounded-lg font-bold hover:bg-gray-100 transition-colors"
+                  to="/reservas"
+                  class="block text-center bg-white text-brand-700 px-4 py-2 rounded-lg font-bold hover:bg-brand-100 transition-colors"
                 >
                   Reservar Ahora
                 </NuxtLink>
@@ -155,7 +155,7 @@
     <!-- Author Bio -->
     <section class="bg-white py-8 px-4 md:px-8 border-t border-gray-200">
       <div class="max-w-4xl mx-auto">
-        <div class="bg-gray-50 rounded-2xl p-6 md:p-8">
+        <div class="bg-surface-softer rounded-2xl p-6 md:p-8">
           <div class="flex flex-col sm:flex-row items-center sm:items-start gap-6">
             <img
               :src="post.author.avatar"
@@ -172,15 +172,15 @@
               </p>
               <div class="mt-4 flex flex-col sm:flex-row items-center gap-3">
                 <NuxtLink
-                  to="/"
-                  class="inline-flex items-center gap-2 bg-red-700 hover:bg-red-800 text-white px-5 py-2.5 rounded-lg font-medium transition-colors"
+                  to="/reservas"
+                  class="inline-flex items-center gap-2 bg-brand-600 hover:bg-brand-700 text-white px-5 py-2.5 rounded-lg font-medium transition-colors"
                 >
                   <UIcon name="i-lucide-car" class="size-4" />
                   Reservar un Carro
                 </NuxtLink>
                 <NuxtLink
                   to="/blog"
-                  class="inline-flex items-center gap-2 text-gray-600 hover:text-red-700 font-medium transition-colors"
+                  class="inline-flex items-center gap-2 text-gray-600 hover:text-brand-700 font-medium transition-colors"
                 >
                   <UIcon name="i-lucide-book-open" class="size-4" />
                   Más artículos
@@ -193,7 +193,7 @@
     </section>
 
     <!-- Related Posts -->
-    <section v-if="relatedPosts?.length" class="bg-gray-100 py-12 px-4 md:px-8">
+    <section v-if="relatedPosts?.length" class="bg-surface-soft py-12 px-4 md:px-8">
       <div class="max-w-7xl mx-auto">
         <h2 class="text-xl font-bold text-gray-800 mb-6">Artículos Relacionados</h2>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
@@ -211,7 +211,7 @@
                 loading="lazy"
               >
               <div class="p-4">
-                <h3 class="font-bold text-gray-900 group-hover:text-red-700 transition-colors line-clamp-2">
+                <h3 class="font-bold font-heading text-gray-900 group-hover:text-brand-700 transition-colors line-clamp-2">
                   {{ related.title }}
                 </h3>
                 <p class="text-sm text-gray-500 mt-2">{{ related.readingTime }} min de lectura</p>
@@ -227,7 +227,7 @@
       <div class="max-w-4xl mx-auto text-center">
         <NuxtLink
           to="/blog"
-          class="inline-flex items-center gap-2 px-6 py-3 bg-gray-200 hover:bg-gray-300 text-black font-medium rounded-lg transition-colors"
+          class="inline-flex items-center gap-2 px-6 py-3 bg-surface-soft hover:bg-surface-softer text-brand-700 font-medium rounded-lg transition-colors"
         >
           <span>&larr;</span>
           <span>Volver al Blog</span>
@@ -262,7 +262,7 @@
         </button>
         <button
           @click="copyLink"
-          class="flex items-center justify-center w-9 h-9 bg-gray-600 hover:bg-gray-700 text-white rounded-full transition-colors"
+          class="flex items-center justify-center w-9 h-9 bg-brand-600 hover:bg-brand-700 text-white rounded-full transition-colors"
           aria-label="Copiar enlace"
         >
           <UIcon :name="linkCopied ? 'i-lucide-check' : 'i-lucide-link'" class="size-4" />
@@ -272,13 +272,13 @@
   </UPage>
 
   <!-- 404 -->
-  <div v-else class="min-h-screen flex items-center justify-center bg-gray-100">
+  <div v-else class="min-h-screen flex items-center justify-center bg-surface-soft">
     <div class="text-center">
-      <h1 class="text-4xl font-bold text-gray-900 mb-4">Artículo no encontrado</h1>
+      <h1 class="text-4xl font-bold font-heading text-gray-900 mb-4">Artículo no encontrado</h1>
       <p class="text-gray-600 mb-6">El artículo que buscas no existe o ha sido movido.</p>
       <NuxtLink
         to="/blog"
-        class="inline-block bg-red-700 text-white px-6 py-3 rounded-lg font-bold hover:bg-red-800 transition-colors"
+        class="inline-block bg-brand-600 text-white px-6 py-3 rounded-lg font-bold hover:bg-brand-700 transition-colors"
       >
         Ir al Blog
       </NuxtLink>
@@ -580,12 +580,12 @@ definePageMeta({
 }
 
 .prose a {
-  color: rgb(185, 28, 28);
+  color: #cc022b;
   text-decoration: underline;
 }
 
 .prose a:hover {
-  color: rgb(153, 27, 27);
+  color: #94001e;
 }
 
 .prose strong {
@@ -596,7 +596,7 @@ definePageMeta({
 .prose blockquote {
   border-left-width: 4px;
   border-left-style: solid;
-  border-color: rgb(185, 28, 28);
+  border-color: #cc022b;
   padding-left: 1rem;
   font-style: italic;
   color: rgb(75, 85, 99);
@@ -606,7 +606,7 @@ definePageMeta({
 
 .prose code {
   background-color: rgb(243, 244, 246);
-  color: rgb(185, 28, 28);
+  color: #cc022b;
   padding: 0.25rem 0.5rem;
   border-radius: 0.25rem;
   font-size: 0.875rem;

--- a/packages/ui-alquilame/app/pages/blog/__tests__/index.test.ts
+++ b/packages/ui-alquilame/app/pages/blog/__tests__/index.test.ts
@@ -1,0 +1,82 @@
+/**
+ * F4 step01 — blog listado reskin a marca alquilame (issue #112).
+ *
+ * Source-text brand guard (mismo patrón que tests/f0-chrome.test.ts:
+ * readFileSync + regex, sin montar el componente). Encoda el holdout SCEN-F4:
+ *   - SCEN-F4-01: hero h1 con font-heading + text-white, acento brand (no red-500).
+ *   - SCEN-F4-02: cero bg-gradient-to-* (v3); badges/hover/filtro-activo en brand-*.
+ *   - SCEN-F4-04: único CTA de reserva → /reservas; ningún to="/" residual.
+ *   - CTA footer: panel bg-brand-900 + [--ctx-text-primary:#fff] (heading blanco).
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const SOURCE = readFileSync(
+  join(__dirname, '..', 'index.vue'),
+  'utf-8',
+)
+
+describe('SCEN-F4-01 — hero brand (blog/index.vue)', () => {
+  // The hero <template #title> h1 block: white over the dark layout ground,
+  // brand font, brand-tone accent legible on dark.
+  const heroH1 = SOURCE.slice(
+    SOURCE.indexOf('<h1'),
+    SOURCE.indexOf('</h1>'),
+  )
+
+  it('hero h1 keeps text-white and adds font-heading', () => {
+    expect(heroH1).toMatch(/class="[^"]*\btext-white\b/)
+    expect(heroH1).toMatch(/class="[^"]*\bfont-heading\b/)
+  })
+
+  it('hero accent uses a brand tone, not the legacy text-red-500', () => {
+    expect(heroH1).toMatch(/text-brand-\d/)
+    expect(heroH1).not.toMatch(/text-red-500/)
+  })
+})
+
+describe('SCEN-F4-02 — sin gradiente v3 + cards/filtros brand', () => {
+  it('source has zero v3 bg-gradient-to-* (Tailwind 4 → bg-linear-to-*)', () => {
+    expect(SOURCE).not.toMatch(/bg-gradient-to-/)
+  })
+
+  it('active category filter fills with bg-brand-600, not bg-red-700', () => {
+    expect(SOURCE).toMatch(/bg-brand-600 text-white/)
+    expect(SOURCE).not.toMatch(/bg-red-700/)
+  })
+
+  it('badges and hovers use brand-* tokens, no raw red-* chrome left', () => {
+    expect(SOURCE).toMatch(/text-brand-700 bg-brand-100/)
+    expect(SOURCE).toMatch(/group-hover:text-brand-700/)
+    expect(SOURCE).not.toMatch(/text-red-700/)
+    expect(SOURCE).not.toMatch(/bg-red-100/)
+  })
+})
+
+describe('SCEN-F4-04 — CTA de reserva centralizado en /reservas', () => {
+  it('the only reserve CTA points to /reservas', () => {
+    expect(SOURCE).toMatch(/to="\/reservas"/)
+  })
+
+  it('no bare to="/" reserve target remains (anti-reward-hack)', () => {
+    expect(SOURCE).not.toMatch(/to="\/"/)
+  })
+})
+
+describe('CTA footer panel brand', () => {
+  // The dark CTA panel rebrands gray-900 → brand-900; the panel sets text-white
+  // which the heading inherits (the h2 uses font-heading, not .heading-*, so no
+  // --ctx-text-primary token is needed — text-white is what keeps it legible).
+  const ctaPanel = SOURCE.slice(SOURCE.indexOf('<!-- CTA Section -->'))
+
+  it('footer CTA panel uses bg-brand-900 with white text, no raw gray-900', () => {
+    expect(ctaPanel).toMatch(/bg-brand-900 text-white/)
+    expect(ctaPanel).not.toMatch(/bg-gray-900/)
+  })
+
+  it('footer CTA button fills brand-600 → brand-700 on hover, no red-*', () => {
+    expect(ctaPanel).toMatch(/bg-brand-600 hover:bg-brand-700/)
+    expect(ctaPanel).not.toMatch(/red-[0-9]/)
+  })
+})

--- a/packages/ui-alquilame/app/pages/blog/__tests__/slug.test.ts
+++ b/packages/ui-alquilame/app/pages/blog/__tests__/slug.test.ts
@@ -1,0 +1,130 @@
+/**
+ * F4 step02 — blog detail (`[...slug].vue`) + callouts (`blog.css`) brand guard.
+ *
+ * Encodes the observable F4 detail scenarios as static-source assertions
+ * (full runtime/visual check deferred to the orchestrator's preview pass):
+ *   - SCEN-F4-05/06/14: hero overlay uses the Tailwind 4 `bg-linear-to-t`
+ *     (never the v3 `bg-gradient-to-*` that renders transparent), and the prose
+ *     MDC accents (link / blockquote / code) are brand #cc022b, not red-700.
+ *   - SCEN-F4-08: share buttons keep their PLATFORM colors (WhatsApp green,
+ *     Facebook blue, X black) in BOTH locations; only the copy-link button
+ *     debrands from gray to a brand token.
+ *   - SCEN-F4-07: BOTH reserve CTAs (sidebar + bio) point to /reservas and NO
+ *     bare `to="/"` reserve target survives (anti-reward-hack); /blog nav stays.
+ *   - SCEN-F4-14: chrome (back button, 404, bio card, sidebar panels) uses
+ *     surface/brand tokens, never `bg-gray-200 text-black` / raw `bg-gray-50`.
+ *   - SCEN-F4-11: the <script setup> SEO/schema (BlogPosting, BreadcrumbList,
+ *     article meta) is preserved untouched.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const PAGES = join(__dirname, '..')
+const ROOT = join(__dirname, '..', '..', '..', '..')
+
+const slug = readFileSync(join(PAGES, '[...slug].vue'), 'utf-8')
+const blogCss = readFileSync(
+  join(ROOT, 'app/assets/css/rentacar-main/blog.css'),
+  'utf-8',
+)
+
+// The script block carries SEO/schema/behavior; it must survive the reskin.
+const scriptBlock = slug.slice(slug.indexOf('<script setup'))
+
+describe('SCEN-F4-05/06/14 — overlay v4 + prose brand accents', () => {
+  it('hero overlay uses bg-linear-to-t, never the broken bg-gradient-to-*', () => {
+    expect(slug).toMatch(/bg-linear-to-t/)
+    expect(slug).not.toMatch(/bg-gradient-to-/)
+  })
+
+  it('.prose a / a:hover use brand #cc022b/#94001e, not red-700 rgb(185, 28, 28)', () => {
+    expect(slug).not.toMatch(/rgb\(185, 28, 28\)/)
+    expect(slug).toMatch(/\.prose a\s*{[^}]*color:\s*#cc022b/)
+    expect(slug).toMatch(/\.prose a:hover\s*{[^}]*color:\s*#94001e/)
+  })
+
+  it('.prose blockquote / code accents use brand #cc022b', () => {
+    expect(slug).toMatch(/\.prose blockquote\s*{[\s\S]*?border-color:\s*#cc022b/)
+    expect(slug).toMatch(/\.prose code\s*{[\s\S]*?color:\s*#cc022b/)
+  })
+
+  it('blog.css callouts use the brand #cc022b accent, no red-700', () => {
+    expect(blogCss).not.toMatch(/rgb\(185, 28, 28\)/)
+    expect(blogCss).toMatch(/#cc022b/)
+  })
+})
+
+describe('SCEN-F4-08 — share platform colors preserved, copy debranded', () => {
+  it('keeps WhatsApp green / Facebook blue / X black in BOTH locations', () => {
+    expect((slug.match(/bg-green-500/g) ?? []).length).toBeGreaterThanOrEqual(2)
+    expect((slug.match(/bg-blue-600/g) ?? []).length).toBeGreaterThanOrEqual(2)
+    expect((slug.match(/bg-black/g) ?? []).length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('copy-link button debrands to a brand token, never bg-gray-600', () => {
+    expect(slug).not.toMatch(/bg-gray-600/)
+    // Both copy buttons (desktop sidebar + mobile bar) carry the brand fill.
+    const copyButtons = (slug.match(/@click="copyLink"[\s\S]*?aria-label="Copiar enlace"/g) ?? [])
+    expect(copyButtons.length).toBe(2)
+    for (const btn of copyButtons) {
+      expect(btn).toMatch(/bg-brand-600 hover:bg-brand-700/)
+    }
+  })
+})
+
+describe('SCEN-F4-07 — reserve CTAs centralized, anti-reward-hack', () => {
+  it('both reserve CTAs point to /reservas', () => {
+    expect((slug.match(/to="\/reservas"/g) ?? []).length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('no bare to="/" reserve target survives', () => {
+    expect(slug).not.toMatch(/to="\/"/)
+  })
+
+  it('keeps /blog navigation links intact', () => {
+    expect(slug).toMatch(/to="\/blog"/)
+  })
+})
+
+describe('SCEN-F4-14 — chrome rebranded to surface/brand tokens', () => {
+  it('back button is surface-soft + brand accent, not bg-gray-200 text-black', () => {
+    expect(slug).not.toMatch(/bg-gray-200/)
+    expect(slug).not.toMatch(/text-black/)
+  })
+
+  it('bio card + sidebar panels use bg-surface-softer, not raw bg-gray-50', () => {
+    expect(slug).not.toMatch(/bg-gray-50\b/)
+    expect((slug.match(/bg-surface-softer/g) ?? []).length).toBeGreaterThanOrEqual(4)
+  })
+
+  it('section grounds + 404 use surface tokens, not raw bg-gray-100', () => {
+    expect(slug).not.toMatch(/bg-gray-100/)
+    expect(slug).toMatch(/bg-surface-soft\b/)
+  })
+})
+
+describe('SCEN-F4-11 — SEO / schema preserved in <script setup>', () => {
+  it('keeps the BlogPosting + BreadcrumbList JSON-LD', () => {
+    expect(scriptBlock).toMatch(/useSchemaOrg/)
+    expect(scriptBlock).toMatch(/BlogPosting/)
+    expect(scriptBlock).toMatch(/BreadcrumbList/)
+  })
+
+  it('keeps all article meta keys intact', () => {
+    expect(scriptBlock).toMatch(/useSeoMeta/)
+    for (const key of [
+      'articlePublishedTime',
+      'articleModifiedTime',
+      'articleAuthor',
+      'articleSection',
+      'articleTag',
+    ]) {
+      expect(scriptBlock).toContain(key)
+    }
+  })
+
+  it('keeps the copyLink + share behavior', () => {
+    expect(scriptBlock).toMatch(/function copyLink/)
+  })
+})

--- a/packages/ui-alquilame/app/pages/blog/index.vue
+++ b/packages/ui-alquilame/app/pages/blog/index.vue
@@ -3,8 +3,8 @@
     <!-- Hero Section -->
     <UPageHero orientation="vertical">
       <template #title>
-        <h1 class="text-white text-3xl md:text-4xl text-center font-bold">
-          Blog de <span class="text-red-500">{{ franchise.shortname }}</span>
+        <h1 class="text-white text-3xl md:text-4xl text-center font-bold font-heading">
+          Blog de <span class="text-brand-300">{{ franchise.shortname }}</span>
         </h1>
       </template>
       <template #description>
@@ -16,7 +16,7 @@
     </UPageHero>
 
     <!-- Blog Posts Grid -->
-    <section class="bg-gray-100 py-12 md:py-16 px-4 md:px-8">
+    <section class="bg-surface-soft py-12 md:py-16 px-4 md:px-8">
       <div class="max-w-7xl mx-auto">
         <!-- Featured Post -->
         <div v-if="featuredPost" class="mb-12">
@@ -35,11 +35,11 @@
                 >
               </div>
               <div class="p-6 md:w-1/2 flex flex-col justify-center">
-                <span class="inline-flex items-center gap-1.5 px-3 py-1 text-xs font-semibold text-red-700 bg-red-100 rounded-full w-fit mb-3">
+                <span class="inline-flex items-center gap-1.5 px-3 py-1 text-xs font-semibold text-brand-700 bg-brand-100 rounded-full w-fit mb-3">
                   <UIcon :name="getCategoryIcon(featuredPost.category)" class="size-3.5" />
                   {{ formatCategory(featuredPost.category) }}
                 </span>
-                <h3 class="text-xl md:text-2xl font-bold text-gray-900 group-hover:text-red-700 transition-colors">
+                <h3 class="text-xl md:text-2xl font-bold font-heading text-gray-900 group-hover:text-brand-700 transition-colors">
                   {{ featuredPost.title }}
                 </h3>
                 <p class="text-gray-600 mt-3 line-clamp-3">
@@ -71,7 +71,7 @@
               :class="[
                 'inline-flex items-center gap-1.5 px-4 py-2 rounded-full text-sm font-medium transition-all',
                 selectedCategory === cat.value
-                  ? 'bg-red-700 text-white'
+                  ? 'bg-brand-600 text-white'
                   : 'bg-white text-gray-700 hover:bg-gray-100 border border-gray-200'
               ]"
             >
@@ -97,13 +97,13 @@
                   class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
                   loading="lazy"
                 >
-                <span class="absolute top-3 left-3 inline-flex items-center gap-1.5 px-3 py-1 text-xs font-semibold text-white bg-red-700 rounded-full">
+                <span class="absolute top-3 left-3 inline-flex items-center gap-1.5 px-3 py-1 text-xs font-semibold text-white bg-brand-600 rounded-full">
                   <UIcon :name="getCategoryIcon(post.category)" class="size-3.5" />
                   {{ formatCategory(post.category) }}
                 </span>
               </div>
               <div class="p-5 flex flex-col flex-grow">
-                <h3 class="text-lg font-bold text-gray-900 group-hover:text-red-700 transition-colors line-clamp-2">
+                <h3 class="text-lg font-bold font-heading text-gray-900 group-hover:text-brand-700 transition-colors line-clamp-2">
                   {{ post.title }}
                 </h3>
                 <p class="text-gray-600 mt-2 text-sm line-clamp-2 flex-grow">
@@ -134,7 +134,7 @@
           <button
             v-if="selectedCategory"
             @click="setCategory('')"
-            class="mt-4 text-red-700 hover:text-red-800 font-medium"
+            class="mt-4 text-brand-700 hover:text-brand-800 font-medium"
           >
             Ver todos los artículos
           </button>
@@ -143,17 +143,17 @@
     </section>
 
     <!-- CTA Section -->
-    <section class="bg-gray-900 text-white py-12 px-4">
+    <section class="bg-brand-900 text-white py-12 px-4">
       <div class="max-w-4xl mx-auto text-center">
-        <h2 class="text-2xl md:text-3xl font-bold mb-4">
+        <h2 class="text-2xl md:text-3xl font-bold font-heading mb-4">
           ¿Listo para tu próxima aventura?
         </h2>
         <p class="text-gray-300 mb-6">
           Reserva tu carro sin anticipos en cualquiera de nuestras 27 sedes
         </p>
         <NuxtLink
-          to="/"
-          class="inline-block bg-red-700 hover:bg-red-800 text-white px-8 py-3 rounded-xl font-bold uppercase transition-colors"
+          to="/reservas"
+          class="inline-block bg-brand-600 hover:bg-brand-700 text-white px-8 py-3 rounded-xl font-bold uppercase transition-colors"
         >
           Reservar Ahora
         </NuxtLink>


### PR DESCRIPTION
## F4 — Reskin del blog a la marca alquilame (fase final de #112)

Última fase del reskin de marca alquilame (cadena F0 fundación → F1 home → F2 city+legales → F3 funcional/reservas → **F4 blog**). Lleva las 2 páginas del blog del estilo genérico (grises + `red-*` default + Facebook azul + gradiente v3) a los tokens de marca (rojo #CC022B, Plus Jakarta Sans / DM Sans). **Solo presentación** — `<script setup>` byte-idéntico en ambas páginas.

Closes #112

### Alcance (aislado a `packages/ui-alquilame`)
- `app/pages/blog/index.vue` — listado: hero contenido brand, featured/grid cards, filtros, CTA footer.
- `app/pages/blog/[...slug].vue` — detalle: hero overlay, meta, prose MDC, sidebar (TOC/tags/share/CTA), bio, relacionados, back, 404 + `<style>` prose.
- `app/assets/css/rentacar-main/blog.css` — callouts/admonitions del MDC.
- `app/pages/blog/__tests__/{index,slug}.test.ts` (NEW) — guards de marca (source-text, 24 asserts).

### Decisiones de diseño (aprobadas)
1. **3 CTAs de reserva → `/reservas`** (footer, sidebar, bio — todos apuntaban a `to="/"`), consistente con la centralización de F3. Cero `to="/"` de reserva residual.
2. **Hero del index oscuro restyleado**: el ground lo aporta el layout (`from-brand-900 to-brand-950`, fuera de scope); solo se restylea el contenido (h1 `text-white` + `font-heading`, acento brand-300).
3. **Share buttons con colores de plataforma** (WhatsApp verde / Facebook azul / X negro — convención UX); solo el botón gris "copiar enlace" pasa a token de marca.
4. **Chrome a tokens surface** (`gray-50/100/200/900` → `surface-soft/softer` + `brand-900`); el TEXTO neutro gris se conserva (legibilidad ≠ chrome de marca).

### Preservado (cero regresión)
`<script setup>` intacto → data contract, `BlogPosting` + `BreadcrumbList` JSON-LD, article/og/twitter meta, TOC, reading-progress, render MDC, ISR. Selectores E2E (text/href, sin testids) sin tocar.

### Verificación (evidencia fresca)
- **Typecheck** delta **0** (184/184 ui-alquilame, **0** en páginas blog) · **Unit 310/310** (incl. 24 guards) · aislamiento solo `ui-alquilame` + docs.
- **Runtime** (preview Vercel, agent-browser) — 14/14 SCEN-F4: hero blanco Plus Jakarta legible · overlay `bg-linear-to-t` renderiza (`linear-gradient(to top, oklab…)`) · prose links `rgb(204,2,43)`=#CC022B · 3 CTAs `/reservas` · share plataforma + copy debrandado · bio/back/404 a surface tokens · `BlogPosting`+`BreadcrumbList` presentes.
- **E2E** `blog.spec.ts` (BRAND=alquilame vs preview): **18 passed, 0 failed**.
- Sin regresión: 0 requests fallidos; hydration de fechas preexistente (preview 64 ≤ main 80); CLS 0.24/0.26 ≈ baseline.

### Notas
- El `bg-gradient-to-` que aparece en /blog renderizado (2×) es CSS generado por `gana.vue` (flujo referido, fuera de #112), preexistente e idéntico en main — no es markup del blog.
- `UPageHero` de Nuxt UI anida un h1 wrapper propio; el h1 visible (slotted) computa blanco correctamente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
