### PR TITLE
fix(unable-card): banner names only the pickup day, not a date range

### DIFF
--- a/packages/logic/src/composables/__tests__/useUnavailabilityContext.test.ts
+++ b/packages/logic/src/composables/__tests__/useUnavailabilityContext.test.ts
@@ -68,45 +68,36 @@ describe('useUnavailabilityContext', () => {
     vi.unstubAllGlobals()
   })
 
-  describe('dateRangeLabel', () => {
-    it('formato compacto cuando pickup y return están en el mismo mes', () => {
+  describe('pickupDateLabel', () => {
+    it('formatea solo el día de recogida: "12 de mayo"', () => {
       const formStore = useStoreReservationForm()
       formStore.fechaRecogida = '2026-05-12'
       formStore.fechaDevolucion = '2026-05-15'
 
-      const { dateRangeLabel } = useUnavailabilityContext()
+      const { pickupDateLabel } = useUnavailabilityContext()
 
-      expect(dateRangeLabel.value).toBe('12-15 mayo')
+      expect(pickupDateLabel.value).toBe('12 de mayo')
     })
 
-    it('mismo día recogida=devolución muestra una sola fecha, no "12-12" (#31)', () => {
+    it('ignora la fecha de devolución (la no disponibilidad solo depende de la recogida)', () => {
       const formStore = useStoreReservationForm()
       formStore.fechaRecogida = '2026-05-12'
-      formStore.fechaDevolucion = '2026-05-12'
+      // Devolución muy posterior y en otro año: no debe afectar el label.
+      formStore.fechaDevolucion = '2027-01-02'
 
-      const { dateRangeLabel } = useUnavailabilityContext()
+      const { pickupDateLabel } = useUnavailabilityContext()
 
-      expect(dateRangeLabel.value).toBe('12 mayo')
+      expect(pickupDateLabel.value).toBe('12 de mayo')
     })
 
-    it('cross-month mismo año usa formato corto separado por " - "', () => {
-      const formStore = useStoreReservationForm()
-      formStore.fechaRecogida = '2026-04-30'
-      formStore.fechaDevolucion = '2026-05-02'
-
-      const { dateRangeLabel } = useUnavailabilityContext()
-
-      expect(dateRangeLabel.value).toBe('30 abr - 2 may')
-    })
-
-    it('cross-year incluye año en ambos lados', () => {
+    it('funciona en cualquier mes (sin año): "30 de diciembre"', () => {
       const formStore = useStoreReservationForm()
       formStore.fechaRecogida = '2026-12-30'
       formStore.fechaDevolucion = '2027-01-02'
 
-      const { dateRangeLabel } = useUnavailabilityContext()
+      const { pickupDateLabel } = useUnavailabilityContext()
 
-      expect(dateRangeLabel.value).toBe('30 dic 2026 - 2 ene 2027')
+      expect(pickupDateLabel.value).toBe('30 de diciembre')
     })
 
     it('retorna string vacío cuando fechaRecogida es null', () => {
@@ -114,9 +105,9 @@ describe('useUnavailabilityContext', () => {
       formStore.fechaRecogida = null
       formStore.fechaDevolucion = '2026-05-15'
 
-      const { dateRangeLabel } = useUnavailabilityContext()
+      const { pickupDateLabel } = useUnavailabilityContext()
 
-      expect(dateRangeLabel.value).toBe('')
+      expect(pickupDateLabel.value).toBe('')
     })
   })
 
@@ -179,7 +170,7 @@ describe('useUnavailabilityContext', () => {
       const { bannerText, isSpecific } = useUnavailabilityContext()
 
       expect(bannerText.value).toBe(
-        'No disponible para el 12-15 mayo en Bogotá Aeropuerto',
+        'No disponible para el 12 de mayo en Bogotá Aeropuerto',
       )
       expect(isSpecific.value).toBe(true)
     })

--- a/packages/logic/src/composables/useUnavailabilityContext.ts
+++ b/packages/logic/src/composables/useUnavailabilityContext.ts
@@ -58,18 +58,6 @@ function formatCity(raw: string): string {
     .join(' ');
 }
 
-// Compact month abbreviations. Built manually because DateFormatter('es-CO',
-// { month: 'short' }) emits "de abr" / "30 de dic de 2026" — the connector "de"
-// is grammatically correct Spanish but visually noisy for a banner label.
-const SHORT_MONTHS_ES = [
-  'ene', 'feb', 'mar', 'abr', 'may', 'jun',
-  'jul', 'ago', 'sep', 'oct', 'nov', 'dic',
-] as const;
-
-function shortMonth(date: DateObject): string {
-  return SHORT_MONTHS_ES[date.month - 1];
-}
-
 function longMonth(date: DateObject): string {
   return new DateFormatter(LOCALE, { month: 'long', timeZone: TIMEZONE })
     .format(date.toDate(TIMEZONE));
@@ -77,9 +65,9 @@ function longMonth(date: DateObject): string {
 
 interface UnavailabilityContext {
   bannerText: ComputedRef<string>;
-  dateRangeLabel: ComputedRef<string>;
+  pickupDateLabel: ComputedRef<string>;
   locationLabel: ComputedRef<string>;
-  // True when both date range and location are populated, i.e. the banner
+  // True when both the pickup day and location are populated, i.e. the banner
   // shows the specific reason rather than the generic fallback. Templates
   // gate the second banner line on this flag so the literal "No disponible
   // para tu búsqueda" never has to be duplicated outside this composable.
@@ -88,29 +76,16 @@ interface UnavailabilityContext {
 
 export default function useUnavailabilityContext(): UnavailabilityContext {
   const formStore = useStoreReservationForm();
-  const { selectedPickupLocation, selectedPickupDate, selectedReturnDate } =
+  const { selectedPickupLocation, selectedPickupDate } =
     storeToRefs(formStore);
 
-  const dateRangeLabel = computed<string>(() => {
+  // Availability is decided by the pickup day alone — the return date never
+  // changes whether a category is bookable — so the banner names only that
+  // day: "13 de junio". (No range, no year: the searcher context supplies it.)
+  const pickupDateLabel = computed<string>(() => {
     const pickup = selectedPickupDate.value;
-    const ret = selectedReturnDate.value;
-    if (!pickup || !ret) return '';
-
-    if (pickup.year !== ret.year) {
-      return `${pickup.day} ${shortMonth(pickup)} ${pickup.year} - ${ret.day} ${shortMonth(ret)} ${ret.year}`;
-    }
-
-    if (pickup.month === ret.month) {
-      if (pickup.day === ret.day) {
-        // Same day (pickup === return): "12 mayo", not the ambiguous "12-12".
-        return `${pickup.day} ${longMonth(pickup)}`;
-      }
-      // Same month: "12-15 mayo"
-      return `${pickup.day}-${ret.day} ${longMonth(pickup)}`;
-    }
-
-    // Different month, same year: "30 abr - 2 may"
-    return `${pickup.day} ${shortMonth(pickup)} - ${ret.day} ${shortMonth(ret)}`;
+    if (!pickup) return '';
+    return `${pickup.day} de ${longMonth(pickup)}`;
   });
 
   const locationLabel = computed<string>(() => {
@@ -134,19 +109,19 @@ export default function useUnavailabilityContext(): UnavailabilityContext {
   });
 
   const isSpecific = computed<boolean>(() =>
-    Boolean(dateRangeLabel.value && locationLabel.value),
+    Boolean(pickupDateLabel.value && locationLabel.value),
   );
 
   const bannerText = computed<string>(() => {
     if (isSpecific.value) {
-      return `No disponible para el ${dateRangeLabel.value} en ${locationLabel.value}`;
+      return `No disponible para el ${pickupDateLabel.value} en ${locationLabel.value}`;
     }
     return 'No disponible para tu búsqueda';
   });
 
   return {
     bannerText,
-    dateRangeLabel,
+    pickupDateLabel,
     locationLabel,
     isSpecific,
   };

--- a/packages/ui-alquilatucarro/app/components/__tests__/UnableCategoryCard.mount.test.ts
+++ b/packages/ui-alquilatucarro/app/components/__tests__/UnableCategoryCard.mount.test.ts
@@ -41,8 +41,8 @@ const ADMIN_PAYLOAD = {
 // beforeEach (alongside useState/useToast) — `vi.unstubAllGlobals` in afterEach
 // would otherwise blow away a top-level stub after the first test.
 const stubbedUnavailabilityContext = () => ({
-  bannerText: ref('No disponible para el 12-15 mayo en Bogotá Aeropuerto'),
-  dateRangeLabel: ref('12-15 mayo'),
+  bannerText: ref('No disponible para el 12 de mayo en Bogotá Aeropuerto'),
+  pickupDateLabel: ref('12 de mayo'),
   locationLabel: ref('Bogotá Aeropuerto'),
   isSpecific: ref(true),
 });
@@ -209,7 +209,7 @@ describe('UnableCategoryCard mount — observable behavior', () => {
     const banner = wrapper.find('.bg-red-50.border-l-4.border-red-500');
     expect(banner.exists()).toBe(true);
     expect(banner.text()).toContain('No disponible');
-    expect(banner.text()).toContain('12-15 mayo');
+    expect(banner.text()).toContain('12 de mayo');
     expect(banner.text()).toContain('Bogotá Aeropuerto');
   });
 


### PR DESCRIPTION
## Cambio

La disponibilidad se decide **solo por el día de recogida** — la fecha de devolución no cambia si una categoría es reservable. El banner mostraba el rango completo ("13-20 junio"), lo que exageraba qué significa la no disponibilidad.

Ahora muestra solo el día de recogida: **"13 de junio"**.

`No disponible para el 13-20 junio en Villavicencio` → `No disponible para el 13 de junio en Villavicencio`

## Detalle técnico

- `dateRangeLabel` → `pickupDateLabel` (un solo día, sin rango ni año).
- Eliminado código muerto: helpers de rango (`shortMonth`, `SHORT_MONTHS_ES`) y `selectedReturnDate` sin uso (habría roto `noUnusedLocals`).
- `isSpecific` ahora se basa en el día de recogida.
- Tests del composable (12/12) y de mount (14/14) actualizados.

**Blast radius:** `useUnavailabilityContext.ts` (+ test) y el mock de `UnableCategoryCard.mount.test.ts`. El componente no cambia (consume `bannerText`).