### PR TITLE
feat(category-card): show 'Único método de pago' with tooltip over the CTA (#124)

### DIFF
--- a/packages/ui-alquicarros/app/assets/css/rentacar-main/category.css
+++ b/packages/ui-alquicarros/app/assets/css/rentacar-main/category.css
@@ -134,7 +134,21 @@
     }
 
     .seccion-boton-seleccion {
-      @apply rounded-b-lg bg-white p-4;
+      @apply rounded-b-lg p-4;
+      /* Fondo gris desvanecido compartido con la sección de precios (issue #124) */
+      background: linear-gradient(to right, white, #ededed 50%, white);
+
+      .metodo-pago {
+        @apply text-center mb-3;
+      }
+
+      .metodo-pago-label {
+        @apply inline-flex items-center justify-center gap-1 text-sm font-semibold text-gray-800;
+      }
+
+      .metodo-pago-valor {
+        @apply block text-xs text-gray-600;
+      }
 
       .boton-seleccion {
         @apply w-full justify-center text-white bg-green-700 py-4 hover:bg-green-800 transition-colors;

--- a/packages/ui-alquicarros/app/components/CategoryCard.vue
+++ b/packages/ui-alquicarros/app/components/CategoryCard.vue
@@ -581,6 +581,37 @@
       </UCollapsible>
 
       <div class="seccion-boton-seleccion">
+        <!-- Único método de pago (issue #124): info sobre el CTA, mismo fondo difuminado -->
+        <div class="metodo-pago">
+          <span class="metodo-pago-label">
+            Único método de pago
+            <UTooltip
+              :open="paymentTooltipOpen"
+              :delay-duration="0"
+              :content="{ onEscapeKeyDown: forcePaymentTooltipClose, onPointerDownOutside: forcePaymentTooltipClose }"
+              :ui="{ content: 'max-w-[240px] h-auto whitespace-normal text-wrap select-text bg-white text-gray-900 shadow-lg border border-gray-200 p-3 text-xs font-normal' }"
+              @update:open="onPaymentTooltipOpenChange"
+            >
+              <template #content>
+                No se acepta efectivo ni tarjeta débito. El pago se realiza únicamente con tarjeta de crédito al recoger el vehículo en la sede.
+              </template>
+              <UButton
+                variant="ghost"
+                color="neutral"
+                size="xs"
+                aria-label="Más información sobre el método de pago"
+                class="cursor-pointer p-0 -my-1"
+                :ui="questionButtonUIConfig"
+              >
+                <template #leading>
+                  <InfoQuestionIcon cls="size-3.5 text-gray-400" />
+                </template>
+              </UButton>
+            </UTooltip>
+          </span>
+          <span class="metodo-pago-valor">Tarjeta de crédito en sede</span>
+        </div>
+
         <UButton
           class="boton-seleccion"
           size="xl"
@@ -686,6 +717,14 @@ const {
   open: totalPriceTooltipOpen,
   onOpenChange: onTotalPriceTooltipOpenChange,
   forceClose: forceTotalPriceTooltipClose,
+} = useDelayedClose(tooltipCloseDelayMs);
+
+// "Único método de pago" tooltip (issue #124): same controlled pattern as the
+// price tooltip so it opens on tap (touch) and focus (keyboard), not hover-only.
+const {
+  open: paymentTooltipOpen,
+  onOpenChange: onPaymentTooltipOpenChange,
+  forceClose: forcePaymentTooltipClose,
 } = useDelayedClose(tooltipCloseDelayMs);
 
 /** Product Schema for SEO */

--- a/packages/ui-alquilame/app/assets/css/rentacar-main/category.css
+++ b/packages/ui-alquilame/app/assets/css/rentacar-main/category.css
@@ -137,7 +137,21 @@
     }
 
     .seccion-boton-seleccion {
-      @apply rounded-b-lg bg-white p-4;
+      @apply rounded-b-lg p-4;
+      /* Fondo gris desvanecido compartido con la sección de precios (issue #124) */
+      background: linear-gradient(to right, white, #ededed 50%, white);
+
+      .metodo-pago {
+        @apply text-center mb-3;
+      }
+
+      .metodo-pago-label {
+        @apply inline-flex items-center justify-center gap-1 text-sm font-semibold text-gray-800;
+      }
+
+      .metodo-pago-valor {
+        @apply block text-xs text-gray-600;
+      }
 
       .boton-seleccion {
         @apply w-full justify-center text-white bg-green-700 py-4 hover:bg-green-800 transition-colors;

--- a/packages/ui-alquilame/app/components/CategoryCard.vue
+++ b/packages/ui-alquilame/app/components/CategoryCard.vue
@@ -581,6 +581,37 @@
       </UCollapsible>
 
       <div class="seccion-boton-seleccion">
+        <!-- Único método de pago (issue #124): info sobre el CTA, mismo fondo difuminado -->
+        <div class="metodo-pago">
+          <span class="metodo-pago-label">
+            Único método de pago
+            <UTooltip
+              :open="paymentTooltipOpen"
+              :delay-duration="0"
+              :content="{ onEscapeKeyDown: forcePaymentTooltipClose, onPointerDownOutside: forcePaymentTooltipClose }"
+              :ui="{ content: 'max-w-[240px] h-auto whitespace-normal text-wrap select-text bg-white text-gray-900 shadow-lg border border-gray-200 p-3 text-xs font-normal' }"
+              @update:open="onPaymentTooltipOpenChange"
+            >
+              <template #content>
+                No se acepta efectivo ni tarjeta débito. El pago se realiza únicamente con tarjeta de crédito al recoger el vehículo en la sede.
+              </template>
+              <UButton
+                variant="ghost"
+                color="neutral"
+                size="xs"
+                aria-label="Más información sobre el método de pago"
+                class="cursor-pointer p-0 -my-1"
+                :ui="questionButtonUIConfig"
+              >
+                <template #leading>
+                  <InfoQuestionIcon cls="size-3.5 text-gray-400" />
+                </template>
+              </UButton>
+            </UTooltip>
+          </span>
+          <span class="metodo-pago-valor">Tarjeta de crédito en sede</span>
+        </div>
+
         <UButton
           class="boton-seleccion"
           size="xl"
@@ -686,6 +717,14 @@ const {
   open: totalPriceTooltipOpen,
   onOpenChange: onTotalPriceTooltipOpenChange,
   forceClose: forceTotalPriceTooltipClose,
+} = useDelayedClose(tooltipCloseDelayMs);
+
+// "Único método de pago" tooltip (issue #124): same controlled pattern as the
+// price tooltip so it opens on tap (touch) and focus (keyboard), not hover-only.
+const {
+  open: paymentTooltipOpen,
+  onOpenChange: onPaymentTooltipOpenChange,
+  forceClose: forcePaymentTooltipClose,
 } = useDelayedClose(tooltipCloseDelayMs);
 
 /** Product Schema for SEO */

--- a/packages/ui-alquilatucarro/app/assets/css/rentacar-main/category.css
+++ b/packages/ui-alquilatucarro/app/assets/css/rentacar-main/category.css
@@ -134,7 +134,21 @@
     }
 
     .seccion-boton-seleccion {
-      @apply rounded-b-lg bg-white p-4;
+      @apply rounded-b-lg p-4;
+      /* Fondo gris desvanecido compartido con la sección de precios (issue #124) */
+      background: linear-gradient(to right, white, #ededed 50%, white);
+
+      .metodo-pago {
+        @apply text-center mb-3;
+      }
+
+      .metodo-pago-label {
+        @apply inline-flex items-center justify-center gap-1 text-sm font-semibold text-gray-800;
+      }
+
+      .metodo-pago-valor {
+        @apply block text-xs text-gray-600;
+      }
 
       .boton-seleccion {
         @apply w-full justify-center text-white bg-green-700 py-4 hover:bg-green-800 transition-colors;

--- a/packages/ui-alquilatucarro/app/components/CategoryCard.vue
+++ b/packages/ui-alquilatucarro/app/components/CategoryCard.vue
@@ -581,6 +581,37 @@
       </UCollapsible>
 
       <div class="seccion-boton-seleccion">
+        <!-- Único método de pago (issue #124): info sobre el CTA, mismo fondo difuminado -->
+        <div class="metodo-pago">
+          <span class="metodo-pago-label">
+            Único método de pago
+            <UTooltip
+              :open="paymentTooltipOpen"
+              :delay-duration="0"
+              :content="{ onEscapeKeyDown: forcePaymentTooltipClose, onPointerDownOutside: forcePaymentTooltipClose }"
+              :ui="{ content: 'max-w-[240px] h-auto whitespace-normal text-wrap select-text bg-white text-gray-900 shadow-lg border border-gray-200 p-3 text-xs font-normal' }"
+              @update:open="onPaymentTooltipOpenChange"
+            >
+              <template #content>
+                No se acepta efectivo ni tarjeta débito. El pago se realiza únicamente con tarjeta de crédito al recoger el vehículo en la sede.
+              </template>
+              <UButton
+                variant="ghost"
+                color="neutral"
+                size="xs"
+                aria-label="Más información sobre el método de pago"
+                class="cursor-pointer p-0 -my-1"
+                :ui="questionButtonUIConfig"
+              >
+                <template #leading>
+                  <InfoQuestionIcon cls="size-3.5 text-gray-400" />
+                </template>
+              </UButton>
+            </UTooltip>
+          </span>
+          <span class="metodo-pago-valor">Tarjeta de crédito en sede</span>
+        </div>
+
         <UButton
           class="boton-seleccion"
           size="xl"
@@ -686,6 +717,14 @@ const {
   open: totalPriceTooltipOpen,
   onOpenChange: onTotalPriceTooltipOpenChange,
   forceClose: forceTotalPriceTooltipClose,
+} = useDelayedClose(tooltipCloseDelayMs);
+
+// "Único método de pago" tooltip (issue #124): same controlled pattern as the
+// price tooltip so it opens on tap (touch) and focus (keyboard), not hover-only.
+const {
+  open: paymentTooltipOpen,
+  onOpenChange: onPaymentTooltipOpenChange,
+  forceClose: forcePaymentTooltipClose,
 } = useDelayedClose(tooltipCloseDelayMs);
 
 /** Product Schema for SEO */


### PR DESCRIPTION
Closes #124

## Qué hace

Cada tarjeta de categoría muestra, centrado **encima del botón** "Solicitar este vehículo":

```
        Único método de pago  (?)
       Tarjeta de crédito en sede
   ┌─────────────────────────────────┐
   │      Solicitar este vehículo    │
   └─────────────────────────────────┘
       (todo sobre fondo gris desvanecido)
```

- **Tooltip (?):** "No se acepta efectivo ni tarjeta débito. El pago se realiza únicamente con tarjeta de crédito al recoger el vehículo en la sede."
- El bloque **y el botón** comparten el **gradiente gris desvanecido** de la sección de precios (`.seccion-boton-seleccion`: `bg-white` → `linear-gradient(to right, white, #ededed 50%, white)`).
- Tooltip con el patrón controlado `useDelayedClose` ya existente (el del precio) → abre con **tap** y **foco de teclado**, no solo hover.

## Decisiones
- **Alcance: las 3 marcas** (CategoryCard.vue idéntico en cada una) para no divergir, aunque solo alquilatucarro está en producción.
- Copy exacto y diseño según la issue (opción 2, botón a ancho completo).

## Verificación
- ✅ Suite logic 361/361.
- ✅ Las 3 `CategoryCard.vue` siguen idénticas tras el cambio.
- Pendiente en preview: tooltip abre con tap/teclado, fondo gris compartido, sin regresiones móvil/desktop, cero errores de consola.

> Nota: el test `SCEN-004` (model-image-optimization) falla **localmente** por un `nuxt.config.ts` desincronizado en el working tree (sin relación con este cambio; no se toca `nuxt.config.ts`). En CI con el `nuxt.config.ts` de `main` no aplica.

**Blast radius:** `CategoryCard.vue` ×3 + `category.css` ×3. Sin lógica nueva en `logic`.