### PR TITLE
test(image-domains): align stale SCEN-004 with env-driven image.domains (#73)

### DIFF
--- a/packages/ui-alquilatucarro/app/components/__tests__/model-image-optimization.test.ts
+++ b/packages/ui-alquilatucarro/app/components/__tests__/model-image-optimization.test.ts
@@ -24,14 +24,20 @@ const carrusel = readFileSync(
 )
 
 describe('model-image-optimization — nuxt.config image.domains (SCEN-004)', () => {
-  it('declares an image.domains array', () => {
-    expect(nuxtConfig).toMatch(/image:\s*\{[\s\S]*?domains:\s*\[/)
+  // Post issue #73 (PR #133) `image.domains` is env-driven — built from
+  // NUXT_IMAGE_DOMAINS with the Blob host as fallback — not a hardcoded array
+  // literal. These assertions track that shipped form; the #48 guarantee (the
+  // Blob host IS whitelisted so external model images route through the
+  // optimizer) still holds via the fallback. See image-domains.test.ts (SCEN-73)
+  // for the full 3-brand env-driven contract.
+  it('declares an image.domains entry', () => {
+    expect(nuxtConfig).toMatch(/image:\s*\{[\s\S]*?domains:/)
   })
 
   it('whitelists the shared Blob host so external model images route through the optimizer', () => {
-    // domains entry, not just the comment / remotePatterns hook
+    // Blob host present as the env fallback after `domains:`, not a literal array
     expect(nuxtConfig).toMatch(
-      new RegExp(`domains:\\s*\\[[^\\]]*['"]${BLOB_HOST.replace(/\./g, '\\.')}['"]`),
+      new RegExp(`domains:[\\s\\S]{0,160}['"]${BLOB_HOST.replace(/\./g, '\\.')}['"]`),
     )
   })
 })


### PR DESCRIPTION
## Problema

Dos tests se contradecían sobre `image.domains`:

- **`image-domains.test.ts`** (de #133/issue #73) exige que el config **NO** use `domains: ['9grznib0…']` (debe ser env-driven con fallback).
- **`model-image-optimization.test.ts` SCEN-004** (holdout de #48) exigía justo `domains: [ … '9grznib0…' ]` (array literal).

#133 cambió `image.domains` a env-driven (`NUXT_IMAGE_DOMAINS || '<blob>'.split(',')…`) pero no actualizó el SCEN-004. Invisible porque **CI solo corre la suite de logic**, no los vitest de marca.

## Fix

Actualizar las 2 aserciones de SCEN-004 al formato env-driven enviado. La garantía de #48 (el host del Blob está whitelisted → imágenes externas pasan por el optimizador) **se mantiene**, ahora verificada vía el fallback de la env en vez de un array literal. No se debilita la intención.

## Verificación
- ✅ `model-image-optimization.test.ts` 5/5
- ✅ `image-domains.test.ts` 15/15 (sin romper)
- Sin cambio de runtime (solo test).

**Blast radius:** un archivo de test (`model-image-optimization.test.ts`).