### PR TITLE
fix(theme): opt out of mobile force-dark so the payment popover stays readable

### DIFF
--- a/packages/ui-alquicarros/app/assets/css/rentacar-main/base.css
+++ b/packages/ui-alquicarros/app/assets/css/rentacar-main/base.css
@@ -1,3 +1,11 @@
+/* Opt out of mobile-browser force-dark (Chrome Android "auto dark theme").
+   The app is light-only (colorMode preference: 'light'); without this declaration
+   the browser auto-darkens content — most visibly teleported overlays like the
+   popover panel, which turns dark-bg + dark-text and becomes unreadable. */
+html {
+  color-scheme: light;
+}
+
 /* ============================================
    CRITICAL CSS - Previene FOUC en hero section
    Estos estilos deben coincidir con los de Nuxt UI

--- a/packages/ui-alquicarros/app/components/CategoryCard.vue
+++ b/packages/ui-alquicarros/app/components/CategoryCard.vue
@@ -585,7 +585,7 @@
         <div class="metodo-pago">
           <span class="metodo-pago-label">
             Único método de pago
-            <UPopover>
+            <UPopover :ui="{ content: 'bg-white ring-1 ring-gray-200' }">
               <UButton
                 variant="ghost"
                 color="neutral"

--- a/packages/ui-alquilame/app/assets/css/rentacar-main/base.css
+++ b/packages/ui-alquilame/app/assets/css/rentacar-main/base.css
@@ -1,3 +1,11 @@
+/* Opt out of mobile-browser force-dark (Chrome Android "auto dark theme").
+   The app is light-only (colorMode preference: 'light'); without this declaration
+   the browser auto-darkens content — most visibly teleported overlays like the
+   popover panel, which turns dark-bg + dark-text and becomes unreadable. */
+html {
+  color-scheme: light;
+}
+
 /* ============================================
    CRITICAL CSS - Previene FOUC en hero section
    Estos estilos deben coincidir con los de Nuxt UI

--- a/packages/ui-alquilame/app/components/CategoryCard.vue
+++ b/packages/ui-alquilame/app/components/CategoryCard.vue
@@ -585,7 +585,7 @@
         <div class="metodo-pago">
           <span class="metodo-pago-label">
             Único método de pago
-            <UPopover>
+            <UPopover :ui="{ content: 'bg-white ring-1 ring-gray-200' }">
               <UButton
                 variant="ghost"
                 color="neutral"

--- a/packages/ui-alquilatucarro/app/assets/css/rentacar-main/base.css
+++ b/packages/ui-alquilatucarro/app/assets/css/rentacar-main/base.css
@@ -1,3 +1,11 @@
+/* Opt out of mobile-browser force-dark (Chrome Android "auto dark theme").
+   The app is light-only (colorMode preference: 'light'); without this declaration
+   the browser auto-darkens content — most visibly teleported overlays like the
+   popover panel, which turns dark-bg + dark-text and becomes unreadable. */
+html {
+  color-scheme: light;
+}
+
 /* ============================================
    CRITICAL CSS - Previene FOUC en hero section
    Estos estilos deben coincidir con los de Nuxt UI

--- a/packages/ui-alquilatucarro/app/components/CategoryCard.vue
+++ b/packages/ui-alquilatucarro/app/components/CategoryCard.vue
@@ -585,7 +585,7 @@
         <div class="metodo-pago">
           <span class="metodo-pago-label">
             Único método de pago
-            <UPopover>
+            <UPopover :ui="{ content: 'bg-white ring-1 ring-gray-200' }">
               <UButton
                 variant="ghost"
                 color="neutral"


### PR DESCRIPTION
## Problema

En Android, el **"tema oscuro automático" de Chrome** (force-dark) oscurece páginas que no declaran `color-scheme`. La app es light-only (`colorMode.preference: 'light'`) pero **nunca declaró `color-scheme`**, así que el navegador auto-oscurecía el contenido — visible sobre todo en el **popover de pago** (overlay teletransportado al `<body>`), que quedaba fondo oscuro + texto oscuro e ilegible.

Desktop y la emulación de `prefers-color-scheme` **no** lo mostraban porque force-dark es un mecanismo distinto.

## Fix (2 capas)

1. **`html { color-scheme: light }`** en el `base.css` de cada marca → opta a todo el sitio **fuera** del force-dark del navegador.
2. **Popover** con `bg-white` + `ring` explícitos → el panel nunca depende de un token de tema que pueda resolver oscuro en el teleport.

## Verificación
- ✅ Render normal sigue correcto (popover blanco, texto legible) — verificado en preview.
- ⚠️ La supresión de force-dark **no se puede emular con agent-browser** (solo emula `prefers-color-scheme`, no el force-dark de Android). La prueba definitiva es el celular del usuario tras el deploy; la declaración `color-scheme: light` es el opt-out documentado (web.dev).

**Blast radius:** `base.css` ×3 (regla global `html`) + `CategoryCard.vue` ×3 (popover `:ui`).