### PR TITLE
style(category-card): align payment text scale + white bg for adicionales panel

### DIFF
--- a/packages/ui-alquicarros/app/assets/css/rentacar-main/category.css
+++ b/packages/ui-alquicarros/app/assets/css/rentacar-main/category.css
@@ -143,7 +143,7 @@
       }
 
       .metodo-pago-label {
-        @apply inline-flex items-center justify-center gap-1 text-lg font-semibold text-gray-700;
+        @apply inline-flex items-center justify-center gap-1 text-sm font-bold text-gray-800;
       }
 
       .metodo-pago-valor {

--- a/packages/ui-alquicarros/app/assets/css/rentacar-main/category.css
+++ b/packages/ui-alquicarros/app/assets/css/rentacar-main/category.css
@@ -147,7 +147,7 @@
       }
 
       .metodo-pago-valor {
-        @apply block text-sm text-gray-600;
+        @apply block text-sm text-gray-800;
       }
 
       .boton-seleccion {

--- a/packages/ui-alquicarros/app/assets/css/rentacar-main/category.css
+++ b/packages/ui-alquicarros/app/assets/css/rentacar-main/category.css
@@ -143,11 +143,11 @@
       }
 
       .metodo-pago-label {
-        @apply inline-flex items-center justify-center gap-1 text-sm font-semibold text-gray-800;
+        @apply inline-flex items-center justify-center gap-1 text-lg font-semibold text-gray-700;
       }
 
       .metodo-pago-valor {
-        @apply block text-xs text-gray-600;
+        @apply block text-sm text-gray-600;
       }
 
       .boton-seleccion {
@@ -163,6 +163,12 @@
     /* Fondo degradado sutil reutilizable */
     .sutil-fondo {
       background: linear-gradient(to right, white, #ededed 50%, white);
+    }
+
+    /* Contenido abierto de "Servicios adicionales": tono blanco como la sección
+       cerrada, no el gris de la sección de precios */
+    .adicionales-contenido {
+      background: linear-gradient(to right, white, #fafafa 50%, white);
     }
 }
 

--- a/packages/ui-alquicarros/app/components/CategoryCard.vue
+++ b/packages/ui-alquicarros/app/components/CategoryCard.vue
@@ -420,7 +420,7 @@
           </template>
         </UButton>
         <template #content>
-          <div class="flex flex-col gap-1 px-5 pt-3 pb-4 sutil-fondo">
+          <div class="flex flex-col gap-1 px-5 pt-3 pb-4 adicionales-contenido">
             <div class="flex items-center justify-between">
               <div class="flex">
                 <UCheckbox
@@ -599,7 +599,7 @@
                 </template>
               </UButton>
               <template #content>
-                <p class="max-w-[260px] p-3 text-xs font-normal text-gray-700">
+                <p class="max-w-[280px] p-3 text-sm font-normal text-gray-700">
                   El pago se realiza al recoger el vehículo en la sede, únicamente con tarjeta de crédito. No se acepta efectivo, Nequi u otros medios de pago.
                 </p>
               </template>

--- a/packages/ui-alquilame/app/assets/css/rentacar-main/category.css
+++ b/packages/ui-alquilame/app/assets/css/rentacar-main/category.css
@@ -146,7 +146,7 @@
       }
 
       .metodo-pago-label {
-        @apply inline-flex items-center justify-center gap-1 text-lg font-semibold text-gray-700;
+        @apply inline-flex items-center justify-center gap-1 text-sm font-bold text-gray-800;
       }
 
       .metodo-pago-valor {

--- a/packages/ui-alquilame/app/assets/css/rentacar-main/category.css
+++ b/packages/ui-alquilame/app/assets/css/rentacar-main/category.css
@@ -146,11 +146,11 @@
       }
 
       .metodo-pago-label {
-        @apply inline-flex items-center justify-center gap-1 text-sm font-semibold text-gray-800;
+        @apply inline-flex items-center justify-center gap-1 text-lg font-semibold text-gray-700;
       }
 
       .metodo-pago-valor {
-        @apply block text-xs text-gray-600;
+        @apply block text-sm text-gray-600;
       }
 
       .boton-seleccion {
@@ -166,6 +166,12 @@
     /* Fondo degradado sutil reutilizable */
     .sutil-fondo {
       background: linear-gradient(to right, white, #ededed 50%, white);
+    }
+
+    /* Contenido abierto de "Servicios adicionales": tono blanco como la sección
+       cerrada, no el gris de la sección de precios */
+    .adicionales-contenido {
+      background: linear-gradient(to right, white, #fafafa 50%, white);
     }
 }
 

--- a/packages/ui-alquilame/app/assets/css/rentacar-main/category.css
+++ b/packages/ui-alquilame/app/assets/css/rentacar-main/category.css
@@ -150,7 +150,7 @@
       }
 
       .metodo-pago-valor {
-        @apply block text-sm text-gray-600;
+        @apply block text-sm text-gray-800;
       }
 
       .boton-seleccion {

--- a/packages/ui-alquilame/app/components/CategoryCard.vue
+++ b/packages/ui-alquilame/app/components/CategoryCard.vue
@@ -420,7 +420,7 @@
           </template>
         </UButton>
         <template #content>
-          <div class="flex flex-col gap-1 px-5 pt-3 pb-4 sutil-fondo">
+          <div class="flex flex-col gap-1 px-5 pt-3 pb-4 adicionales-contenido">
             <div class="flex items-center justify-between">
               <div class="flex">
                 <UCheckbox
@@ -599,7 +599,7 @@
                 </template>
               </UButton>
               <template #content>
-                <p class="max-w-[260px] p-3 text-xs font-normal text-gray-700">
+                <p class="max-w-[280px] p-3 text-sm font-normal text-gray-700">
                   El pago se realiza al recoger el vehículo en la sede, únicamente con tarjeta de crédito. No se acepta efectivo, Nequi u otros medios de pago.
                 </p>
               </template>

--- a/packages/ui-alquilatucarro/app/assets/css/rentacar-main/category.css
+++ b/packages/ui-alquilatucarro/app/assets/css/rentacar-main/category.css
@@ -143,7 +143,7 @@
       }
 
       .metodo-pago-label {
-        @apply inline-flex items-center justify-center gap-1 text-lg font-semibold text-gray-700;
+        @apply inline-flex items-center justify-center gap-1 text-sm font-bold text-gray-800;
       }
 
       .metodo-pago-valor {

--- a/packages/ui-alquilatucarro/app/assets/css/rentacar-main/category.css
+++ b/packages/ui-alquilatucarro/app/assets/css/rentacar-main/category.css
@@ -147,7 +147,7 @@
       }
 
       .metodo-pago-valor {
-        @apply block text-sm text-gray-600;
+        @apply block text-sm text-gray-800;
       }
 
       .boton-seleccion {

--- a/packages/ui-alquilatucarro/app/assets/css/rentacar-main/category.css
+++ b/packages/ui-alquilatucarro/app/assets/css/rentacar-main/category.css
@@ -143,11 +143,11 @@
       }
 
       .metodo-pago-label {
-        @apply inline-flex items-center justify-center gap-1 text-sm font-semibold text-gray-800;
+        @apply inline-flex items-center justify-center gap-1 text-lg font-semibold text-gray-700;
       }
 
       .metodo-pago-valor {
-        @apply block text-xs text-gray-600;
+        @apply block text-sm text-gray-600;
       }
 
       .boton-seleccion {
@@ -163,6 +163,12 @@
     /* Fondo degradado sutil reutilizable */
     .sutil-fondo {
       background: linear-gradient(to right, white, #ededed 50%, white);
+    }
+
+    /* Contenido abierto de "Servicios adicionales": tono blanco como la sección
+       cerrada, no el gris de la sección de precios */
+    .adicionales-contenido {
+      background: linear-gradient(to right, white, #fafafa 50%, white);
     }
 }
 

--- a/packages/ui-alquilatucarro/app/components/CategoryCard.vue
+++ b/packages/ui-alquilatucarro/app/components/CategoryCard.vue
@@ -420,7 +420,7 @@
           </template>
         </UButton>
         <template #content>
-          <div class="flex flex-col gap-1 px-5 pt-3 pb-4 sutil-fondo">
+          <div class="flex flex-col gap-1 px-5 pt-3 pb-4 adicionales-contenido">
             <div class="flex items-center justify-between">
               <div class="flex">
                 <UCheckbox
@@ -599,7 +599,7 @@
                 </template>
               </UButton>
               <template #content>
-                <p class="max-w-[260px] p-3 text-xs font-normal text-gray-700">
+                <p class="max-w-[280px] p-3 text-sm font-normal text-gray-700">
                   El pago se realiza al recoger el vehículo en la sede, únicamente con tarjeta de crédito. No se acepta efectivo, Nequi u otros medios de pago.
                 </p>
               </template>


### PR DESCRIPTION
Ajustes visuales (follow-up #124). Pendiente de aprobación visual en preview antes de prod.

1. **Tipografía del bloque de pago** alineada al sistema de la tarjeta: 'Único método de pago' text-sm→**text-lg** (como 'Escoge protección' / 'Servicios adicionales'); valor y popover text-xs→**text-sm** (como el texto de los modales).
2. **Fondo de 'Servicios adicionales' abierto**: era `.sutil-fondo` (gris de precios) → ahora gradiente **blanco** propio, para que el contenido expandido se lea blanco como la fila cerrada.

Blast radius: `CategoryCard.vue` ×3 + `category.css` ×3.