### PR TITLE
fix(searcher): guard calendar against null deselect that wiped the date (#123)

### DIFF
--- a/packages/ui-alquicarros/app/components/Searcher.vue
+++ b/packages/ui-alquicarros/app/components/Searcher.vue
@@ -146,7 +146,7 @@
                             </u-button>
                             <template #content>
                                 <u-calendar
-                                    v-model="selectedPickupDate"
+                                    :model-value="selectedPickupDate"
                                     class="p-2 calendar-light"
                                     :min-value="minPickupDate"
                                     color="success"
@@ -155,7 +155,7 @@
                                     :year-controls="false"
                                     :prev-month="{ color: 'gray', variant: 'soft' }"
                                     :next-month="{ color: 'gray', variant: 'soft' }"
-                                    @update:model-value="pickupDateCalendarOpen = false"
+                                    @update:model-value="(v) => { if (v) { selectedPickupDate = v; pickupDateCalendarOpen = false; } }"
                                 />
                             </template>
                         </u-popover>
@@ -211,7 +211,7 @@
                             </u-button>
                             <template #content>
                                 <u-calendar
-                                    v-model="selectedReturnDate"
+                                    :model-value="selectedReturnDate"
                                     class="p-2 calendar-light"
                                     :min-value="minReturnDate"
                                     :max-value="maxReturnDate"
@@ -221,7 +221,7 @@
                                     :year-controls="false"
                                     :prev-month="{ color: 'gray', variant: 'soft' }"
                                     :next-month="{ color: 'gray', variant: 'soft' }"
-                                    @update:model-value="returnDateCalendarOpen = false"
+                                    @update:model-value="(v) => { if (v) { selectedReturnDate = v; returnDateCalendarOpen = false; } }"
                                 />
                             </template>
                         </u-popover>

--- a/packages/ui-alquilame/app/components/Searcher.vue
+++ b/packages/ui-alquilame/app/components/Searcher.vue
@@ -146,7 +146,7 @@
                             </u-button>
                             <template #content>
                                 <u-calendar
-                                    v-model="selectedPickupDate"
+                                    :model-value="selectedPickupDate"
                                     class="p-2 calendar-light"
                                     :min-value="minPickupDate"
                                     color="success"
@@ -155,7 +155,7 @@
                                     :year-controls="false"
                                     :prev-month="{ color: 'gray', variant: 'soft' }"
                                     :next-month="{ color: 'gray', variant: 'soft' }"
-                                    @update:model-value="pickupDateCalendarOpen = false"
+                                    @update:model-value="(v) => { if (v) { selectedPickupDate = v; pickupDateCalendarOpen = false; } }"
                                 />
                             </template>
                         </u-popover>
@@ -211,7 +211,7 @@
                             </u-button>
                             <template #content>
                                 <u-calendar
-                                    v-model="selectedReturnDate"
+                                    :model-value="selectedReturnDate"
                                     class="p-2 calendar-light"
                                     :min-value="minReturnDate"
                                     :max-value="maxReturnDate"
@@ -221,7 +221,7 @@
                                     :year-controls="false"
                                     :prev-month="{ color: 'gray', variant: 'soft' }"
                                     :next-month="{ color: 'gray', variant: 'soft' }"
-                                    @update:model-value="returnDateCalendarOpen = false"
+                                    @update:model-value="(v) => { if (v) { selectedReturnDate = v; returnDateCalendarOpen = false; } }"
                                 />
                             </template>
                         </u-popover>

--- a/packages/ui-alquilatucarro/app/components/Searcher.vue
+++ b/packages/ui-alquilatucarro/app/components/Searcher.vue
@@ -146,7 +146,7 @@
                             </u-button>
                             <template #content>
                                 <u-calendar
-                                    v-model="selectedPickupDate"
+                                    :model-value="selectedPickupDate"
                                     class="p-2 calendar-light"
                                     :min-value="minPickupDate"
                                     color="success"
@@ -155,7 +155,7 @@
                                     :year-controls="false"
                                     :prev-month="{ color: 'gray', variant: 'soft' }"
                                     :next-month="{ color: 'gray', variant: 'soft' }"
-                                    @update:model-value="pickupDateCalendarOpen = false"
+                                    @update:model-value="(v) => { if (v) { selectedPickupDate = v; pickupDateCalendarOpen = false; } }"
                                 />
                             </template>
                         </u-popover>
@@ -211,7 +211,7 @@
                             </u-button>
                             <template #content>
                                 <u-calendar
-                                    v-model="selectedReturnDate"
+                                    :model-value="selectedReturnDate"
                                     class="p-2 calendar-light"
                                     :min-value="minReturnDate"
                                     :max-value="maxReturnDate"
@@ -221,7 +221,7 @@
                                     :year-controls="false"
                                     :prev-month="{ color: 'gray', variant: 'soft' }"
                                     :next-month="{ color: 'gray', variant: 'soft' }"
-                                    @update:model-value="returnDateCalendarOpen = false"
+                                    @update:model-value="(v) => { if (v) { selectedReturnDate = v; returnDateCalendarOpen = false; } }"
                                 />
                             </template>
                         </u-popover>


### PR DESCRIPTION
Closes #123.

## Problema

En `Searcher.vue`, hacer click en el **día ya seleccionado** del `<u-calendar>` (modo single) lo deselecciona (toggle) y emite `update:model-value` con `null`. El handler anterior solo cerraba el popover, así que `v-model` escribía `null`, el campo de fecha quedaba en blanco y **BUSCAR VEHÍCULOS** caía al fallback `/#requisitos` → la búsqueda dejaba de funcionar. Reproducido en producción (alquilatucarro), desktop.

## Fix

En los dos `<u-calendar>` (recogida + devolución) de los tres brands:
- `v-model="selected…Date"` → `:model-value="selected…Date"` (binding de una vía).
- Handler con guard que ignora emisiones nulas:
  `@update:model-value="(v) => { if (v) { selected…Date = v; …CalendarOpen = false; } }"`

Re-click en el día ya seleccionado → **conserva** la fecha. Día distinto → actualiza y cierra el popover. Inputs nativos móviles sin tocar (no tienen el toggle).

## Alcance

- `packages/ui-alquilatucarro/app/components/Searcher.vue`
- `packages/ui-alquicarros/app/components/Searcher.vue`
- `packages/ui-alquilame/app/components/Searcher.vue`

Solo template. Sin cambios en store/composables. Solo `ui-alquilatucarro` está en producción; los otros dos se corrigen por paridad.

## Verificación

- **Navegador** (agent-browser, alquilatucarro local):
  - Re-click día seleccionado (recogida y devolución) → fecha conservada, BUSCAR con URL válida ✅
  - Elegir día distinto → actualiza fecha, devolución auto-avanza +7, popover cierra ✅
  - Consola sin errores (`[error]` = 0) ✅
- **Tests CI** (`pnpm --filter @rentacar-main/logic test`): **361/361** verdes, incluido `useStoreReservationForm.minReturnDate.test.ts` que hace assertions sobre el bloque `<u-calendar>`.