### PR TITLE
feat(nav): in-page Requisitos/Sedes/FAQ anchors keep the city selection

### DIFF
--- a/packages/ui-alquicarros/app/components/CityPage.vue
+++ b/packages/ui-alquicarros/app/components/CityPage.vue
@@ -320,6 +320,9 @@
       </div>
     </section>
 
+    <!-- Requisitos Section (shared with home) -->
+    <RequisitosSection />
+
     <!-- FAQ Section -->
     <UPageSection id="faqs" class="bg-gray-100 text-black">
       <div class="max-w-7xl mx-auto px-1 sm:px-2 lg:px-6">

--- a/packages/ui-alquicarros/app/components/RequisitosSection.vue
+++ b/packages/ui-alquicarros/app/components/RequisitosSection.vue
@@ -1,0 +1,62 @@
+<template>
+  <!-- Persona Section -->
+  <UPageSection
+    id="requisitos"
+    orientation="horizontal"
+    :reverse="true"
+    class="bg-gray-200 text-black scroll-mt-20"
+  >
+    <template #title>
+      <span class="block text-2xl md:text-3xl text-center">
+        <span class="text-red-700">Requisitos</span>{{ ' ' }}<span class="text-black">para tu alquiler</span>
+      </span>
+    </template>
+    <template #description>
+      <div class="text-black justify-items-center">
+        <div class="mb-4 text-center">
+          En {{ franchise.shortname }} tu experiencia es sin complicaciones...
+        </div>
+        <ul class="flex flex-col gap-4">
+          <li class="flex items-start gap-2">
+            <IconsLocationIcon cls="text-red-600 size-5 mt-0.5" />
+            <div>
+              <div class="font-bold text-black">RESERVA PREVIA</div>
+              <div class="text-black text-sm">(más anticipación más descuento)</div>
+            </div>
+          </li>
+          <li class="flex items-start gap-2">
+            <IconsLocationIcon cls="text-red-600 size-5 mt-0.5" />
+            <div>
+              <div class="font-bold text-black">DOCUMENTO DE IDENTIDAD</div>
+              <div class="text-black text-sm">(18+ Cédula o pasaporte original)</div>
+            </div>
+          </li>
+          <li class="flex items-start gap-2">
+            <IconsLocationIcon cls="text-red-600 size-5 mt-0.5" />
+            <div>
+              <div class="font-bold text-black">TARJETA DE CRÉDITO</div>
+              <div class="text-black text-sm">(Única forma de pago)</div>
+            </div>
+          </li>
+          <li class="flex items-start gap-2">
+            <IconsLocationIcon cls="text-red-600 size-5 mt-0.5" />
+            <div>
+              <div class="font-bold text-black">LICENCIA DE CONDUCIR</div>
+              <div class="text-black text-sm">(física y vigente)</div>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </template>
+    <template #default>
+      <!-- CLS fix: reservar espacio con aspect-ratio antes de que cargue la imagen -->
+      <div class="w-full aspect-[100/81]">
+        <LazyImagesPersona hydrate-on-visible />
+      </div>
+    </template>
+  </UPageSection>
+</template>
+
+<script setup lang="ts">
+const { franchise } = useAppConfig();
+</script>

--- a/packages/ui-alquicarros/app/layouts/default.vue
+++ b/packages/ui-alquicarros/app/layouts/default.vue
@@ -131,18 +131,27 @@ const route = useRoute();
 // Estado del menú móvil slideover
 const mobileMenuOpen = ref(false);
 
+// La home (/) y todas las páginas de ciudad ([city] param) renderizan las
+// secciones #requisitos y #faqs. En esas páginas enlazamos con ancla relativa
+// para hacer scroll en sitio sin navegar (no se pierde la selección de ciudad);
+// en el resto caemos a /#... (home). #sedes vive en el layout → siempre presente.
+const hasInPageSections = computed(() => route.path === '/' || !!route.params.city);
+
+const requisitosTo = computed(() => hasInPageSections.value ? '#requisitos' : '/#requisitos');
+const faqsTo = computed(() => hasInPageSections.value ? '#faqs' : '/#faqs');
+
 // Items para menú desktop (texto blanco sobre fondo azul)
 const items = computed<NavigationMenuItem[]>(() => [
   {
     label: 'Requisitos',
-    to: '/#requisitos',
-    active: route.path.startsWith('#requisitos'),
+    to: requisitosTo.value,
+    active: route.hash === '#requisitos',
     class: "text-white hover:text-white hover:bg-white/10",
   },
   {
     label: 'Sedes',
-    to: '/#sedes',
-    active: route.path.startsWith('#sedes'),
+    to: '#sedes',
+    active: route.hash === '#sedes',
     class: "text-white hover:text-white hover:bg-white/10",
   },
   {
@@ -153,8 +162,8 @@ const items = computed<NavigationMenuItem[]>(() => [
   },
   {
     label: 'Preguntas frecuentes',
-    to: '/#faqs',
-    active: route.path.startsWith('#faqs'),
+    to: faqsTo.value,
+    active: route.hash === '#faqs',
     class: "text-white hover:text-white hover:bg-white/10",
   },
 ])
@@ -163,13 +172,13 @@ const items = computed<NavigationMenuItem[]>(() => [
 const mobileItems = computed<NavigationMenuItem[]>(() => [
   {
     label: 'Requisitos',
-    to: '/#requisitos',
-    active: route.path.startsWith('#requisitos'),
+    to: requisitosTo.value,
+    active: route.hash === '#requisitos',
   },
   {
     label: 'Sedes',
-    to: '/#sedes',
-    active: route.path.startsWith('#sedes'),
+    to: '#sedes',
+    active: route.hash === '#sedes',
   },
   {
     label: 'Blog',
@@ -178,8 +187,8 @@ const mobileItems = computed<NavigationMenuItem[]>(() => [
   },
   {
     label: 'Preguntas frecuentes',
-    to: '/#faqs',
-    active: route.path.startsWith('#faqs'),
+    to: faqsTo.value,
+    active: route.hash === '#faqs',
   },
 ])
 

--- a/packages/ui-alquicarros/app/pages/index.vue
+++ b/packages/ui-alquicarros/app/pages/index.vue
@@ -57,62 +57,8 @@
       </template>
     </UPageSection>
 
-    <!-- Persona Section -->
-    <UPageSection
-      id="requisitos"
-      orientation="horizontal"
-      :reverse="true"
-      class="bg-gray-200 text-black"
-    >
-      <template #title>
-        <span class="block text-2xl md:text-3xl text-center">
-          <span class="text-red-700">Requisitos</span>{{ ' ' }}<span class="text-black">para tu alquiler</span>
-        </span>
-      </template>
-      <template #description>
-        <div class="text-black justify-items-center">
-          <div class="mb-4 text-center">
-            En {{ franchise.shortname }} tu experiencia es sin complicaciones...
-          </div>
-          <ul class="flex flex-col gap-4">
-            <li class="flex items-start gap-2">
-              <LocationIcon cls="text-red-600 size-5 mt-0.5" />
-              <div>
-                <div class="font-bold text-black">RESERVA PREVIA</div>
-                <div class="text-black text-sm">(más anticipación más descuento)</div>
-              </div>
-            </li>
-            <li class="flex items-start gap-2">
-              <LocationIcon cls="text-red-600 size-5 mt-0.5" />
-              <div>
-                <div class="font-bold text-black">DOCUMENTO DE IDENTIDAD</div>
-                <div class="text-black text-sm">(18+ Cédula o pasaporte original)</div>
-              </div>
-            </li>
-            <li class="flex items-start gap-2">
-              <LocationIcon cls="text-red-600 size-5 mt-0.5" />
-              <div>
-                <div class="font-bold text-black">TARJETA DE CRÉDITO</div>
-                <div class="text-black text-sm">(Única forma de pago)</div>
-              </div>
-            </li>
-            <li class="flex items-start gap-2">
-              <LocationIcon cls="text-red-600 size-5 mt-0.5" />
-              <div>
-                <div class="font-bold text-black">LICENCIA DE CONDUCIR</div>
-                <div class="text-black text-sm">(física y vigente)</div>
-              </div>
-            </li>
-          </ul>
-        </div>
-      </template>
-      <template #default>
-        <!-- CLS fix: reservar espacio con aspect-ratio antes de que cargue la imagen -->
-        <div class="w-full aspect-[100/81]">
-          <LazyImagesPersona hydrate-on-visible />
-        </div>
-      </template>
-    </UPageSection>
+    <!-- Persona / Requisitos Section (shared with city pages) -->
+    <RequisitosSection />
 
     <!-- Vehicle Category Section -->
     <UPageSection
@@ -263,7 +209,6 @@ import type Testimonial from "@rentacar-main/logic/utils/types/type/Testimonial"
 /** components */
 import {
   IconsStarIcon as StarIcon,
-  IconsLocationIcon as LocationIcon,
 } from "#components";
 
 const { franchise } = useAppConfig();

--- a/packages/ui-alquilame/app/layouts/default.vue
+++ b/packages/ui-alquilame/app/layouts/default.vue
@@ -154,18 +154,27 @@ const route = useRoute();
 // Estado del menú móvil slideover
 const mobileMenuOpen = ref(false);
 
+// La home (/) y todas las páginas de ciudad ([city] param) renderizan las
+// secciones #requisitos y #faqs. En esas páginas enlazamos con ancla relativa
+// para hacer scroll en sitio sin navegar (no se pierde la selección de ciudad);
+// en el resto caemos a /#... (home). #sedes vive en el layout → siempre presente.
+const hasInPageSections = computed(() => route.path === '/' || !!route.params.city);
+
+const requisitosTo = computed(() => hasInPageSections.value ? '#requisitos' : '/#requisitos');
+const faqsTo = computed(() => hasInPageSections.value ? '#faqs' : '/#faqs');
+
 // Items para menú desktop (texto blanco sobre fondo azul)
 const items = computed<NavigationMenuItem[]>(() => [
   {
     label: 'Requisitos',
-    to: '/#requisitos',
-    active: route.path.startsWith('#requisitos'),
+    to: requisitosTo.value,
+    active: route.hash === '#requisitos',
     class: "text-white hover:text-white hover:bg-white/10",
   },
   {
     label: 'Sedes',
-    to: '/#sedes',
-    active: route.path.startsWith('#sedes'),
+    to: '#sedes',
+    active: route.hash === '#sedes',
     class: "text-white hover:text-white hover:bg-white/10",
   },
   {
@@ -176,8 +185,8 @@ const items = computed<NavigationMenuItem[]>(() => [
   },
   {
     label: 'Preguntas frecuentes',
-    to: '/#faqs',
-    active: route.path.startsWith('#faqs'),
+    to: faqsTo.value,
+    active: route.hash === '#faqs',
     class: "text-white hover:text-white hover:bg-white/10",
   },
 ])
@@ -186,13 +195,13 @@ const items = computed<NavigationMenuItem[]>(() => [
 const mobileItems = computed<NavigationMenuItem[]>(() => [
   {
     label: 'Requisitos',
-    to: '/#requisitos',
-    active: route.path.startsWith('#requisitos'),
+    to: requisitosTo.value,
+    active: route.hash === '#requisitos',
   },
   {
     label: 'Sedes',
-    to: '/#sedes',
-    active: route.path.startsWith('#sedes'),
+    to: '#sedes',
+    active: route.hash === '#sedes',
   },
   {
     label: 'Blog',
@@ -201,8 +210,8 @@ const mobileItems = computed<NavigationMenuItem[]>(() => [
   },
   {
     label: 'Preguntas frecuentes',
-    to: '/#faqs',
-    active: route.path.startsWith('#faqs'),
+    to: faqsTo.value,
+    active: route.hash === '#faqs',
   },
 ])
 

--- a/packages/ui-alquilatucarro/app/assets/css/rentacar-main/category.css
+++ b/packages/ui-alquilatucarro/app/assets/css/rentacar-main/category.css
@@ -76,6 +76,11 @@
       @apply font-normal text-black px-2 py-1 rounded-full text-xs bg-white border border-gray-300;
     }
 
+    /* "sin pico y placa" pill filled with the discount-badge background color */
+    .etiqueta-carro.etiqueta-sin-pyp {
+      @apply bg-[#a3f78b] border-[#a3f78b];
+    }
+
     .contenedor-tarifas{
       @apply grid grid-cols-2 py-4 relative text-gray-800 rounded-b-lg;
     }

--- a/packages/ui-alquilatucarro/app/components/CategoryTags.vue
+++ b/packages/ui-alquilatucarro/app/components/CategoryTags.vue
@@ -1,6 +1,6 @@
 <template>
     <span class="space-x-1">
-        <span v-if="isPicoyPlacaExempt()" class="etiqueta-carro">sin pico y placa</span>
+        <span v-if="isPicoyPlacaExempt()" class="etiqueta-carro etiqueta-sin-pyp">sin pico y placa</span>
         <span v-for="tag in categoryTags[categoryCode]" :key="tag" class="etiqueta-carro" v-text="tag"></span>
     </span>
 </template>

--- a/packages/ui-alquilatucarro/app/components/CityPage.vue
+++ b/packages/ui-alquilatucarro/app/components/CityPage.vue
@@ -316,6 +316,9 @@
       </div>
     </section>
 
+    <!-- Requisitos Section (shared with home) -->
+    <RequisitosSection />
+
     <!-- FAQ Section -->
     <UPageSection id="faqs" class="bg-gray-100 text-black">
       <div class="max-w-7xl mx-auto px-1 sm:px-2 lg:px-6">

--- a/packages/ui-alquilatucarro/app/components/RequisitosSection.vue
+++ b/packages/ui-alquilatucarro/app/components/RequisitosSection.vue
@@ -1,0 +1,62 @@
+<template>
+  <!-- Persona Section -->
+  <UPageSection
+    id="requisitos"
+    orientation="horizontal"
+    :reverse="true"
+    class="bg-gray-200 text-black scroll-mt-20"
+  >
+    <template #title>
+      <span class="block text-2xl md:text-3xl text-center">
+        <span class="text-red-700">Requisitos</span>{{ ' ' }}<span class="text-black">para tu alquiler</span>
+      </span>
+    </template>
+    <template #description>
+      <div class="text-black justify-items-center">
+        <div class="mb-4 text-center">
+          En {{ franchise.shortname }} tu experiencia es sin complicaciones...
+        </div>
+        <ul class="flex flex-col gap-4">
+          <li class="flex items-start gap-2">
+            <IconsLocationIcon cls="text-red-600 size-5 mt-0.5" />
+            <div>
+              <div class="font-bold text-black">RESERVA PREVIA</div>
+              <div class="text-black text-sm">(más anticipación más descuento)</div>
+            </div>
+          </li>
+          <li class="flex items-start gap-2">
+            <IconsLocationIcon cls="text-red-600 size-5 mt-0.5" />
+            <div>
+              <div class="font-bold text-black">DOCUMENTO DE IDENTIDAD</div>
+              <div class="text-black text-sm">(18+ Cédula o pasaporte original)</div>
+            </div>
+          </li>
+          <li class="flex items-start gap-2">
+            <IconsLocationIcon cls="text-red-600 size-5 mt-0.5" />
+            <div>
+              <div class="font-bold text-black">TARJETA DE CRÉDITO</div>
+              <div class="text-black text-sm">(Única forma de pago)</div>
+            </div>
+          </li>
+          <li class="flex items-start gap-2">
+            <IconsLocationIcon cls="text-red-600 size-5 mt-0.5" />
+            <div>
+              <div class="font-bold text-black">LICENCIA DE CONDUCIR</div>
+              <div class="text-black text-sm">(física y vigente)</div>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </template>
+    <template #default>
+      <!-- CLS fix: reservar espacio con aspect-ratio antes de que cargue la imagen -->
+      <div class="w-full aspect-[100/81]">
+        <LazyImagesPersona hydrate-on-visible />
+      </div>
+    </template>
+  </UPageSection>
+</template>
+
+<script setup lang="ts">
+const { franchise } = useAppConfig();
+</script>

--- a/packages/ui-alquilatucarro/app/layouts/default.vue
+++ b/packages/ui-alquilatucarro/app/layouts/default.vue
@@ -139,18 +139,27 @@ const route = useRoute();
 // Estado del menú móvil slideover
 const mobileMenuOpen = ref(false);
 
+// La home (/) y todas las páginas de ciudad ([city] param) renderizan las
+// secciones #requisitos y #faqs. En esas páginas enlazamos con ancla relativa
+// para hacer scroll en sitio sin navegar (no se pierde la selección de ciudad);
+// en el resto caemos a /#... (home). #sedes vive en el layout → siempre presente.
+const hasInPageSections = computed(() => route.path === '/' || !!route.params.city);
+
+const requisitosTo = computed(() => hasInPageSections.value ? '#requisitos' : '/#requisitos');
+const faqsTo = computed(() => hasInPageSections.value ? '#faqs' : '/#faqs');
+
 // Items para menú desktop (texto blanco sobre fondo azul)
 const items = computed<NavigationMenuItem[]>(() => [
   {
     label: 'Requisitos',
-    to: '/#requisitos',
-    active: route.path.startsWith('#requisitos'),
+    to: requisitosTo.value,
+    active: route.hash === '#requisitos',
     class: "text-white hover:text-white hover:bg-white/10",
   },
   {
     label: 'Sedes',
-    to: '/#sedes',
-    active: route.path.startsWith('#sedes'),
+    to: '#sedes',
+    active: route.hash === '#sedes',
     class: "text-white hover:text-white hover:bg-white/10",
   },
   {
@@ -161,8 +170,8 @@ const items = computed<NavigationMenuItem[]>(() => [
   },
   {
     label: 'Preguntas frecuentes',
-    to: '/#faqs',
-    active: route.path.startsWith('#faqs'),
+    to: faqsTo.value,
+    active: route.hash === '#faqs',
     class: "text-white hover:text-white hover:bg-white/10",
   },
 ])
@@ -171,13 +180,13 @@ const items = computed<NavigationMenuItem[]>(() => [
 const mobileItems = computed<NavigationMenuItem[]>(() => [
   {
     label: 'Requisitos',
-    to: '/#requisitos',
-    active: route.path.startsWith('#requisitos'),
+    to: requisitosTo.value,
+    active: route.hash === '#requisitos',
   },
   {
     label: 'Sedes',
-    to: '/#sedes',
-    active: route.path.startsWith('#sedes'),
+    to: '#sedes',
+    active: route.hash === '#sedes',
   },
   {
     label: 'Blog',
@@ -186,8 +195,8 @@ const mobileItems = computed<NavigationMenuItem[]>(() => [
   },
   {
     label: 'Preguntas frecuentes',
-    to: '/#faqs',
-    active: route.path.startsWith('#faqs'),
+    to: faqsTo.value,
+    active: route.hash === '#faqs',
   },
 ])
 

--- a/packages/ui-alquilatucarro/app/pages/index.vue
+++ b/packages/ui-alquilatucarro/app/pages/index.vue
@@ -57,62 +57,8 @@
       </template>
     </UPageSection>
 
-    <!-- Persona Section -->
-    <UPageSection
-      id="requisitos"
-      orientation="horizontal"
-      :reverse="true"
-      class="bg-gray-200 text-black"
-    >
-      <template #title>
-        <span class="block text-2xl md:text-3xl text-center">
-          <span class="text-red-700">Requisitos</span>{{ ' ' }}<span class="text-black">para tu alquiler</span>
-        </span>
-      </template>
-      <template #description>
-        <div class="text-black justify-items-center">
-          <div class="mb-4 text-center">
-            En {{ franchise.shortname }} tu experiencia es sin complicaciones...
-          </div>
-          <ul class="flex flex-col gap-4">
-            <li class="flex items-start gap-2">
-              <LocationIcon cls="text-red-600 size-5 mt-0.5" />
-              <div>
-                <div class="font-bold text-black">RESERVA PREVIA</div>
-                <div class="text-black text-sm">(más anticipación más descuento)</div>
-              </div>
-            </li>
-            <li class="flex items-start gap-2">
-              <LocationIcon cls="text-red-600 size-5 mt-0.5" />
-              <div>
-                <div class="font-bold text-black">DOCUMENTO DE IDENTIDAD</div>
-                <div class="text-black text-sm">(18+ Cédula o pasaporte original)</div>
-              </div>
-            </li>
-            <li class="flex items-start gap-2">
-              <LocationIcon cls="text-red-600 size-5 mt-0.5" />
-              <div>
-                <div class="font-bold text-black">TARJETA DE CRÉDITO</div>
-                <div class="text-black text-sm">(Única forma de pago)</div>
-              </div>
-            </li>
-            <li class="flex items-start gap-2">
-              <LocationIcon cls="text-red-600 size-5 mt-0.5" />
-              <div>
-                <div class="font-bold text-black">LICENCIA DE CONDUCIR</div>
-                <div class="text-black text-sm">(física y vigente)</div>
-              </div>
-            </li>
-          </ul>
-        </div>
-      </template>
-      <template #default>
-        <!-- CLS fix: reservar espacio con aspect-ratio antes de que cargue la imagen -->
-        <div class="w-full aspect-[100/81]">
-          <LazyImagesPersona hydrate-on-visible />
-        </div>
-      </template>
-    </UPageSection>
+    <!-- Persona / Requisitos Section (shared with city pages) -->
+    <RequisitosSection />
 
     <!-- Vehicle Category Section -->
     <UPageSection
@@ -266,7 +212,6 @@ import type Testimonial from "@rentacar-main/logic/utils/types/type/Testimonial"
 /** components */
 import {
   IconsStarIcon as StarIcon,
-  IconsLocationIcon as LocationIcon,
 } from "#components";
 
 const { franchise } = useAppConfig();


### PR DESCRIPTION
## Problema

Los botones del menú **Requisitos**, **Sedes** y **Preguntas frecuentes** apuntaban a rutas absolutas con ancla (`/#requisitos`, `/#sedes`, `/#faqs`). Ese `/` inicial forzaba navegar al index aunque la sección ya existiera en la página actual, sacando al usuario de la ciudad y perdiendo su selección.

## Solución

Menú **context-aware**: en la home (`/`) y en cualquier página de ciudad (param `[city]`) los enlaces usan ancla relativa (`#requisitos`, `#faqs`) → scroll en sitio sin navegar. En el resto de páginas caen a `/#…`. `#sedes` vive en el layout (presente en toda página), así que siempre es relativo.

Para que `#requisitos` exista también en la página de ciudad, la sección se extrajo a un componente compartido y se renderiza en home + ciudad (antes de FAQs). `#faqs` ya existía en ambas.

De paso se corrigió el `active` del menú, que nunca matcheaba (`route.path` no incluye el hash) → ahora usa `route.hash`.

## Cambios por marca

- **alquilatucarro**: `RequisitosSection.vue` (nuevo) + index + CityPage + menú context-aware.
- **alquicarros**: igual que alquilatucarro.
- **alquilame**: solo menú (su home y CityPage ya renderizan `HomeRequirements` + `Faq` components).

## Extra

- `style(category-card)`: la píldora "sin pico y placa" se rellena con el verde `#a3f78b` del badge "Dto hoy" (solo alquilatucarro). Confirmado en preview.

## Validación

- agent-browser en dev (4000/4001/4002): `/bogota` muestra `#requisitos` + `#faqs`; los 3 enlaces del menú resuelven a `/bogota#…` sin rebote a la home; **cero page errors** en las tres marcas.
- `nuxt typecheck`: sin errores nuevos en los archivos tocados (los que arroja son preexistentes en `server/**`, `nuxt.config.ts`, `color:'white'` del header y `Testimonial` sin import).

## Nota de scope

La rama también incluye el commit `be8310c fix(searcher): guard calendar against null deselect (#123)` (3 marcas), que no forma parte de este trabajo de navegación pero quedó en la rama. Si se prefiere PR separado, avisar y lo extraigo.