### PR TITLE
feat(seo): abrir bots de entrenamiento IA en robots.txt en las 3 marcas (#71)

### DIFF
--- a/docs/specs/2026-06-13-issue-71-robots-ai-training-bots/scenarios/robots-ai-training-bots.scenarios.md
+++ b/docs/specs/2026-06-13-issue-71-robots-ai-training-bots/scenarios/robots-ai-training-bots.scenarios.md
@@ -1,0 +1,58 @@
+---
+name: robots-ai-training-bots
+created_by: claude
+created_at: 2026-06-13T00:00:00Z
+issue: 71
+---
+
+# robots.txt: abrir bots de entrenamiento IA en las 3 marcas (#71)
+
+Decisión de negocio del épico #63 (origen: auditoría agéntica 2026-05-26, #7).
+
+**Decisión tomada (operador, 2026-06-13): abrir las 3.** Permitir `GPTBot`,
+`CCBot`, `Google-Extended` (y los demás bots de entrenamiento) para maximizar
+*mindshare* en respuestas de IA. El contenido es comercial/transaccional, no IP
+propietaria — estar en el recall de los modelos es upside, no hay nada que
+proteger del training.
+
+## Estado previo (verificado en código)
+
+La política descrita en el issue **solo existía en 1 de las 3 marcas**:
+
+- `alquilatucarro` — `nuxt.config.ts` con `robots.groups` que **bloqueaba**
+  `GPTBot, Google-Extended, CCBot, Bytespider, Amazonbot` (`Disallow: /`).
+- `alquilame` / `alquicarros` — `robots` con `allow/disallow` plano sobre `*`,
+  **sin** grupos por-bot → ya permitían a todos los bots.
+
+La inconsistencia ya existía y 2/3 marcas ya estaban abiertas. "Abrir las 3"
+solo requiere quitar el grupo de bloqueo de `alquilatucarro`; las otras dos solo
+reciben un comentario que documenta la política para evitar que una auditoría
+futura reintroduzca el bloqueo (regresión cross-issue).
+
+## Nota de testing
+
+Los e2e corren contra el dev server (`pnpm --filter ui-* dev`), y en dev
+`nuxt-robots` fuerza `User-agent: *  Disallow: /` (indexación bloqueada). Para
+observar las reglas reales de producción el test usa el query `?mockProductionEnv`.
+
+## SCEN-001: GPTBot/CCBot/Google-Extended reciben Allow en las 3 marcas
+**Given**: el `robots.txt` generado de cada marca (`alquilatucarro`, `alquilame`, `alquicarros`), reglas de producción
+**When**: se evalúa la regla efectiva de robots.txt para `GPTBot`, `CCBot` y `Google-Extended` sobre el path `/`
+**Then**: cada uno está **permitido** (cae bajo `User-agent: *` con `Allow: /`); ningún grupo les aplica `Disallow: /`
+**Evidence**: `e2e/seo.spec.ts` → test "robots.txt debe permitir bots de entrenamiento IA (#71)", parametrizado por `BRAND`, parser de robots.txt que evalúa la regla efectiva por user-agent. Verificado: 3/3 marcas `passed`.
+
+## SCEN-002: el grupo de bloqueo desaparece del robots.txt de alquilatucarro
+**Given**: el `robots.txt` de producción de `alquilatucarro` (`?mockProductionEnv`)
+**When**: se inspecciona el contenido renderizado
+**Then**: **no** existe el grupo `User-agent: GPTBot / Google-Extended / CCBot / Bytespider / Amazonbot` con `Disallow: /`; el grupo de búsqueda IA (`OAI-SearchBot, PerplexityBot, Applebot-Extended → Allow: /`) se conserva intacto
+**Evidence**: `curl http://localhost:4000/robots.txt?mockProductionEnv` (2026-06-13) — el bloque de training bots ya no aparece; `User-agent: *` queda con `Allow: /` y `Disallow: /seo`.
+
+## SCEN-003: consistencia documentada en las 3 marcas
+**Given**: los `nuxt.config.ts` de las 3 marcas
+**When**: se revisa el bloque `robots`
+**Then**: ninguna marca bloquea bots de entrenamiento IA, y cada config lleva un comentario que marca la política abierta como deliberada (decisión #71) para impedir reintroducir el bloqueo
+**Evidence**: diff de `packages/ui-{alquilatucarro,alquilame,alquicarros}/nuxt.config.ts`.
+
+## Blast radius
+
+`nuxt.config.ts` de las 3 marcas (3 archivos) + el test e2e. Reversible.

--- a/e2e/seo.spec.ts
+++ b/e2e/seo.spec.ts
@@ -85,6 +85,69 @@ test.describe('SEO y metadatos', () => {
     expect(content).toContain('User-agent');
   });
 
+  // Issue #71: política de bots de entrenamiento IA.
+  // Decisión de negocio (#71): permitir GPTBot/CCBot/Google-Extended para
+  // maximizar mindshare en respuestas de IA, de forma consistente en las 3
+  // marcas. Este test corre por marca vía la env BRAND.
+  test('robots.txt debe permitir bots de entrenamiento IA (#71)', async ({ page }) => {
+    // En dev, nuxt-robots bloquea todo (Disallow: /). ?mockProductionEnv
+    // renderiza las reglas reales de producción (los groups de nuxt.config).
+    const response = await page.goto('/robots.txt?mockProductionEnv');
+    expect(response?.status()).toBe(200);
+    const content = (await page.textContent('body')) ?? '';
+
+    // Evalúa la regla efectiva de robots.txt para un user-agent sobre un path.
+    // Grupo aplicable: el que nombra exactamente el UA, o el de '*' si ninguno.
+    // Dentro del grupo gana el prefijo más largo; en empate gana Allow.
+    const isAllowed = (txt: string, ua: string, path: string): boolean => {
+      const lines = txt.split('\n').map((l) => l.trim());
+      type Group = { agents: string[]; rules: { allow: boolean; path: string }[] };
+      const groups: Group[] = [];
+      let current: Group | null = null;
+      let lastWasAgent = false;
+      for (const line of lines) {
+        if (!line || line.startsWith('#')) continue;
+        const [rawKey, ...rest] = line.split(':');
+        const key = rawKey.toLowerCase().trim();
+        const value = rest.join(':').trim();
+        if (key === 'user-agent') {
+          if (!current || !lastWasAgent) {
+            current = { agents: [], rules: [] };
+            groups.push(current);
+          }
+          current.agents.push(value.toLowerCase());
+          lastWasAgent = true;
+        } else if ((key === 'allow' || key === 'disallow') && current) {
+          current.rules.push({ allow: key === 'allow', path: value });
+          lastWasAgent = false;
+        } else {
+          lastWasAgent = false;
+        }
+      }
+      const named = groups.find((g) => g.agents.includes(ua.toLowerCase()));
+      const group = named ?? groups.find((g) => g.agents.includes('*'));
+      if (!group) return true; // sin reglas → permitido
+      let best: { allow: boolean; path: string } | null = null;
+      for (const rule of group.rules) {
+        if (rule.path === '' ) continue;
+        if (path.startsWith(rule.path)) {
+          if (
+            !best ||
+            rule.path.length > best.path.length ||
+            (rule.path.length === best.path.length && rule.allow)
+          ) {
+            best = rule;
+          }
+        }
+      }
+      return best ? best.allow : true;
+    };
+
+    for (const bot of ['GPTBot', 'CCBot', 'Google-Extended']) {
+      expect(isAllowed(content, bot, '/'), `${bot} debe poder rastrear /`).toBe(true);
+    }
+  });
+
   test('las páginas de ciudades deben tener canonical correcto', async ({ page }) => {
     const ciudades = ['bogota', 'medellin', 'cali'];
 

--- a/packages/ui-alquicarros/nuxt.config.ts
+++ b/packages/ui-alquicarros/nuxt.config.ts
@@ -649,6 +649,9 @@ export default defineNuxtConfig({
   },
 
   robots: {
+    // Bots de entrenamiento IA (GPTBot, CCBot, Google-Extended, etc.) permitidos
+    // vía wildcard. Decisión #71: priorizar mindshare en IA. No agregar grupos de
+    // bloqueo aquí — rompe la consistencia con las 3 marcas.
     blockNonSeoBots: false,
     disallow: ['/seo', '/seo/*'],
     allow: [

--- a/packages/ui-alquilame/nuxt.config.ts
+++ b/packages/ui-alquilame/nuxt.config.ts
@@ -662,6 +662,9 @@ export default defineNuxtConfig({
   },
 
   robots: {
+    // Bots de entrenamiento IA (GPTBot, CCBot, Google-Extended, etc.) permitidos
+    // vía wildcard. Decisión #71: priorizar mindshare en IA. No agregar grupos de
+    // bloqueo aquí — rompe la consistencia con las 3 marcas.
     blockNonSeoBots: false,
     disallow: ['/seo', '/seo/*'],
     allow: [

--- a/packages/ui-alquilatucarro/nuxt.config.ts
+++ b/packages/ui-alquilatucarro/nuxt.config.ts
@@ -713,11 +713,10 @@ export default defineNuxtConfig({
         userAgent: ['OAI-SearchBot', 'PerplexityBot', 'Applebot-Extended'],
         allow: ['/'],
       },
-      // Bots de entrenamiento IA — bloqueados (consumen sin retorno)
-      {
-        userAgent: ['GPTBot', 'Google-Extended', 'CCBot', 'Bytespider', 'Amazonbot'],
-        disallow: ['/'],
-      },
+      // Bots de entrenamiento IA (GPTBot, Google-Extended, CCBot, Bytespider,
+      // Amazonbot) — permitidos vía '*'. Decisión #71: priorizar mindshare en
+      // respuestas de IA sobre proteger el contenido del training. Consistente
+      // con alquilame y alquicarros, que ya permiten estos bots.
     ],
     sitemap: "/sitemap.xml"
   },


### PR DESCRIPTION
Cierra #71 (épico #63 · auditoría agéntica #7).

## Decisión de negocio (aprobada por operador)

Abrir `GPTBot`, `CCBot`, `Google-Extended` (y demás bots de entrenamiento) para maximizar *mindshare* en respuestas de IA. El contenido es comercial/transaccional, no IP propietaria — estar en el recall de los modelos es upside; no hay nada que proteger del training.

## Contexto que cambió el marco

La política de bloqueo **solo existía en `alquilatucarro`**. `alquilame` y `alquicarros` ya permitían a todos los bots (sin grupos por-bot). Es decir, la inconsistencia ya existía y 2/3 marcas ya estaban abiertas.

## Cambios

| Archivo | Cambio |
|---|---|
| `ui-alquilatucarro/nuxt.config.ts` | **Funcional**: elimina el grupo que bloqueaba `GPTBot/Google-Extended/CCBot/Bytespider/Amazonbot`. Ahora caen bajo `*` → `Allow: /` |
| `ui-alquilame/nuxt.config.ts` | Comentario documentando la política abierta (sin cambio funcional) |
| `ui-alquicarros/nuxt.config.ts` | Igual comentario (anti-regresión cross-issue) |
| `e2e/seo.spec.ts` | Test del escenario, parametrizado por `BRAND`, con parser de robots.txt |
| `docs/specs/2026-06-13-issue-71-.../scenarios/...md` | Doc de escenarios (holdout) |

## Escenario observable

**Given** robots.txt de producción, **When** lo lee `GPTBot`/`CCBot`/`Google-Extended`, **Then** recibe `Allow`, consistente en las 3 marcas.

## Verificación

- **E2E del escenario**: `passed` en las 3 marcas (alquilatucarro, alquilame, alquicarros).
- **robots.txt de producción** (alquilatucarro, vía `?mockProductionEnv`): el grupo de bloqueo desapareció; queda `User-agent: *  Allow: /  Disallow: /seo`.
- **Suite unit completa**: 554 tests verdes.

> Nota: en dev, `nuxt-robots` fuerza `Disallow: /`; el test usa `?mockProductionEnv` para observar las reglas reales de producción.

## Blast radius

`nuxt.config.ts` de las 3 marcas + test e2e. Reversible.