### PR TITLE
fix(searcher): hour labels casing + calendar contrast & weekday alignment

### DIFF
--- a/packages/logic/src/composables/useSearch.ts
+++ b/packages/logic/src/composables/useSearch.ts
@@ -33,9 +33,9 @@ const generateHourOptions = () => {
 
   while (initHour.compare(endHour) < 0) {
     if (initHour.toString() === "00:00:00") {
-      options.push({ value: "00:00", label: "MEDIANOCHE" });
+      options.push({ value: "00:00", label: "Medianoche" });
     } else if (initHour.toString() === "12:00:00") {
-      options.push({ value: "12:00", label: "MEDIODIA" });
+      options.push({ value: "12:00", label: "Mediodía" });
     } else {
       const datetime = toDatetime(createCurrentDateObject(), initHour);
       options.push({ value: formatTime(datetime), label: formatHumanTime(datetime) });

--- a/packages/ui-alquicarros/app/components/Searcher.vue
+++ b/packages/ui-alquicarros/app/components/Searcher.vue
@@ -346,7 +346,8 @@ const returnDateCalendarOpen = ref<boolean>(false);
 // Calendar UI configuration for better contrast
 const calendarUIConfig = {
     heading: '!text-gray-900 !font-bold',
-    cellTrigger: '!text-gray-900 !font-semibold data-[disabled]:!text-gray-300 data-[disabled]:!opacity-40 data-[unavailable]:!text-gray-300 data-[unavailable]:!opacity-40 data-[outside-view]:!text-gray-400 data-[outside-view]:!opacity-50'
+    gridRow: 'w-full',
+    cellTrigger: '!text-gray-900 !font-semibold data-[disabled]:!text-gray-400 data-[disabled]:!opacity-50 data-[unavailable]:!text-gray-400 data-[unavailable]:!opacity-50 data-[outside-view]:!text-gray-400 data-[outside-view]:!opacity-50'
 };
 
 // bfcache restoration: the Searcher has 15+ watchers binding local refs to

--- a/packages/ui-alquilame/app/components/Searcher.vue
+++ b/packages/ui-alquilame/app/components/Searcher.vue
@@ -348,7 +348,8 @@ const returnDateCalendarOpen = ref<boolean>(false);
 // Calendar UI configuration for better contrast
 const calendarUIConfig = {
     heading: '!text-gray-900 !font-bold',
-    cellTrigger: '!text-gray-900 !font-semibold data-[disabled]:!text-gray-300 data-[disabled]:!opacity-40 data-[unavailable]:!text-gray-300 data-[unavailable]:!opacity-40 data-[outside-view]:!text-gray-400 data-[outside-view]:!opacity-50'
+    gridRow: 'w-full',
+    cellTrigger: '!text-gray-900 !font-semibold data-[disabled]:!text-gray-400 data-[disabled]:!opacity-50 data-[unavailable]:!text-gray-400 data-[unavailable]:!opacity-50 data-[outside-view]:!text-gray-400 data-[outside-view]:!opacity-50'
 };
 
 // bfcache restoration: the Searcher has 15+ watchers binding local refs to

--- a/packages/ui-alquilatucarro/app/components/Searcher.vue
+++ b/packages/ui-alquilatucarro/app/components/Searcher.vue
@@ -346,7 +346,8 @@ const returnDateCalendarOpen = ref<boolean>(false);
 // Calendar UI configuration for better contrast
 const calendarUIConfig = {
     heading: '!text-gray-900 !font-bold',
-    cellTrigger: '!text-gray-900 !font-semibold data-[disabled]:!text-gray-300 data-[disabled]:!opacity-40 data-[unavailable]:!text-gray-300 data-[unavailable]:!opacity-40 data-[outside-view]:!text-gray-400 data-[outside-view]:!opacity-50'
+    gridRow: 'w-full',
+    cellTrigger: '!text-gray-900 !font-semibold data-[disabled]:!text-gray-400 data-[disabled]:!opacity-50 data-[unavailable]:!text-gray-400 data-[unavailable]:!opacity-50 data-[outside-view]:!text-gray-400 data-[outside-view]:!opacity-50'
 };
 
 // bfcache restoration: the Searcher has 15+ watchers binding local refs to


### PR DESCRIPTION
## Qué

Tres ajustes en el buscador (las 3 marcas):

1. **Etiquetas de hora** — `MEDIODIA`/`MEDIANOCHE` → `Mediodía`/`Medianoche` en `useSearch.ts` (lógica compartida, aplica a las 3 marcas).
2. **Contraste del calendario** — días pasados/no disponibles pasan de `gray-300 + opacity-40` a `gray-400 + opacity-50`, para que sigan visibles en pantallas de bajo contraste (igualados al gris de los días del mes siguiente).
3. **Alineación encabezados** — se añade `gridRow: 'w-full'` al `calendarUIConfig`. El theme de `<u-calendar>` daba `w-full` solo a la fila de los nombres de día, no a la de números, lo que desalineaba las columnas. Ahora ambas usan el mismo modelo de ancho.

## Verificación

- `pnpm --filter @rentacar-main/logic test` → **361 tests pasan**.
- QA visual con agent-browser en **alquilatucarro** (desktop):
  - Dropdown de hora muestra "Mediodía" (12:00, seleccionado) y "Medianoche" (00:00).
  - Días pasados/mes siguiente con gris medio uniforme y visible.
  - **Offset 0px** medido por JS en las 7 columnas (letra centrada sobre su número).
  - **Cero errores de consola** (solo warnings preexistentes de `image.screens`).

Cambios idénticos en los 3 `Searcher.vue`; verificado en la marca de producción (alquilatucarro). El formato de fecha "14 junio 2026" quedó **descartado** por decisión del owner (sigue 14/06/2026).