### PR TITLE
feat(attribution): capture click-id + utm + referrer and forward attribution in the reservation (#121)

### DIFF
--- a/packages/logic/src/composables/__tests__/useRecordReservationForm.attribution.test.ts
+++ b/packages/logic/src/composables/__tests__/useRecordReservationForm.attribution.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Contract boundary (issue #121 / Apéndice A de rentacar-dashboard#113): the
+// record payload must ALWAYS carry an `attribution` object — `{}` means
+// "Directo", an absent key would mean "Desconocido". These source-level checks
+// mirror the existing `total_insurance` test approach (fully mocking Nuxt
+// auto-imports + Pinia + ofetch in the node env is not worth it here); the real
+// runtime payload is asserted separately via agent-browser.
+
+const recordSource = readFileSync(
+  fileURLToPath(new URL('../useRecordReservationForm.ts', import.meta.url)),
+  'utf8',
+);
+
+const fieldsSource = readFileSync(
+  fileURLToPath(new URL('../../utils/types/fields/FormRecordFields.ts', import.meta.url)),
+  'utf8',
+);
+
+describe('useRecordReservationForm — attribution payload', () => {
+  it('reads attribution from the store via storeToRefs', () => {
+    expect(recordSource).toMatch(/attribution,/);
+    expect(recordSource).toContain('storeToRefs(storeForm)');
+  });
+
+  it('always assigns an object: store value, then storage fallback, then {} (Directo)', () => {
+    expect(recordSource).toContain(
+      'partialData.attribution = attribution.value ?? readStoredAttribution() ?? {};',
+    );
+  });
+
+  it('never sends attribution as null (would be "Desconocido", not "Directo")', () => {
+    expect(recordSource).not.toMatch(/attribution\s*=\s*attribution\.value\s*\?\?\s*null/);
+  });
+
+  it('assigns attribution BEFORE both reservation branches so the spread keeps it', () => {
+    const assignIdx = recordSource.indexOf('partialData.attribution =');
+    const monthlyIdx = recordSource.indexOf('haveMonthlyReservation.value');
+    const regularIdx = recordSource.indexOf('// reserva regular');
+    expect(assignIdx).toBeGreaterThan(-1);
+    expect(assignIdx).toBeLessThan(monthlyIdx);
+    expect(assignIdx).toBeLessThan(regularIdx);
+    // both branches build formData by spreading partialData → attribution rides along
+    expect(recordSource).toMatch(/\.\.\.partialData,[\s\S]*\.\.\.partialData,/);
+  });
+});
+
+describe('FormRecordFields — attribution type', () => {
+  it('declares an optional attribution field of type AttributionInput', () => {
+    expect(fieldsSource).toMatch(/attribution\?:\s*AttributionInput/);
+  });
+});

--- a/packages/logic/src/composables/useRecordReservationForm.ts
+++ b/packages/logic/src/composables/useRecordReservationForm.ts
@@ -8,6 +8,9 @@ import type { FetchError } from 'ofetch';
 import useStoreReservationForm from '../stores/useStoreReservationForm';
 import useStoreSearchData from '../stores/useStoreSearchData';
 
+// Internal dependencies - utils
+import { readStoredAttribution } from '@rentacar-main/logic/utils';
+
 // Types
 import type { FormRecordFields, RecordReservationApiData } from '@rentacar-main/logic/utils';
 
@@ -41,6 +44,7 @@ export default async function useRecordReservationForm() {
     haveTotalInsurance,
     haveMonthlyReservation,
     selectedMonthlyMileage,
+    attribution,
   } = storeToRefs(storeForm);
 
   const { selectedCategory } = storeToRefs(useStoreSearchData());
@@ -77,6 +81,11 @@ export default async function useRecordReservationForm() {
   };
 
   if (referido.value) partialData["user"] = referido.value;
+
+  // Marketing attribution: prefer the store's last-touch, fall back to storage
+  // (e.g. store re-created mid-session). Always send an object — `{}` signals
+  // "Directo" to the dashboard; an absent key would signal "Desconocido".
+  partialData.attribution = attribution.value ?? readStoredAttribution() ?? {};
 
   let total_price_to_pay: number = 0,
     total_price: number = 0;

--- a/packages/logic/src/stores/useStoreReservationForm.ts
+++ b/packages/logic/src/stores/useStoreReservationForm.ts
@@ -19,6 +19,9 @@ import {
   formatHumanDate,
   formatHumanTime,
   toDatetime,
+  buildAttributionTouch,
+  persistAttribution,
+  readStoredAttribution,
 } from '@rentacar-main/logic/utils';
 
 // Types
@@ -31,6 +34,7 @@ import type {
   TimeObject,
   ReservationWithFlightFormValidationSchemaType,
   ReservationFormValidationSchemaType,
+  AttributionInput,
 } from '@rentacar-main/logic/utils';
 
 
@@ -58,6 +62,34 @@ const useStoreReservationForm = defineStore("reservationForm", () => {
   const email = ref<string | null>(null);
 
   const aerolinea = ref<string | null>(null);
+
+  // Marketing attribution (click-id + utm + external referrer). Captured by the
+  // per-brand client plugin on load; the record composable reads it at submit.
+  const attribution = ref<AttributionInput | null>(null);
+
+  // Client-only. Reads the current URL + referrer; if this load is a real touch
+  // (has a click-id/utm or an external referrer) it overwrites the stored
+  // last-touch. Otherwise it seeds from storage so a signal captured earlier in
+  // the funnel survives to the reservation. Never throws — attribution must
+  // never break hydration or the reservation flow.
+  function captureAttribution(): void {
+    if (typeof window === 'undefined') return;
+    try {
+      const { attribution: touch, isTouch } = buildAttributionTouch(
+        window.location.search,
+        document.referrer,
+        window.location.hostname,
+      );
+      if (isTouch) {
+        attribution.value = touch;
+        persistAttribution(touch);
+      } else if (attribution.value === null) {
+        attribution.value = readStoredAttribution();
+      }
+    } catch {
+      /* never block the flow on attribution capture */
+    }
+  }
   const numeroVueloIda = ref<string | null>(null);
   const referido = ref<string | null>(null);
 
@@ -261,6 +293,7 @@ const useStoreReservationForm = defineStore("reservationForm", () => {
     numeroVueloIda,
     politicaPrivacidad,
     referido,
+    attribution,
     // other vars
     selectedDays,
     selectedMonthlyMileage,
@@ -269,6 +302,7 @@ const useStoreReservationForm = defineStore("reservationForm", () => {
     haveMonthlyReservation,
     haveFlight,
     // functions
+    captureAttribution,
     registerConvertion,
     serverFailed,
     submitForm,

--- a/packages/logic/src/utils/__tests__/attributionStorage.test.ts
+++ b/packages/logic/src/utils/__tests__/attributionStorage.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  persistAttribution,
+  readStoredAttribution,
+  ATTRIBUTION_STORAGE_KEY,
+} from '@rentacar-main/logic/utils';
+
+// Minimal in-memory localStorage stub (node vitest env has no DOM storage).
+function createStorageMock(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear: () => map.clear(),
+    getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+    key: (i: number) => Array.from(map.keys())[i] ?? null,
+    removeItem: (k: string) => void map.delete(k),
+    setItem: (k: string, v: string) => void map.set(k, String(v)),
+  } as Storage;
+}
+
+const DAY = 24 * 60 * 60 * 1000;
+
+describe('attributionStorage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', createStorageMock());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('persists and reads back the attribution object (roundtrip)', () => {
+    persistAttribution({ gclid: 'ABC' }, 1_000);
+    expect(readStoredAttribution(1_000)).toEqual({ gclid: 'ABC' });
+  });
+
+  it('returns null when nothing is stored', () => {
+    expect(readStoredAttribution(1_000)).toBeNull();
+  });
+
+  it('SCEN-W3: a signal stored on the landing survives a later read within 90 days', () => {
+    persistAttribution({ fbclid: 'fb1' }, 0);
+    // user reserves 89 days later, several pages deep, with no param in the URL
+    expect(readStoredAttribution(89 * DAY)).toEqual({ fbclid: 'fb1' });
+  });
+
+  it('expires entries older than 90 days and clears them', () => {
+    persistAttribution({ gclid: 'old' }, 0);
+    expect(readStoredAttribution(91 * DAY)).toBeNull();
+    // expired entry was removed, so a fresh read at t0 is also null
+    expect(localStorage.getItem(ATTRIBUTION_STORAGE_KEY)).toBeNull();
+  });
+
+  it('SCEN-W4: last-touch — a newer persisted touch overwrites the previous one', () => {
+    persistAttribution({ gclid: 'first' }, 0);
+    persistAttribution({ fbclid: 'second' }, 10 * DAY);
+    expect(readStoredAttribution(10 * DAY)).toEqual({ fbclid: 'second' });
+  });
+
+  it('returns null on corrupt stored JSON', () => {
+    localStorage.setItem(ATTRIBUTION_STORAGE_KEY, '{not valid json');
+    expect(readStoredAttribution(1_000)).toBeNull();
+  });
+
+  it('degrades to no-op / null when localStorage is unavailable', () => {
+    vi.unstubAllGlobals(); // remove the stub → typeof localStorage === 'undefined'
+    expect(() => persistAttribution({ gclid: 'x' }, 0)).not.toThrow();
+    expect(readStoredAttribution(0)).toBeNull();
+  });
+});

--- a/packages/logic/src/utils/__tests__/buildAttributionTouch.test.ts
+++ b/packages/logic/src/utils/__tests__/buildAttributionTouch.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { buildAttributionTouch } from '@rentacar-main/logic/utils';
+
+const HOST = 'alquilatucarro.com';
+
+describe('buildAttributionTouch — signal extraction', () => {
+  it('SCEN-W1: captures gclid from the query string', () => {
+    const { attribution, isTouch } = buildAttributionTouch('?gclid=ABC', '', HOST);
+    expect(attribution.gclid).toBe('ABC');
+    expect(isTouch).toBe(true);
+  });
+
+  it('SCEN-W2: maps every click-id and utm to its field', () => {
+    const search =
+      '?utm_source=facebook&utm_medium=cpc&gclid=g1&gad_source=1&fbclid=fb1&ttclid=tt1&msclkid=ms1';
+    const { attribution, isTouch } = buildAttributionTouch(search, '', HOST);
+    expect(attribution).toEqual({
+      utm_source: 'facebook',
+      utm_medium: 'cpc',
+      gclid: 'g1',
+      gad_source: '1',
+      fbclid: 'fb1',
+      ttclid: 'tt1',
+      msclkid: 'ms1',
+    });
+    expect(isTouch).toBe(true);
+  });
+
+  it('accepts a URLSearchParams instance as input', () => {
+    const params = new URLSearchParams({ msclkid: 'bing123' });
+    const { attribution } = buildAttributionTouch(params, '', HOST);
+    expect(attribution.msclkid).toBe('bing123');
+  });
+
+  it('trims surrounding whitespace and ignores empty params', () => {
+    const { attribution, isTouch } = buildAttributionTouch('?gclid=%20%20&fbclid=%20fb%20', '', HOST);
+    expect(attribution.gclid).toBeUndefined(); // whitespace-only → dropped
+    expect(attribution.fbclid).toBe('fb');
+    expect(isTouch).toBe(true);
+  });
+
+  it('includes an EXTERNAL referrer and flags a touch', () => {
+    const { attribution, isTouch } = buildAttributionTouch('', 'https://www.google.com/', HOST);
+    expect(attribution.referrer).toBe('https://www.google.com/');
+    expect(isTouch).toBe(true);
+  });
+
+  it('excludes a same-host referrer (internal navigation is not a touch)', () => {
+    const { attribution, isTouch } = buildAttributionTouch(
+      '',
+      'https://alquilatucarro.com/bogota/buscar-vehiculos',
+      HOST,
+    );
+    expect(attribution.referrer).toBeUndefined();
+    expect(isTouch).toBe(false);
+  });
+
+  it('treats www and apex as the same host', () => {
+    const { isTouch } = buildAttributionTouch('', 'https://www.alquilatucarro.com/', HOST);
+    expect(isTouch).toBe(false);
+  });
+
+  it('ignores a malformed referrer', () => {
+    const { attribution, isTouch } = buildAttributionTouch('', 'not-a-url', HOST);
+    expect(attribution.referrer).toBeUndefined();
+    expect(isTouch).toBe(false);
+  });
+
+  it('SCEN-W5: no params and no external referrer → empty object, not a touch', () => {
+    const { attribution, isTouch } = buildAttributionTouch('', '', HOST);
+    expect(attribution).toEqual({});
+    expect(isTouch).toBe(false);
+  });
+
+  it('still captures utm when a click-id is absent', () => {
+    const { attribution, isTouch } = buildAttributionTouch('?utm_source=newsletter&utm_medium=email', '', HOST);
+    expect(attribution).toEqual({ utm_source: 'newsletter', utm_medium: 'email' });
+    expect(isTouch).toBe(true);
+  });
+});

--- a/packages/logic/src/utils/attribution/attributionStorage.ts
+++ b/packages/logic/src/utils/attribution/attributionStorage.ts
@@ -1,0 +1,61 @@
+// localStorage persistence for captured attribution, with a 90-day TTL and
+// last-touch semantics (every persisted touch overwrites the previous one).
+// This is what makes attribution survive across pages: a signal captured on the
+// landing page is still there when the user reserves several pages later.
+//
+// All access is guarded: SSR (no `localStorage`), privacy mode, and quota
+// errors degrade to a no-op / null instead of throwing — attribution must never
+// break the reservation flow.
+
+import type AttributionInput from '../types/type/AttributionInput';
+
+export const ATTRIBUTION_STORAGE_KEY = 'rentacar_attribution';
+const TTL_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
+
+interface StoredAttribution {
+  data: AttributionInput;
+  ts: number;
+}
+
+function getStore(): Storage | null {
+  try {
+    return typeof localStorage !== 'undefined' ? localStorage : null;
+  } catch {
+    return null; // access denied (privacy mode / disabled storage)
+  }
+}
+
+export function persistAttribution(
+  attribution: AttributionInput,
+  now: number = Date.now(),
+): void {
+  const store = getStore();
+  if (!store) return;
+  try {
+    const payload: StoredAttribution = { data: attribution, ts: now };
+    store.setItem(ATTRIBUTION_STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    /* quota exceeded / disabled — non-fatal */
+  }
+}
+
+export function readStoredAttribution(now: number = Date.now()): AttributionInput | null {
+  const store = getStore();
+  if (!store) return null;
+  try {
+    const raw = store.getItem(ATTRIBUTION_STORAGE_KEY);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as StoredAttribution;
+    if (!parsed || typeof parsed.ts !== 'number' || typeof parsed.data !== 'object') {
+      return null;
+    }
+    if (now - parsed.ts > TTL_MS) {
+      store.removeItem(ATTRIBUTION_STORAGE_KEY); // expired → drop it
+      return null;
+    }
+    return parsed.data;
+  } catch {
+    return null; // corrupt JSON / access error
+  }
+}

--- a/packages/logic/src/utils/attribution/buildAttributionTouch.ts
+++ b/packages/logic/src/utils/attribution/buildAttributionTouch.ts
@@ -1,0 +1,67 @@
+// Pure extraction of marketing attribution signals from a URL query string and
+// `document.referrer`. No DOM, no storage — so each branch is unit-testable in
+// the node vitest env. Side effects (persistence) live in `attributionStorage`.
+//
+// A "touch" = the page load carries at least one marketing signal: a click-id,
+// a utm_* param, or an EXTERNAL referrer. Internal navigation (referrer host ==
+// own host) is NOT a touch, so it never overwrites a previously captured touch.
+
+import type AttributionInput from '../types/type/AttributionInput';
+
+// Order mirrors the contract (Apéndice A de rentacar-dashboard#113).
+const SIGNAL_KEYS = [
+  'utm_source',
+  'utm_medium',
+  'gclid',
+  'gad_source',
+  'fbclid',
+  'ttclid',
+  'msclkid',
+] as const;
+
+export interface AttributionTouch {
+  /** Captured signals. `{}` when the load carries nothing relevant. */
+  attribution: AttributionInput;
+  /** True when this load should overwrite stored attribution (last-touch). */
+  isTouch: boolean;
+}
+
+/** Strip a leading `www.` so apex ↔ www referrers count as the same host. */
+function normalizeHost(host: string): string {
+  return host.replace(/^www\./i, '').toLowerCase();
+}
+
+/** Returns the referrer only when it points to a DIFFERENT (external) host. */
+function pickExternalReferrer(referrer: string, currentHost: string): string | null {
+  if (!referrer) return null;
+  try {
+    const referrerHost = normalizeHost(new URL(referrer).hostname);
+    if (!referrerHost || referrerHost === normalizeHost(currentHost)) return null;
+    return referrer;
+  } catch {
+    return null; // malformed referrer → ignore
+  }
+}
+
+export default function buildAttributionTouch(
+  search: string | URLSearchParams,
+  referrer: string,
+  currentHost: string,
+): AttributionTouch {
+  const params = typeof search === 'string' ? new URLSearchParams(search) : search;
+  const attribution: AttributionInput = {};
+  let hasParam = false;
+
+  for (const key of SIGNAL_KEYS) {
+    const value = params.get(key)?.trim();
+    if (value) {
+      attribution[key] = value;
+      hasParam = true;
+    }
+  }
+
+  const externalReferrer = pickExternalReferrer(referrer, currentHost);
+  if (externalReferrer) attribution.referrer = externalReferrer;
+
+  return { attribution, isTouch: hasParam || externalReferrer !== null };
+}

--- a/packages/logic/src/utils/index.ts
+++ b/packages/logic/src/utils/index.ts
@@ -32,6 +32,17 @@ export { buildCityReservationURL } from './buildCityReservationURL';
 export type { CityReservationDates } from './buildCityReservationURL';
 
 // ============================================================================
+// Attribution (marketing origin capture)
+// ============================================================================
+export { default as buildAttributionTouch } from './attribution/buildAttributionTouch';
+export type { AttributionTouch } from './attribution/buildAttributionTouch';
+export {
+  persistAttribution,
+  readStoredAttribution,
+  ATTRIBUTION_STORAGE_KEY,
+} from './attribution/attributionStorage';
+
+// ============================================================================
 // Server Helpers
 // ============================================================================
 export { extractStructuredError } from './helpers/extractStructuredError';
@@ -73,6 +84,7 @@ export type { default as CategoryProps } from './types/props/CategoryProps';
 // ============================================================================
 // Type Definitions - General Types
 // ============================================================================
+export type { default as AttributionInput } from './types/type/AttributionInput';
 export type { default as City } from './types/type/City';
 export type { default as FAQ } from './types/type/FAQ';
 export type { default as Testimonial } from './types/type/Testimonial';

--- a/packages/logic/src/utils/types/fields/FormRecordFields.ts
+++ b/packages/logic/src/utils/types/fields/FormRecordFields.ts
@@ -1,5 +1,6 @@
 import { type CategoryType } from '../type/CategoryType';
 import { type MonthlyMileage } from '../type/MonthlyMileage';
+import type AttributionInput from '../type/AttributionInput';
 
 export default interface FormFields {
   fullname: string | null;
@@ -36,4 +37,5 @@ export default interface FormFields {
   aeroline?: string | null;
   flight_number?: string | null;
   monthly_mileage?: MonthlyMileage | null;
+  attribution?: AttributionInput;
 }

--- a/packages/logic/src/utils/types/type/AttributionInput.ts
+++ b/packages/logic/src/utils/types/type/AttributionInput.ts
@@ -1,0 +1,15 @@
+// Raw marketing attribution signals captured from the ad URL (click-ids + utm)
+// plus the external `document.referrer`, forwarded inside the reservation
+// payload as the `attribution` object. Mirrors the receiver contract
+// (Apéndice A de rentacar-dashboard#113). Channel derivation lives in the
+// dashboard — this side only captures and forwards the raw signals.
+export default interface AttributionInput {
+  utm_source?: string | null;
+  utm_medium?: string | null;
+  gclid?: string | null;
+  gad_source?: string | null;
+  fbclid?: string | null;
+  ttclid?: string | null;
+  msclkid?: string | null;
+  referrer?: string | null;
+}

--- a/packages/ui-alquicarros/app/plugins/attribution.client.ts
+++ b/packages/ui-alquicarros/app/plugins/attribution.client.ts
@@ -1,0 +1,14 @@
+// Capture marketing attribution (click-ids + utm + external referrer) on each
+// client load and persist it last-touch (~90 days) in localStorage, so the
+// reservation payload can forward it to the dashboard as the `attribution`
+// object. See issue #121 and the receiver contract (Apéndice A de
+// rentacar-dashboard#113). The capture itself lives in `packages/logic`
+// (store action + pure util), shared by the three brands; only this trigger
+// is per-package because Nuxt plugins are not part of the layer.
+export default defineNuxtPlugin(() => {
+  try {
+    useStoreReservationForm().captureAttribution()
+  } catch {
+    /* never block hydration on attribution capture */
+  }
+})

--- a/packages/ui-alquilame/app/plugins/attribution.client.ts
+++ b/packages/ui-alquilame/app/plugins/attribution.client.ts
@@ -1,0 +1,14 @@
+// Capture marketing attribution (click-ids + utm + external referrer) on each
+// client load and persist it last-touch (~90 days) in localStorage, so the
+// reservation payload can forward it to the dashboard as the `attribution`
+// object. See issue #121 and the receiver contract (Apéndice A de
+// rentacar-dashboard#113). The capture itself lives in `packages/logic`
+// (store action + pure util), shared by the three brands; only this trigger
+// is per-package because Nuxt plugins are not part of the layer.
+export default defineNuxtPlugin(() => {
+  try {
+    useStoreReservationForm().captureAttribution()
+  } catch {
+    /* never block hydration on attribution capture */
+  }
+})

--- a/packages/ui-alquilatucarro/app/plugins/attribution.client.ts
+++ b/packages/ui-alquilatucarro/app/plugins/attribution.client.ts
@@ -1,0 +1,14 @@
+// Capture marketing attribution (click-ids + utm + external referrer) on each
+// client load and persist it last-touch (~90 days) in localStorage, so the
+// reservation payload can forward it to the dashboard as the `attribution`
+// object. See issue #121 and the receiver contract (Apéndice A de
+// rentacar-dashboard#113). The capture itself lives in `packages/logic`
+// (store action + pure util), shared by the three brands; only this trigger
+// is per-package because Nuxt plugins are not part of the layer.
+export default defineNuxtPlugin(() => {
+  try {
+    useStoreReservationForm().captureAttribution()
+  } catch {
+    /* never block hydration on attribution capture */
+  }
+})


### PR DESCRIPTION
Implementa **#121** (Fase 1: captura + reenvío). La derivación del canal y el reporte viven en el dashboard (**#113**, ya cerrado). Contrato receptor: Apéndice A de rentacar-dashboard#113.

## Qué hace
Captura las señales que las plataformas inyectan en la URL del anuncio (`gclid`, `gad_source`, `fbclid`, `ttclid`, `msclkid`, `utm_*`) + `document.referrer` externo, las persiste **last-touch ~90 días** en `localStorage`, y las envía como objeto `attribution` en el payload que crea la reserva.

- Sin señales → `attribution: {}` (Directo). Nunca `null` ni clave ausente.

## Cambios
**Compartido en `packages/logic` (cubre las 3 marcas):**
- `utils/types/type/AttributionInput.ts` — tipo con las 8 claves del contrato + export en el barrel
- `utils/attribution/buildAttributionTouch.ts` — extracción **pura** (URL + referrer externo; navegación interna y `www`↔apex **no** son touch)
- `utils/attribution/attributionStorage.ts` — `localStorage`, TTL 90 días, last-touch, degradación segura (SSR / modo privado / quota / JSON corrupto nunca lanzan)
- `stores/useStoreReservationForm.ts` — ref `attribution` + action `captureAttribution()`
- `composables/useRecordReservationForm.ts` — inyecta `attribution: <last-touch> ?? stored ?? {}`
- `utils/types/fields/FormRecordFields.ts` — `attribution?: AttributionInput`

**Por marca (3×):** `app/plugins/attribution.client.ts` dispara la captura al cargar.

El proxy Nitro `record.post.ts` ya reenvía el body completo sin filtrar → sin cambio.

## Verificación
- ✅ **383 tests** vitest (CI). Extracción por señal, exclusión de referrer propio/`www`, vacío→`{}`, storage roundtrip/expiración/last-touch, y un check de contrato del payload (`attribution` llega al body como `{}` vs poblado, en ambas ramas de reserva).
- ✅ **Revisión adversarial** (sub-agente): sin P0.
- ✅ **QA runtime agent-browser (local)** — escenarios de **captura + persistencia**:
  - **SCEN-W1** `?gclid=ABC123` → `{gclid, utm_source, utm_medium}` en storage
  - **SCEN-W2** mapeo de click-ids/utm a sus campos
  - **SCEN-W3** navegación cross-page sin el param → persiste
  - **SCEN-W4** nuevo click-id → sobrescribe (last-touch)
  - **SCEN-W5** sin señales → no captura → `{}`
  - Cero errores de consola propios.

## Pendiente en este PR (preview)
La aserción **end-to-end del POST** (que `attribution` llega al proxy/dashboard recorriendo el embudo) **no corre en local** — las páginas de búsqueda/reserva dan 500 en local (límite env-only documentado). **Se valida en el preview de Vercel de este PR**, en las 3 marcas, antes de merge.

Closes #121