### PR TITLE
feat(tracking): GA4 clic_boton_llamada en el botón de llamada

### DIFF
--- a/packages/ui-alquilatucarro/nuxt.config.ts
+++ b/packages/ui-alquilatucarro/nuxt.config.ts
@@ -443,6 +443,15 @@ export default defineNuxtConfig({
           innerHTML:
             "(function(){document.addEventListener('click',function(e){try{var t=e.target;if(!t||typeof t.closest!=='function')return;var a=t.closest('a[href*=\"wa.me\"],a[href*=\"api.whatsapp.com\"],a[href*=\"web.whatsapp.com\"]');if(!a||typeof window.gtag!=='function')return;window.gtag('event','clic_boton_whatsapp');}catch(_e){}},true);})();",
         },
+        // Google Ads conversion — fires the GA4 event `clic_boton_llamada` on
+        // every call-button click via event delegation (mirror of the WhatsApp
+        // event above). `tel:` links open the dialer without unloading the page,
+        // so gtag's sendBeacon transport always reaches GA4. Capture phase,
+        // never preventDefault → native dialer + the beacon both run.
+        {
+          innerHTML:
+            "(function(){document.addEventListener('click',function(e){try{var t=e.target;if(!t||typeof t.closest!=='function')return;var a=t.closest('a[href^=\"tel:\"]');if(!a||typeof window.gtag!=='function')return;window.gtag('event','clic_boton_llamada');}catch(_e){}},true);})();",
+        },
         // WhatsApp attribution click beacon (shared connector). Event delegation
         // over wa.me anchors — fires a ping on every WhatsApp click without
         // touching the button. data-ga4 lets it use the GA4 client_id as


### PR DESCRIPTION
## Qué

Dispara el evento GA4 `clic_boton_llamada` en cada clic sobre el botón de llamada (`tel:`), para poder importarlo como conversión en Google Ads — paralelo exacto al ya existente `clic_boton_whatsapp`.

## Por qué

El botón "Llámanos" del `ChatWidget` no estaba instrumentado: Google Ads no veía esas conversiones. WhatsApp sí lo estaba.

## Cómo

Un script de delegación inline en `packages/ui-alquilatucarro/nuxt.config.ts`, espejo del de WhatsApp:
- Captura clics en `a[href^="tel:"]` en fase de captura.
- `tel:` abre el marcador sin descargar la página → el transporte `sendBeacon` de gtag siempre llega a GA4.
- Cero cambios en componentes. **Solo el flagship** (`ui-alquilatucarro`); los otros brands no tienen GA4.

## Blast radius

1 archivo: `packages/ui-alquilatucarro/nuxt.config.ts` (+9 líneas). Sin consumidores, sin tests afectados.

## Verificación (runtime, local, agent-browser)

| Anchor | Evento gtag |
|---|---|
| `tel:+57 301 672 9250` | `clic_boton_llamada` ✅ |
| `wa.me/573016729250` | `clic_boton_whatsapp` ✅ (sin regresión) |

## Pasos post-merge (manuales, en consola — no código)

1. Tras el deploy, disparar el evento en producción (clic en "Llámanos") para que GA4 lo registre.
2. GA4 → marcar `clic_boton_llamada` como evento clave.
3. Google Ads → importar el evento como conversión secundaria (igual que WhatsApp).