### PR TITLE
feat(searcher): chip de días de alquiler en el selector de devolución (#152)

### DIFF
--- a/packages/logic/src/stores/__tests__/useStoreReservationForm.rentalDays.test.ts
+++ b/packages/logic/src/stores/__tests__/useStoreReservationForm.rentalDays.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { createDateFromString, dayDifference } from '../../utils/useDateFunctions'
+
+// Issue #152 — day-count chip in the Searcher's return-date selector.
+//
+// `rentalDays` is the plain CALENDAR-day span between pickup and return (date
+// subtraction, time-of-day ignored), deliberately distinct from `selectedDays`
+// (billable days via rentalDayCount). It drives the floating chip and returns 0
+// when either date is missing so the chip can hide.
+//
+// Two layers, mirroring selectedDays.test.ts (source-level to avoid booting
+// Pinia/Nuxt auto-imports):
+//   1. Wiring guard: the computed delegates to dayDifference and guards the
+//      empty state.
+//   2. Behavioral: dayDifference (the math, previously untested) over the
+//      scenarios the chip renders.
+
+const source = readFileSync(
+  fileURLToPath(new URL('../useStoreReservationForm.ts', import.meta.url)),
+  'utf8',
+)
+
+function extractComputed(name: string): string {
+  const start = source.indexOf(`const ${name} = computed`)
+  expect(start, `missing computed ${name}`).toBeGreaterThan(-1)
+  const end = source.indexOf('\n  });', start) + '\n  });'.length
+  return source.slice(start, end)
+}
+
+describe('useStoreReservationForm — rentalDays wiring (issue #152)', () => {
+  const block = extractComputed('rentalDays')
+
+  it('delegates the span to the dayDifference util', () => {
+    expect(block).toMatch(/dayDifference\(/)
+  })
+
+  it('subtracts the calendar dates, not the full datetimes', () => {
+    expect(block).toContain('selectedPickupDate.value')
+    expect(block).toContain('selectedReturnDate.value')
+    // calendar-day span: must NOT fold in the selected hours
+    expect(block).not.toContain('selectedPickupHour.value')
+    expect(block).not.toContain('selectedReturnHour.value')
+  })
+
+  it('returns 0 when either date is missing (empty state hides the chip)', () => {
+    expect(block).toMatch(/if \(!pickupDate \|\| !returnDate\) return 0/)
+  })
+
+  it('is exposed from the store', () => {
+    expect(source).toMatch(/^\s*rentalDays,\s*$/m)
+  })
+})
+
+describe('rentalDays — calendar-day span behavior (dayDifference)', () => {
+  const span = (from: string, to: string) =>
+    dayDifference(createDateFromString(from), createDateFromString(to))
+
+  it('counts the default pickup+1 → pickup+8 window as 7 days', () => {
+    expect(span('2026-06-15', '2026-06-22')).toBe(7)
+  })
+
+  it('counts a single-day rental as 1', () => {
+    expect(span('2026-06-15', '2026-06-16')).toBe(1)
+  })
+
+  it('counts the maximum 30-day window', () => {
+    expect(span('2026-06-15', '2026-07-15')).toBe(30)
+  })
+
+  it('counts same pickup and return dates as 0', () => {
+    expect(span('2026-06-15', '2026-06-15')).toBe(0)
+  })
+
+  it('ignores time-of-day (pure calendar subtraction)', () => {
+    // dayDifference operates on CalendarDate objects (no time component), so the
+    // span depends only on the dates — this is exactly the contract rentalDays
+    // relies on to differ from billable selectedDays.
+    expect(span('2026-06-15', '2026-06-18')).toBe(3)
+  })
+})

--- a/packages/logic/src/stores/__tests__/useStoreReservationForm.selectedDays.test.ts
+++ b/packages/logic/src/stores/__tests__/useStoreReservationForm.selectedDays.test.ts
@@ -44,7 +44,9 @@ describe('useStoreReservationForm — selectedDays delegates to rentalDayCount',
 
   it('imports rentalDayCount and no longer imports the dropped date helpers', () => {
     expect(source).toMatch(/rentalDayCount/)
-    expect(source).not.toMatch(/\bdayDifference\b/)
+    // dayDifference now legitimately backs the `rentalDays` computed (issue #152,
+    // a plain calendar-day span). The guard that selectedDays itself does NOT use
+    // it lives at block level above (`expect(block).not.toMatch(/dayDifference/)`).
     expect(source).not.toMatch(/\bhourDifference\b/)
   })
 })

--- a/packages/logic/src/stores/useStoreReservationForm.ts
+++ b/packages/logic/src/stores/useStoreReservationForm.ts
@@ -15,6 +15,7 @@ import {
   createCurrentDateObject,
   createDateFromString,
   createTimeFromString,
+  dayDifference,
   rentalDayCount,
   formatHumanDate,
   formatHumanTime,
@@ -205,6 +206,18 @@ const useStoreReservationForm = defineStore("reservationForm", () => {
     return rentalDayCount(pickupAt, returnAt);
   });
 
+  // Calendar-day span between pickup and return (issue #152). Plain date
+  // subtraction — ignores time-of-day, unlike selectedDays/rentalDayCount which
+  // counts billable days. Drives the day-count chip in the Searcher; returns 0
+  // when either date is missing so the chip can hide (empty state).
+  const rentalDays = computed<number>(() => {
+    const pickupDate = selectedPickupDate.value;
+    const returnDate = selectedReturnDate.value;
+    if (!pickupDate || !returnDate) return 0;
+
+    return dayDifference(pickupDate, returnDate);
+  });
+
   const minPickupDate = computed<DateObject>(() => {
     return createCurrentDateObject();
   });
@@ -296,6 +309,7 @@ const useStoreReservationForm = defineStore("reservationForm", () => {
     attribution,
     // other vars
     selectedDays,
+    rentalDays,
     selectedMonthlyMileage,
     isSubmittingForm,
     haveTotalInsurance,

--- a/packages/ui-alquicarros/app/components/Searcher.vue
+++ b/packages/ui-alquicarros/app/components/Searcher.vue
@@ -164,7 +164,11 @@
             </u-form-field>
         </div>
         <!-- MÓVIL: Form field con input date nativo -->
-        <div class="bg-white rounded-xl p-2 shadow-sm sm:hidden">
+        <div class="relative bg-white rounded-xl p-2 shadow-sm sm:hidden">
+            <span
+                v-if="rentalDays > 0"
+                class="absolute top-0 right-0 z-10 bg-[#a3f78b] text-black text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
+            >{{ rentalDays }} {{ rentalDays === 1 ? 'día' : 'días' }}</span>
             <u-form-field label="Día de devolución" size="xl">
                 <input
                     v-if="minReturnDate"
@@ -181,7 +185,11 @@
         </div>
 
         <!-- DESKTOP: Form field con u-input-date -->
-        <div class="bg-white rounded-xl p-2 shadow-sm hidden sm:block">
+        <div class="relative bg-white rounded-xl p-2 shadow-sm hidden sm:block">
+            <span
+                v-if="rentalDays > 0"
+                class="absolute top-0 right-0 z-10 bg-[#a3f78b] text-black text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
+            >{{ rentalDays }} {{ rentalDays === 1 ? 'día' : 'días' }}</span>
             <u-form-field label="Día de devolución" size="xl">
                 <u-input-date
                     v-if="minReturnDate"
@@ -331,6 +339,7 @@ const minPickupDate = ref<any>(null);
 const maxReturnDate = ref<any>(null);
 const selectedPickupDate = ref<any>(null);
 const selectedReturnDate = ref<any>(null);
+const rentalDays = ref<number>(0);
 const minReturnDate = computed<any>(() => selectedPickupDate.value ?? minPickupDate.value);
 const pendingSearching = ref<boolean>(false);
 const sortedBranches = ref<any[]>([]);
@@ -396,6 +405,7 @@ onMounted(() => {
   watch(() => formRefs.maxReturnDate.value, (val) => maxReturnDate.value = val, { immediate: true });
   watch(() => formRefs.selectedPickupDate.value, (val) => selectedPickupDate.value = val, { immediate: true });
   watch(() => formRefs.selectedReturnDate.value, (val) => selectedReturnDate.value = val, { immediate: true });
+  watch(() => formRefs.rentalDays.value, (val) => rentalDays.value = val, { immediate: true });
   watch(() => searchRefs.pending.value, (val) => pendingSearching.value = val, { immediate: true });
   watch(() => adminRefs.sortedBranches.value, (val) => sortedBranches.value = val, { immediate: true });
 

--- a/packages/ui-alquilame/app/components/Searcher.vue
+++ b/packages/ui-alquilame/app/components/Searcher.vue
@@ -164,7 +164,11 @@
             </u-form-field>
         </div>
         <!-- MÓVIL: Form field con input date nativo -->
-        <div class="bg-white rounded-xl p-2 shadow-sm sm:hidden">
+        <div class="relative bg-white rounded-xl p-2 shadow-sm sm:hidden">
+            <span
+                v-if="rentalDays > 0"
+                class="absolute top-0 right-0 z-10 bg-red-600 text-white text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
+            >{{ rentalDays }} {{ rentalDays === 1 ? 'día' : 'días' }}</span>
             <u-form-field label="Día de devolución" size="xl">
                 <input
                     v-if="minReturnDate"
@@ -181,7 +185,11 @@
         </div>
 
         <!-- DESKTOP: Form field con u-input-date -->
-        <div class="bg-white rounded-xl p-2 shadow-sm hidden sm:block">
+        <div class="relative bg-white rounded-xl p-2 shadow-sm hidden sm:block">
+            <span
+                v-if="rentalDays > 0"
+                class="absolute top-0 right-0 z-10 bg-red-600 text-white text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
+            >{{ rentalDays }} {{ rentalDays === 1 ? 'día' : 'días' }}</span>
             <u-form-field label="Día de devolución" size="xl">
                 <u-input-date
                     v-if="minReturnDate"
@@ -333,6 +341,7 @@ const minPickupDate = ref<any>(null);
 const maxReturnDate = ref<any>(null);
 const selectedPickupDate = ref<any>(null);
 const selectedReturnDate = ref<any>(null);
+const rentalDays = ref<number>(0);
 const minReturnDate = computed<any>(() => selectedPickupDate.value ?? minPickupDate.value);
 const pendingSearching = ref<boolean>(false);
 const sortedBranches = ref<any[]>([]);
@@ -398,6 +407,7 @@ onMounted(() => {
   watch(() => formRefs.maxReturnDate.value, (val) => maxReturnDate.value = val, { immediate: true });
   watch(() => formRefs.selectedPickupDate.value, (val) => selectedPickupDate.value = val, { immediate: true });
   watch(() => formRefs.selectedReturnDate.value, (val) => selectedReturnDate.value = val, { immediate: true });
+  watch(() => formRefs.rentalDays.value, (val) => rentalDays.value = val, { immediate: true });
   watch(() => searchRefs.pending.value, (val) => pendingSearching.value = val, { immediate: true });
   watch(() => adminRefs.sortedBranches.value, (val) => sortedBranches.value = val, { immediate: true });
 

--- a/packages/ui-alquilatucarro/app/components/Searcher.vue
+++ b/packages/ui-alquilatucarro/app/components/Searcher.vue
@@ -164,7 +164,11 @@
             </u-form-field>
         </div>
         <!-- MÓVIL: Form field con input date nativo -->
-        <div class="bg-white rounded-xl px-2 py-2 max-sm:py-0.5! shadow-sm sm:hidden">
+        <div class="relative bg-white rounded-xl px-2 py-2 max-sm:py-0.5! shadow-sm sm:hidden">
+            <span
+                v-if="rentalDays > 0"
+                class="absolute top-0 right-0 z-10 bg-[#a3f78b] text-black text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
+            >{{ rentalDays }} {{ rentalDays === 1 ? 'día' : 'días' }}</span>
             <u-form-field label="Día de devolución" size="xl">
                 <input
                     v-if="minReturnDate"
@@ -181,7 +185,11 @@
         </div>
 
         <!-- DESKTOP: Form field con u-input-date -->
-        <div class="bg-white rounded-xl px-2 py-2 max-sm:py-0.5! shadow-sm hidden sm:block">
+        <div class="relative bg-white rounded-xl px-2 py-2 max-sm:py-0.5! shadow-sm hidden sm:block">
+            <span
+                v-if="rentalDays > 0"
+                class="absolute top-0 right-0 z-10 bg-[#a3f78b] text-black text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
+            >{{ rentalDays }} {{ rentalDays === 1 ? 'día' : 'días' }}</span>
             <u-form-field label="Día de devolución" size="xl">
                 <u-input-date
                     v-if="minReturnDate"
@@ -331,6 +339,7 @@ const minPickupDate = ref<any>(null);
 const maxReturnDate = ref<any>(null);
 const selectedPickupDate = ref<any>(null);
 const selectedReturnDate = ref<any>(null);
+const rentalDays = ref<number>(0);
 const minReturnDate = computed<any>(() => selectedPickupDate.value ?? minPickupDate.value);
 const pendingSearching = ref<boolean>(false);
 const sortedBranches = ref<any[]>([]);
@@ -396,6 +405,7 @@ onMounted(() => {
   watch(() => formRefs.maxReturnDate.value, (val) => maxReturnDate.value = val, { immediate: true });
   watch(() => formRefs.selectedPickupDate.value, (val) => selectedPickupDate.value = val, { immediate: true });
   watch(() => formRefs.selectedReturnDate.value, (val) => selectedReturnDate.value = val, { immediate: true });
+  watch(() => formRefs.rentalDays.value, (val) => rentalDays.value = val, { immediate: true });
   watch(() => searchRefs.pending.value, (val) => pendingSearching.value = val, { immediate: true });
   watch(() => adminRefs.sortedBranches.value, (val) => sortedBranches.value = val, { immediate: true });
 


### PR DESCRIPTION
Closes #152

## Qué
Chip flotante sobre el campo **Día de devolución** que muestra los días de alquiler seleccionados en días de calendario (`7 días` / `1 día`). Feedback visual de la ventana 1–30 días que el calendario ya impone.

## Cómo
- **logic** (`useStoreReservationForm`): nuevo computed `rentalDays` = `dayDifference(pickup, return)`, `0` si falta alguna fecha (oculta el chip). Distinto de `selectedDays` (días facturables vía `rentalDayCount`).
- **ui** (3 marcas): chip anclado a la esquina superior derecha del campo, tamaño de texto igual al label. Color según el badge "Dto hoy" de cada marca — verde `#a3f78b` en alquilatucarro/alquicarros, rojo en alquilame.
- **tests**: nuevos tests de wiring de `rentalDays` + comportamiento de `dayDifference`; ampliada la aserción source-level de `selectedDays` para permitir el nuevo import de `dayDifference`.

## Verificación
- ✅ `pnpm --filter @rentacar-main/logic test` → 392/392
- ✅ Typecheck: sin errores nuevos en los archivos tocados (los preexistentes del repo siguen igual)
- ✅ Runtime (alquilatucarro): chip `7 días`/`1 día`, 12px = label, esquina superior derecha, sin errores de consola nuevos
- ⚠️ alquilame/alquicarros: validados por paridad de código + tests (no runtime)

## Blast radius
1 store + 3 `Searcher.vue` + 2 tests. No toca `selectedDays`, precios ni URLs.