### PR TITLE
feat(ui): resumen de reserva, compartir, selector móvil y menú activo

### DIFF
--- a/packages/ui-alquicarros/app/assets/css/rentacar-main/reservation-resume.css
+++ b/packages/ui-alquicarros/app/assets/css/rentacar-main/reservation-resume.css
@@ -13,10 +13,14 @@
         @apply flex flex-col text-sm text-black;
 
         .category-name {
-            @apply mb-0 text-2xl;
+            @apply mb-0 text-sm;
         }
 
-        .category-description, .category-picoyplaca {
+        .category-description {
+            @apply lowercase leading-tight font-bold;
+        }
+
+        .category-picoyplaca {
             @apply lowercase leading-tight;
         }
 

--- a/packages/ui-alquicarros/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquicarros/app/components/CategorySelectionSection.vue
@@ -107,28 +107,28 @@
               <span class="text-sm text-gray-600 font-medium">Compartir</span>
               <button
                 @click="shareWhatsApp"
-                class="flex items-center justify-center w-9 h-9 bg-green-500 hover:bg-green-600 text-white rounded-full transition-colors"
+                class="flex items-center justify-center w-8 h-8 bg-green-500 hover:bg-green-600 text-white rounded-full transition-colors"
                 aria-label="Compartir en WhatsApp"
               >
-                <UIcon name="i-lucide-message-circle" class="size-4" />
+                <WhatsappIcon cls="size-4 text-white" />
               </button>
               <button
                 @click="shareFacebook"
-                class="flex items-center justify-center w-9 h-9 bg-blue-600 hover:bg-blue-700 text-white rounded-full transition-colors"
+                class="flex items-center justify-center w-8 h-8 bg-blue-600 hover:bg-blue-700 text-white rounded-full transition-colors"
                 aria-label="Compartir en Facebook"
               >
-                <UIcon name="i-lucide-facebook" class="size-4" />
+                <FacebookIcon cls="size-4 text-white" />
               </button>
               <button
                 @click="shareTwitter"
-                class="flex items-center justify-center w-9 h-9 bg-black hover:bg-gray-800 text-white rounded-full transition-colors"
+                class="flex items-center justify-center w-8 h-8 bg-black hover:bg-gray-800 text-white rounded-full transition-colors"
                 aria-label="Compartir en X"
               >
-                <UIcon name="i-lucide-twitter" class="size-4" />
+                <XIcon cls="size-4 text-white" />
               </button>
               <button
                 @click="copyReservationLink"
-                class="flex items-center justify-center w-9 h-9 bg-gray-500 hover:bg-gray-600 text-white rounded-full transition-colors"
+                class="flex items-center justify-center w-8 h-8 bg-gray-500 hover:bg-gray-600 text-white rounded-full transition-colors"
                 aria-label="Copiar enlace"
               >
                 <UIcon :name="linkCopied ? 'i-lucide-check' : 'i-lucide-link'" class="size-4" />
@@ -176,11 +176,11 @@
           <u-button
             color="neutral"
             size="xl"
-            class="flex-1 py-4 justify-center bg-green-700 hover:bg-green-800 disabled:bg-green-700 aria-disabled:bg-green-700 disabled:opacity-80 aria-disabled:opacity-80 text-white"
+            class="flex-1 py-4 justify-center whitespace-nowrap bg-green-700 hover:bg-green-800 disabled:bg-green-700 aria-disabled:bg-green-700 disabled:opacity-80 aria-disabled:opacity-80 text-white"
             :loading="isSubmittingForm"
             :disabled="isSubmittingForm"
             @click="reservationFormComponent?.submit()"
-            >Solicitar reserva
+            >{{ isSubmittingForm ? 'Solicitando' : 'Solicitar reserva' }}
             <template #trailing>
               <ChevronRightIcon v-if="!isSubmittingForm" cls="size-5" />
             </template>
@@ -206,7 +206,10 @@ import {
   CategoryCard,
   ReservationResume,
   ReservationForm,
-  IconsChevronRightIcon as ChevronRightIcon
+  IconsChevronRightIcon as ChevronRightIcon,
+  IconsWhatsappIcon as WhatsappIcon,
+  IconsFacebookIcon as FacebookIcon,
+  IconsXIcon as XIcon
 } from "#components";
 
 // Note: composables and functions are auto-imported by Nuxt

--- a/packages/ui-alquicarros/app/components/Icons/FacebookIcon.vue
+++ b/packages/ui-alquicarros/app/components/Icons/FacebookIcon.vue
@@ -1,0 +1,12 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" :class="cls" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M14 13.5h2.5l1-4H14v-2c0-1.03 0-2 2-2h1.5V2.14c-.326-.043-1.557-.14-2.857-.14C11.928 2 10 3.657 10 6.7v2.8H7v4h3V22h4v-8.5z"/>
+  </svg>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ cls?: string }>()
+const cls = props.cls ?? ''
+</script>
+
+<style scoped></style>

--- a/packages/ui-alquicarros/app/components/Icons/XIcon.vue
+++ b/packages/ui-alquicarros/app/components/Icons/XIcon.vue
@@ -1,0 +1,12 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" :class="cls" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.153h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z"/>
+  </svg>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ cls?: string }>()
+const cls = props.cls ?? ''
+</script>
+
+<style scoped></style>

--- a/packages/ui-alquicarros/app/components/ReservationResume.vue
+++ b/packages/ui-alquicarros/app/components/ReservationResume.vue
@@ -14,7 +14,7 @@
           <div class="category-name" v-text="`Gama ${categoryCode}`"></div>
           <div class="category-description" v-text="categoryDescription"></div>
           <div v-if="isPicoyPlacaExempt()" class="category-picoyplaca" >
-            <span class="inline-block px-2 py-0.5 text-xs border border-blue-500 text-blue-600 rounded-full">sin pico y placa</span>
+            <span class="inline-block px-2 py-0.5 text-xs bg-[#a3f78b] border border-green-600 text-green-900 rounded-full">sin pico y placa</span>
           </div>
           <div class="pickup-info">
             <div class="pickup-location">

--- a/packages/ui-alquicarros/app/components/SelectBranch.vue
+++ b/packages/ui-alquicarros/app/components/SelectBranch.vue
@@ -1,7 +1,7 @@
 <template>
     <!-- Móvil: select nativo (mejor UX táctil) -->
     <div class="relative w-full sm:hidden">
-      <LocationIcon cls="absolute left-3 top-1/2 -translate-y-1/2 text-red-600 size-5 pointer-events-none" />
+      <LocationIcon cls="absolute left-3 inset-y-0 m-auto text-red-600 size-5 pointer-events-none" />
       <select
         id="select-branch-mobile"
         v-model="selectedBranch"
@@ -20,7 +20,7 @@
           v-text="branch.name"
         ></option>
       </select>
-      <ChevronDownIcon cls="absolute right-4 top-1/2 -translate-y-1/2 size-6 pointer-events-none text-gray-600" />
+      <ChevronDownIcon cls="absolute right-4 inset-y-0 m-auto size-6 pointer-events-none text-gray-600" />
     </div>
     <!-- Desktop: USelectMenu con búsqueda -->
     <USelectMenu

--- a/packages/ui-alquicarros/app/layouts/default.vue
+++ b/packages/ui-alquicarros/app/layouts/default.vue
@@ -140,33 +140,27 @@ const hasInPageSections = computed(() => route.path === '/' || !!route.params.ci
 const requisitosTo = computed(() => hasInPageSections.value ? '#requisitos' : '/#requisitos');
 const faqsTo = computed(() => hasInPageSections.value ? '#faqs' : '/#faqs');
 
-// Items para menú desktop (texto blanco sobre fondo azul)
-const items = computed<NavigationMenuItem[]>(() => [
-  {
-    label: 'Requisitos',
-    to: requisitosTo.value,
-    active: route.hash === '#requisitos',
-    class: "text-white hover:text-white hover:bg-white/10",
-  },
-  {
-    label: 'Sedes',
-    to: '#sedes',
-    active: route.hash === '#sedes',
-    class: "text-white hover:text-white hover:bg-white/10",
-  },
-  {
-    label: 'Blog',
-    to: '/blog',
-    active: route.path.startsWith('/blog'),
-    class: "text-white hover:text-white hover:bg-white/10",
-  },
-  {
-    label: 'Preguntas frecuentes',
-    to: faqsTo.value,
-    active: route.hash === '#faqs',
-    class: "text-white hover:text-white hover:bg-white/10",
-  },
-])
+// Items para menú desktop (texto blanco sobre fondo azul).
+// El item activo recibe un fondo claro del UNavigationMenu; sin un color de
+// texto que contraste quedaba blanco-sobre-blanco e ilegible. linkClass pasa el
+// texto a gris oscuro cuando el item está activo.
+const linkClass = (active: boolean) =>
+  active
+    ? "text-gray-900 hover:text-gray-900"
+    : "text-white hover:text-white hover:bg-white/10";
+
+const items = computed<NavigationMenuItem[]>(() => {
+  const requisitosActive = route.hash === '#requisitos';
+  const sedesActive = route.hash === '#sedes';
+  const blogActive = route.path.startsWith('/blog');
+  const faqsActive = route.hash === '#faqs';
+  return [
+    { label: 'Requisitos', to: requisitosTo.value, active: requisitosActive, class: linkClass(requisitosActive) },
+    { label: 'Sedes', to: '#sedes', active: sedesActive, class: linkClass(sedesActive) },
+    { label: 'Blog', to: '/blog', active: blogActive, class: linkClass(blogActive) },
+    { label: 'Preguntas frecuentes', to: faqsTo.value, active: faqsActive, class: linkClass(faqsActive) },
+  ];
+})
 
 // Items para menú móvil (texto oscuro sobre fondo blanco)
 const mobileItems = computed<NavigationMenuItem[]>(() => [

--- a/packages/ui-alquilame/app/assets/css/rentacar-main/reservation-resume.css
+++ b/packages/ui-alquilame/app/assets/css/rentacar-main/reservation-resume.css
@@ -15,10 +15,14 @@
         /* Brand: Gama title uses .heading-card (Plus Jakarta) + red from the
            template; keep tight bottom margin here. */
         .category-name {
-            @apply mb-0;
+            @apply mb-0 text-sm;
         }
 
-        .category-description, .category-picoyplaca {
+        .category-description {
+            @apply lowercase leading-tight font-bold;
+        }
+
+        .category-picoyplaca {
             @apply lowercase leading-tight;
         }
 

--- a/packages/ui-alquilame/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquilame/app/components/CategorySelectionSection.vue
@@ -108,28 +108,28 @@
               <span class="text-sm text-gray-600 font-medium">Compartir</span>
               <button
                 @click="shareWhatsApp"
-                class="flex items-center justify-center w-9 h-9 bg-green-500 hover:bg-green-600 text-white rounded-full transition-colors"
+                class="flex items-center justify-center w-8 h-8 bg-green-500 hover:bg-green-600 text-white rounded-full transition-colors"
                 aria-label="Compartir en WhatsApp"
               >
-                <UIcon name="i-lucide-message-circle" class="size-4" />
+                <WhatsappIcon cls="size-4 text-white" />
               </button>
               <button
                 @click="shareFacebook"
-                class="flex items-center justify-center w-9 h-9 bg-blue-600 hover:bg-blue-700 text-white rounded-full transition-colors"
+                class="flex items-center justify-center w-8 h-8 bg-blue-600 hover:bg-blue-700 text-white rounded-full transition-colors"
                 aria-label="Compartir en Facebook"
               >
-                <UIcon name="i-lucide-facebook" class="size-4" />
+                <FacebookIcon cls="size-4 text-white" />
               </button>
               <button
                 @click="shareTwitter"
-                class="flex items-center justify-center w-9 h-9 bg-black hover:bg-gray-800 text-white rounded-full transition-colors"
+                class="flex items-center justify-center w-8 h-8 bg-black hover:bg-gray-800 text-white rounded-full transition-colors"
                 aria-label="Compartir en X"
               >
-                <UIcon name="i-lucide-twitter" class="size-4" />
+                <XIcon cls="size-4 text-white" />
               </button>
               <button
                 @click="copyReservationLink"
-                class="flex items-center justify-center w-9 h-9 bg-gray-500 hover:bg-gray-600 text-white rounded-full transition-colors"
+                class="flex items-center justify-center w-8 h-8 bg-gray-500 hover:bg-gray-600 text-white rounded-full transition-colors"
                 aria-label="Copiar enlace"
               >
                 <UIcon :name="linkCopied ? 'i-lucide-check' : 'i-lucide-link'" class="size-4" />
@@ -177,11 +177,11 @@
           <u-button
             color="neutral"
             size="xl"
-            class="flex-1 py-4 justify-center bg-green-700 hover:bg-green-800 disabled:bg-green-700 aria-disabled:bg-green-700 disabled:opacity-80 aria-disabled:opacity-80 text-white"
+            class="flex-1 py-4 justify-center whitespace-nowrap bg-green-700 hover:bg-green-800 disabled:bg-green-700 aria-disabled:bg-green-700 disabled:opacity-80 aria-disabled:opacity-80 text-white"
             :loading="isSubmittingForm"
             :disabled="isSubmittingForm"
             @click="reservationFormComponent?.submit()"
-            >Solicitar reserva
+            >{{ isSubmittingForm ? 'Solicitando' : 'Solicitar reserva' }}
             <template #trailing>
               <ChevronRightIcon v-if="!isSubmittingForm" cls="size-5" />
             </template>
@@ -207,7 +207,10 @@ import {
   CategoryCard,
   ReservationResume,
   ReservationForm,
-  IconsChevronRightIcon as ChevronRightIcon
+  IconsChevronRightIcon as ChevronRightIcon,
+  IconsWhatsappIcon as WhatsappIcon,
+  IconsFacebookIcon as FacebookIcon,
+  IconsXIcon as XIcon
 } from "#components";
 
 // Note: composables and functions are auto-imported by Nuxt

--- a/packages/ui-alquilame/app/components/Icons/FacebookIcon.vue
+++ b/packages/ui-alquilame/app/components/Icons/FacebookIcon.vue
@@ -1,0 +1,12 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" :class="cls" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M14 13.5h2.5l1-4H14v-2c0-1.03 0-2 2-2h1.5V2.14c-.326-.043-1.557-.14-2.857-.14C11.928 2 10 3.657 10 6.7v2.8H7v4h3V22h4v-8.5z"/>
+  </svg>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ cls?: string }>()
+const cls = props.cls ?? ''
+</script>
+
+<style scoped></style>

--- a/packages/ui-alquilame/app/components/Icons/XIcon.vue
+++ b/packages/ui-alquilame/app/components/Icons/XIcon.vue
@@ -1,0 +1,12 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" :class="cls" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.153h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z"/>
+  </svg>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ cls?: string }>()
+const cls = props.cls ?? ''
+</script>
+
+<style scoped></style>

--- a/packages/ui-alquilame/app/components/ReservationResume.vue
+++ b/packages/ui-alquilame/app/components/ReservationResume.vue
@@ -15,7 +15,7 @@
           <div class="category-name heading-card text-red-700" v-text="`Gama ${categoryCode}`"></div>
           <div class="category-description" v-text="categoryDescription"></div>
           <div v-if="isPicoyPlacaExempt()" class="category-picoyplaca" >
-            <span class="inline-block px-2 py-0.5 text-xs border border-blue-500 text-blue-600 rounded-full">sin pico y placa</span>
+            <span class="inline-block px-2 py-0.5 text-xs bg-[#a3f78b] border border-green-600 text-green-900 rounded-full">sin pico y placa</span>
           </div>
           <div class="pickup-info">
             <div class="pickup-location">

--- a/packages/ui-alquilame/app/components/SelectBranch.vue
+++ b/packages/ui-alquilame/app/components/SelectBranch.vue
@@ -1,7 +1,7 @@
 <template>
     <!-- Móvil: select nativo (mejor UX táctil) -->
     <div class="relative w-full sm:hidden">
-      <LocationIcon cls="absolute left-3 top-1/2 -translate-y-1/2 text-red-600 size-5 pointer-events-none" />
+      <LocationIcon cls="absolute left-3 inset-y-0 m-auto text-red-600 size-5 pointer-events-none" />
       <select
         id="select-branch-mobile"
         v-model="selectedBranch"
@@ -20,7 +20,7 @@
           v-text="branch.name"
         ></option>
       </select>
-      <ChevronDownIcon cls="absolute right-4 top-1/2 -translate-y-1/2 size-6 pointer-events-none text-gray-600" />
+      <ChevronDownIcon cls="absolute right-4 inset-y-0 m-auto size-6 pointer-events-none text-gray-600" />
     </div>
     <!-- Desktop: USelectMenu con búsqueda -->
     <USelectMenu

--- a/packages/ui-alquilame/app/layouts/default.vue
+++ b/packages/ui-alquilame/app/layouts/default.vue
@@ -163,33 +163,27 @@ const hasInPageSections = computed(() => route.path === '/' || !!route.params.ci
 const requisitosTo = computed(() => hasInPageSections.value ? '#requisitos' : '/#requisitos');
 const faqsTo = computed(() => hasInPageSections.value ? '#faqs' : '/#faqs');
 
-// Items para menú desktop (texto blanco sobre fondo azul)
-const items = computed<NavigationMenuItem[]>(() => [
-  {
-    label: 'Requisitos',
-    to: requisitosTo.value,
-    active: route.hash === '#requisitos',
-    class: "text-white hover:text-white hover:bg-white/10",
-  },
-  {
-    label: 'Sedes',
-    to: '#sedes',
-    active: route.hash === '#sedes',
-    class: "text-white hover:text-white hover:bg-white/10",
-  },
-  {
-    label: 'Blog',
-    to: '/blog',
-    active: route.path.startsWith('/blog'),
-    class: "text-white hover:text-white hover:bg-white/10",
-  },
-  {
-    label: 'Preguntas frecuentes',
-    to: faqsTo.value,
-    active: route.hash === '#faqs',
-    class: "text-white hover:text-white hover:bg-white/10",
-  },
-])
+// Items para menú desktop (texto blanco sobre fondo azul).
+// El item activo recibe un fondo claro del UNavigationMenu; sin un color de
+// texto que contraste quedaba blanco-sobre-blanco e ilegible. linkClass pasa el
+// texto a gris oscuro cuando el item está activo.
+const linkClass = (active: boolean) =>
+  active
+    ? "text-gray-900 hover:text-gray-900"
+    : "text-white hover:text-white hover:bg-white/10";
+
+const items = computed<NavigationMenuItem[]>(() => {
+  const requisitosActive = route.hash === '#requisitos';
+  const sedesActive = route.hash === '#sedes';
+  const blogActive = route.path.startsWith('/blog');
+  const faqsActive = route.hash === '#faqs';
+  return [
+    { label: 'Requisitos', to: requisitosTo.value, active: requisitosActive, class: linkClass(requisitosActive) },
+    { label: 'Sedes', to: '#sedes', active: sedesActive, class: linkClass(sedesActive) },
+    { label: 'Blog', to: '/blog', active: blogActive, class: linkClass(blogActive) },
+    { label: 'Preguntas frecuentes', to: faqsTo.value, active: faqsActive, class: linkClass(faqsActive) },
+  ];
+})
 
 // Items para menú móvil (texto oscuro sobre fondo blanco)
 const mobileItems = computed<NavigationMenuItem[]>(() => [

--- a/packages/ui-alquilatucarro/app/assets/css/rentacar-main/reservation-resume.css
+++ b/packages/ui-alquilatucarro/app/assets/css/rentacar-main/reservation-resume.css
@@ -13,10 +13,14 @@
         @apply flex flex-col text-sm text-black;
 
         .category-name {
-            @apply mb-0 text-2xl;
+            @apply mb-0 text-sm;
         }
 
-        .category-description, .category-picoyplaca {
+        .category-description {
+            @apply lowercase leading-tight font-bold;
+        }
+
+        .category-picoyplaca {
             @apply lowercase leading-tight;
         }
 

--- a/packages/ui-alquilatucarro/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquilatucarro/app/components/CategorySelectionSection.vue
@@ -107,28 +107,28 @@
               <span class="text-sm text-gray-600 font-medium">Compartir</span>
               <button
                 @click="shareWhatsApp"
-                class="flex items-center justify-center w-9 h-9 bg-green-500 hover:bg-green-600 text-white rounded-full transition-colors"
+                class="flex items-center justify-center w-8 h-8 bg-green-500 hover:bg-green-600 text-white rounded-full transition-colors"
                 aria-label="Compartir en WhatsApp"
               >
-                <UIcon name="i-lucide-message-circle" class="size-4" />
+                <WhatsappIcon cls="size-4 text-white" />
               </button>
               <button
                 @click="shareFacebook"
-                class="flex items-center justify-center w-9 h-9 bg-blue-600 hover:bg-blue-700 text-white rounded-full transition-colors"
+                class="flex items-center justify-center w-8 h-8 bg-blue-600 hover:bg-blue-700 text-white rounded-full transition-colors"
                 aria-label="Compartir en Facebook"
               >
-                <UIcon name="i-lucide-facebook" class="size-4" />
+                <FacebookIcon cls="size-4 text-white" />
               </button>
               <button
                 @click="shareTwitter"
-                class="flex items-center justify-center w-9 h-9 bg-black hover:bg-gray-800 text-white rounded-full transition-colors"
+                class="flex items-center justify-center w-8 h-8 bg-black hover:bg-gray-800 text-white rounded-full transition-colors"
                 aria-label="Compartir en X"
               >
-                <UIcon name="i-lucide-twitter" class="size-4" />
+                <XIcon cls="size-4 text-white" />
               </button>
               <button
                 @click="copyReservationLink"
-                class="flex items-center justify-center w-9 h-9 bg-gray-500 hover:bg-gray-600 text-white rounded-full transition-colors"
+                class="flex items-center justify-center w-8 h-8 bg-gray-500 hover:bg-gray-600 text-white rounded-full transition-colors"
                 aria-label="Copiar enlace"
               >
                 <UIcon :name="linkCopied ? 'i-lucide-check' : 'i-lucide-link'" class="size-4" />
@@ -176,11 +176,11 @@
           <u-button
             color="neutral"
             size="xl"
-            class="flex-1 py-4 justify-center bg-green-700 hover:bg-green-800 disabled:bg-green-700 aria-disabled:bg-green-700 disabled:opacity-80 aria-disabled:opacity-80 text-white"
+            class="flex-1 py-4 justify-center whitespace-nowrap bg-green-700 hover:bg-green-800 disabled:bg-green-700 aria-disabled:bg-green-700 disabled:opacity-80 aria-disabled:opacity-80 text-white"
             :loading="isSubmittingForm"
             :disabled="isSubmittingForm"
             @click="reservationFormComponent?.submit()"
-            >Solicitar reserva
+            >{{ isSubmittingForm ? 'Solicitando' : 'Solicitar reserva' }}
             <template #trailing>
               <ChevronRightIcon v-if="!isSubmittingForm" cls="size-5" />
             </template>
@@ -206,7 +206,10 @@ import {
   CategoryCard,
   ReservationResume,
   ReservationForm,
-  IconsChevronRightIcon as ChevronRightIcon
+  IconsChevronRightIcon as ChevronRightIcon,
+  IconsWhatsappIcon as WhatsappIcon,
+  IconsFacebookIcon as FacebookIcon,
+  IconsXIcon as XIcon
 } from "#components";
 
 // Note: composables and functions are auto-imported by Nuxt

--- a/packages/ui-alquilatucarro/app/components/Icons/FacebookIcon.vue
+++ b/packages/ui-alquilatucarro/app/components/Icons/FacebookIcon.vue
@@ -1,0 +1,12 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" :class="cls" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M14 13.5h2.5l1-4H14v-2c0-1.03 0-2 2-2h1.5V2.14c-.326-.043-1.557-.14-2.857-.14C11.928 2 10 3.657 10 6.7v2.8H7v4h3V22h4v-8.5z"/>
+  </svg>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ cls?: string }>()
+const cls = props.cls ?? ''
+</script>
+
+<style scoped></style>

--- a/packages/ui-alquilatucarro/app/components/Icons/XIcon.vue
+++ b/packages/ui-alquilatucarro/app/components/Icons/XIcon.vue
@@ -1,0 +1,12 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" :class="cls" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.153h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z"/>
+  </svg>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ cls?: string }>()
+const cls = props.cls ?? ''
+</script>
+
+<style scoped></style>

--- a/packages/ui-alquilatucarro/app/components/ReservationResume.vue
+++ b/packages/ui-alquilatucarro/app/components/ReservationResume.vue
@@ -14,7 +14,7 @@
           <div class="category-name" v-text="`Gama ${categoryCode}`"></div>
           <div class="category-description" v-text="categoryDescription"></div>
           <div v-if="isPicoyPlacaExempt()" class="category-picoyplaca" >
-            <span class="inline-block px-2 py-0.5 text-xs border border-blue-500 text-blue-600 rounded-full">sin pico y placa</span>
+            <span class="inline-block px-2 py-0.5 text-xs bg-[#a3f78b] border border-green-600 text-green-900 rounded-full">sin pico y placa</span>
           </div>
           <div class="pickup-info">
             <div class="pickup-location">

--- a/packages/ui-alquilatucarro/app/components/SelectBranch.vue
+++ b/packages/ui-alquilatucarro/app/components/SelectBranch.vue
@@ -1,7 +1,7 @@
 <template>
     <!-- Móvil: select nativo (mejor UX táctil) -->
     <div class="relative w-full sm:hidden">
-      <LocationIcon cls="absolute left-3 top-1/2 -translate-y-1/2 text-red-600 size-5 pointer-events-none" />
+      <LocationIcon cls="absolute left-3 inset-y-0 m-auto text-red-600 size-5 pointer-events-none" />
       <select
         id="select-branch-mobile"
         v-model="selectedBranch"
@@ -20,7 +20,7 @@
           v-text="branch.name"
         ></option>
       </select>
-      <ChevronDownIcon cls="absolute right-4 top-1/2 -translate-y-1/2 size-6 pointer-events-none text-gray-600" />
+      <ChevronDownIcon cls="absolute right-4 inset-y-0 m-auto size-6 pointer-events-none text-gray-600" />
     </div>
     <!-- Desktop: USelectMenu con búsqueda -->
     <USelectMenu

--- a/packages/ui-alquilatucarro/app/layouts/default.vue
+++ b/packages/ui-alquilatucarro/app/layouts/default.vue
@@ -148,33 +148,27 @@ const hasInPageSections = computed(() => route.path === '/' || !!route.params.ci
 const requisitosTo = computed(() => hasInPageSections.value ? '#requisitos' : '/#requisitos');
 const faqsTo = computed(() => hasInPageSections.value ? '#faqs' : '/#faqs');
 
-// Items para menú desktop (texto blanco sobre fondo azul)
-const items = computed<NavigationMenuItem[]>(() => [
-  {
-    label: 'Requisitos',
-    to: requisitosTo.value,
-    active: route.hash === '#requisitos',
-    class: "text-white hover:text-white hover:bg-white/10",
-  },
-  {
-    label: 'Sedes',
-    to: '#sedes',
-    active: route.hash === '#sedes',
-    class: "text-white hover:text-white hover:bg-white/10",
-  },
-  {
-    label: 'Blog',
-    to: '/blog',
-    active: route.path.startsWith('/blog'),
-    class: "text-white hover:text-white hover:bg-white/10",
-  },
-  {
-    label: 'Preguntas frecuentes',
-    to: faqsTo.value,
-    active: route.hash === '#faqs',
-    class: "text-white hover:text-white hover:bg-white/10",
-  },
-])
+// Items para menú desktop (texto blanco sobre fondo azul).
+// El item activo recibe un fondo claro del UNavigationMenu; sin un color de
+// texto que contraste quedaba blanco-sobre-blanco e ilegible. linkClass pasa el
+// texto a azul oscuro cuando el item está activo.
+const linkClass = (active: boolean) =>
+  active
+    ? "text-blue-900 hover:text-blue-900"
+    : "text-white hover:text-white hover:bg-white/10";
+
+const items = computed<NavigationMenuItem[]>(() => {
+  const requisitosActive = route.hash === '#requisitos';
+  const sedesActive = route.hash === '#sedes';
+  const blogActive = route.path.startsWith('/blog');
+  const faqsActive = route.hash === '#faqs';
+  return [
+    { label: 'Requisitos', to: requisitosTo.value, active: requisitosActive, class: linkClass(requisitosActive) },
+    { label: 'Sedes', to: '#sedes', active: sedesActive, class: linkClass(sedesActive) },
+    { label: 'Blog', to: '/blog', active: blogActive, class: linkClass(blogActive) },
+    { label: 'Preguntas frecuentes', to: faqsTo.value, active: faqsActive, class: linkClass(faqsActive) },
+  ];
+})
 
 // Items para menú móvil (texto oscuro sobre fondo blanco)
 const mobileItems = computed<NavigationMenuItem[]>(() => [


### PR DESCRIPTION
Cinco mejoras de UI en las 3 marcas (alquilatucarro, alquilame, alquicarros).

## Cambios
1. **Resumen de reserva** — badge "sin pico y placa" pasa de azul a verde (`bg-[#a3f78b]` + borde verde, como el badge "Dto hoy" de la tarjeta). "Gama XX" baja a `text-sm` (tamaño tarifa diaria); la descripción ("sedán automático") pasa a **negrilla** — se invierte el énfasis visual.
2. **Compartir** — se reemplazan los glifos lucide genéricos por logos de marca reales (WhatsApp teléfono, F de Facebook sólida, logo X), rellenos en blanco; botones ~10% más pequeños (`w-9`→`w-8`). Nuevos componentes `FacebookIcon`/`XIcon` por marca; reutiliza `WhatsappIcon` existente.
3. **Selector móvil** — el pin de mapa y la flecha se centran con `inset-y-0 m-auto` (antes `top-1/2 -translate-y-1/2`), quedando en el mismo eje exacto (delta 0px; antes ~2px de desfase en selects nativos).
4. **Menú header** — el item activo recibía fondo claro de UNavigationMenu pero mantenía `text-white` → blanco sobre blanco ilegible. Ahora el item activo usa texto oscuro.
5. **Botón "Solicitar reserva"** — muestra "Solicitando" durante el envío + `whitespace-nowrap`, para que el spinner no parta el texto en 2 líneas y agrande el botón.

## Verificación
- ✅ Typecheck: 0 errores nuevos en los archivos tocados (los del repo son preexistentes: issue #18 auto-imports + `color:'gray'` del calendario).
- ✅ Runtime local (alquilatucarro): **fix 3** íconos móvil alineados (delta=0) y **fix 4** "Blog" legible (texto oscuro), 0 errores JS de consola.
- ⏳ **fix 1, 2, 5** viven en el slideover de reserva, que no carga localmente (la disponibilidad apunta a un backend externo). Se validan en el **preview de Vercel** de este PR.

## Alcance
21 archivos: 15 modificados (3× ReservationResume + css, CategorySelectionSection, SelectBranch, layout) + 6 nuevos (FacebookIcon/XIcon ×3). No toca lógica, precios ni rutas.