### PR TITLE
fix(searcher): align calendar weekdays & clamp mobile date inputs

### DIFF
--- a/packages/ui-alquicarros/app/components/Searcher.vue
+++ b/packages/ui-alquicarros/app/components/Searcher.vue
@@ -112,6 +112,7 @@
                     aria-label="Día de recogida"
                     class="w-full"
                     :min="minPickupDate.toString()"
+                    @change="onMobilePickupDateChange"
                 >
             </u-form-field>
         </div>
@@ -180,6 +181,7 @@
                     class="w-full"
                     :min="minReturnDate.toString()"
                     :max="maxReturnDate?.toString()"
+                    @change="onMobileReturnDateChange"
                 >
             </u-form-field>
         </div>
@@ -341,6 +343,38 @@ const selectedPickupDate = ref<any>(null);
 const selectedReturnDate = ref<any>(null);
 const rentalDays = ref<number>(0);
 const minReturnDate = computed<any>(() => selectedPickupDate.value ?? minPickupDate.value);
+
+// Mobile uses a native <input type="date">. On some Android date pickers an
+// out-of-range value can still be committed, which makes the browser surface
+// its native validation bubble ("El valor debe ser igual o posterior a …").
+// That bubble is unstyleable and renders dark-on-dark under Android force-dark.
+// We never want it: silently snap any out-of-range value back into range on
+// change (the user can't rent in the past anyway). Native date inputs always
+// emit ISO `YYYY-MM-DD`, so lexicographic comparison is chronological. Desktop
+// uses <u-calendar>, which already disables out-of-range days.
+const clampMobileDateInput = (event: Event, min?: string | null, max?: string | null): string | null => {
+    const target = event.target as HTMLInputElement;
+    let value = target.value;
+    if (!value) return null;
+    if (min && value < min) value = min;
+    if (max && value > max) value = max;
+    if (value !== target.value) target.value = value;
+    return value;
+};
+
+const onMobilePickupDateChange = (event: Event) => {
+    const clamped = clampMobileDateInput(event, minPickupDate.value?.toString());
+    if (clamped !== null) selectedPickupDate.value = clamped;
+};
+
+const onMobileReturnDateChange = (event: Event) => {
+    const clamped = clampMobileDateInput(
+        event,
+        minReturnDate.value?.toString(),
+        maxReturnDate.value?.toString(),
+    );
+    if (clamped !== null) selectedReturnDate.value = clamped;
+};
 const pendingSearching = ref<boolean>(false);
 const sortedBranches = ref<any[]>([]);
 const pickupHourOptions = ref<any[]>([]);
@@ -356,6 +390,11 @@ const returnDateCalendarOpen = ref<boolean>(false);
 const calendarUIConfig = {
     heading: '!text-gray-900 !font-bold',
     gridRow: 'w-full',
+    // Center each weekday letter within its column so it lines up vertically
+    // with the day numbers. The default `gridRow` already has place-items-center
+    // (numbers centered) but `gridWeekDaysRow` does not, so without this the
+    // letters left-align inside their column and drift left of the numbers.
+    gridWeekDaysRow: 'w-full place-items-center',
     cellTrigger: '!text-gray-900 !font-semibold data-[disabled]:!text-gray-400 data-[disabled]:!opacity-50 data-[unavailable]:!text-gray-400 data-[unavailable]:!opacity-50 data-[outside-view]:!text-gray-400 data-[outside-view]:!opacity-50'
 };
 

--- a/packages/ui-alquilame/app/components/Searcher.vue
+++ b/packages/ui-alquilame/app/components/Searcher.vue
@@ -112,6 +112,7 @@
                     aria-label="Día de recogida"
                     class="w-full"
                     :min="minPickupDate.toString()"
+                    @change="onMobilePickupDateChange"
                 >
             </u-form-field>
         </div>
@@ -180,6 +181,7 @@
                     class="w-full"
                     :min="minReturnDate.toString()"
                     :max="maxReturnDate?.toString()"
+                    @change="onMobileReturnDateChange"
                 >
             </u-form-field>
         </div>
@@ -343,6 +345,38 @@ const selectedPickupDate = ref<any>(null);
 const selectedReturnDate = ref<any>(null);
 const rentalDays = ref<number>(0);
 const minReturnDate = computed<any>(() => selectedPickupDate.value ?? minPickupDate.value);
+
+// Mobile uses a native <input type="date">. On some Android date pickers an
+// out-of-range value can still be committed, which makes the browser surface
+// its native validation bubble ("El valor debe ser igual o posterior a …").
+// That bubble is unstyleable and renders dark-on-dark under Android force-dark.
+// We never want it: silently snap any out-of-range value back into range on
+// change (the user can't rent in the past anyway). Native date inputs always
+// emit ISO `YYYY-MM-DD`, so lexicographic comparison is chronological. Desktop
+// uses <u-calendar>, which already disables out-of-range days.
+const clampMobileDateInput = (event: Event, min?: string | null, max?: string | null): string | null => {
+    const target = event.target as HTMLInputElement;
+    let value = target.value;
+    if (!value) return null;
+    if (min && value < min) value = min;
+    if (max && value > max) value = max;
+    if (value !== target.value) target.value = value;
+    return value;
+};
+
+const onMobilePickupDateChange = (event: Event) => {
+    const clamped = clampMobileDateInput(event, minPickupDate.value?.toString());
+    if (clamped !== null) selectedPickupDate.value = clamped;
+};
+
+const onMobileReturnDateChange = (event: Event) => {
+    const clamped = clampMobileDateInput(
+        event,
+        minReturnDate.value?.toString(),
+        maxReturnDate.value?.toString(),
+    );
+    if (clamped !== null) selectedReturnDate.value = clamped;
+};
 const pendingSearching = ref<boolean>(false);
 const sortedBranches = ref<any[]>([]);
 const pickupHourOptions = ref<any[]>([]);
@@ -358,6 +392,11 @@ const returnDateCalendarOpen = ref<boolean>(false);
 const calendarUIConfig = {
     heading: '!text-gray-900 !font-bold',
     gridRow: 'w-full',
+    // Center each weekday letter within its column so it lines up vertically
+    // with the day numbers. The default `gridRow` already has place-items-center
+    // (numbers centered) but `gridWeekDaysRow` does not, so without this the
+    // letters left-align inside their column and drift left of the numbers.
+    gridWeekDaysRow: 'w-full place-items-center',
     cellTrigger: '!text-gray-900 !font-semibold data-[disabled]:!text-gray-400 data-[disabled]:!opacity-50 data-[unavailable]:!text-gray-400 data-[unavailable]:!opacity-50 data-[outside-view]:!text-gray-400 data-[outside-view]:!opacity-50'
 };
 

--- a/packages/ui-alquilatucarro/app/components/Searcher.vue
+++ b/packages/ui-alquilatucarro/app/components/Searcher.vue
@@ -112,6 +112,7 @@
                     aria-label="Día de recogida"
                     class="w-full"
                     :min="minPickupDate.toString()"
+                    @change="onMobilePickupDateChange"
                 >
             </u-form-field>
         </div>
@@ -180,6 +181,7 @@
                     class="w-full"
                     :min="minReturnDate.toString()"
                     :max="maxReturnDate?.toString()"
+                    @change="onMobileReturnDateChange"
                 >
             </u-form-field>
         </div>
@@ -341,6 +343,38 @@ const selectedPickupDate = ref<any>(null);
 const selectedReturnDate = ref<any>(null);
 const rentalDays = ref<number>(0);
 const minReturnDate = computed<any>(() => selectedPickupDate.value ?? minPickupDate.value);
+
+// Mobile uses a native <input type="date">. On some Android date pickers an
+// out-of-range value can still be committed, which makes the browser surface
+// its native validation bubble ("El valor debe ser igual o posterior a …").
+// That bubble is unstyleable and renders dark-on-dark under Android force-dark.
+// We never want it: silently snap any out-of-range value back into range on
+// change (the user can't rent in the past anyway). Native date inputs always
+// emit ISO `YYYY-MM-DD`, so lexicographic comparison is chronological. Desktop
+// uses <u-calendar>, which already disables out-of-range days.
+const clampMobileDateInput = (event: Event, min?: string | null, max?: string | null): string | null => {
+    const target = event.target as HTMLInputElement;
+    let value = target.value;
+    if (!value) return null;
+    if (min && value < min) value = min;
+    if (max && value > max) value = max;
+    if (value !== target.value) target.value = value;
+    return value;
+};
+
+const onMobilePickupDateChange = (event: Event) => {
+    const clamped = clampMobileDateInput(event, minPickupDate.value?.toString());
+    if (clamped !== null) selectedPickupDate.value = clamped;
+};
+
+const onMobileReturnDateChange = (event: Event) => {
+    const clamped = clampMobileDateInput(
+        event,
+        minReturnDate.value?.toString(),
+        maxReturnDate.value?.toString(),
+    );
+    if (clamped !== null) selectedReturnDate.value = clamped;
+};
 const pendingSearching = ref<boolean>(false);
 const sortedBranches = ref<any[]>([]);
 const pickupHourOptions = ref<any[]>([]);
@@ -356,6 +390,11 @@ const returnDateCalendarOpen = ref<boolean>(false);
 const calendarUIConfig = {
     heading: '!text-gray-900 !font-bold',
     gridRow: 'w-full',
+    // Center each weekday letter within its column so it lines up vertically
+    // with the day numbers. The default `gridRow` already has place-items-center
+    // (numbers centered) but `gridWeekDaysRow` does not, so without this the
+    // letters left-align inside their column and drift left of the numbers.
+    gridWeekDaysRow: 'w-full place-items-center',
     cellTrigger: '!text-gray-900 !font-semibold data-[disabled]:!text-gray-400 data-[disabled]:!opacity-50 data-[unavailable]:!text-gray-400 data-[unavailable]:!opacity-50 data-[outside-view]:!text-gray-400 data-[outside-view]:!opacity-50'
 };
 


### PR DESCRIPTION
## Qué arregla

Dos bugs del date-picker del buscador, en los 3 brands (`Searcher.vue`).

### 1. Días de la semana desalineados con los números (desktop calendar)
Las letras **L M X J V S D** quedaban a la izquierda de la columna de su número. En el tema de Nuxt UI v4 la fila de números (`gridRow`) trae `place-items-center` (centra el número en su columna) pero la fila de letras (`gridWeekDaysRow`) no, así que las letras se alineaban a la izquierda. El intento previo (#153) añadió `gridRow: w-full`, que igualó el ancho de columnas pero nunca centró las letras.

**Fix:** `gridWeekDaysRow: 'w-full place-items-center'`.

### 2. Tooltip de error negro/ilegible en móvil al elegir una fecha pasada
Era el **globo de validación nativo del navegador** (`<input type="date">` con `min`): es no estilizable (Chrome quitó `::-webkit-validation-bubble*`) y en Android puede salir oscuro pese a `color-scheme: light`.

**Fix:** clamp en silencio. Los inputs nativos móviles ajustan en `@change` cualquier fecha fuera de rango al límite válido (`[min,max]`), así `rangeUnderflow`/`rangeOverflow` nunca se disparan y el globo no aparece. El usuario no puede alquilar en el pasado de todos modos. Desktop usa `<u-calendar>`, que ya deshabilita los días fuera de rango.

## Verificación (runtime, agent-browser)
- **Alineación:** captura del calendario abierto → letras centradas sobre cada número. ✅
- **Clamp recogida:** `2026-06-01` (pasada) → `2026-06-14`, sin mensaje. ✅
- **Clamp devolución < recogida:** → ajusta al mínimo, sin mensaje. ✅
- **Clamp devolución > +30 días:** → ajusta al máximo, sin mensaje. ✅
- **Fecha válida:** pasa sin tocar. ✅
- Cero errores de consola nuevos. Typecheck sin errores en `Searcher.vue` (los existentes son preexistentes en `server/*` y `nuxt.config.ts`).

## Alcance
Solo 3 archivos (`Searcher.vue` × brand). Sin cambios en lógica, store ni tipos. Handlers solo en los inputs nativos móviles; desktop intacto.