### PR TITLE
fix(a11y): suppress native form-validation bubbles site-wide

### DIFF
--- a/packages/logic/plugins/suppress-native-validation-bubble.client.ts
+++ b/packages/logic/plugins/suppress-native-validation-bubble.client.ts
@@ -1,0 +1,27 @@
+/**
+ * Native HTML form-validation bubbles — e.g. "El valor debe ser igual o
+ * posterior a …" shown by a date <input> whose value is below its `min` — are
+ * browser/OS-drawn chrome. They cannot be styled (Chrome removed the
+ * `::-webkit-validation-bubble*` pseudo-elements years ago) and render
+ * dark-on-dark under Android Chrome's force-dark "auto dark theme", even when
+ * the page declares `color-scheme: light`.
+ *
+ * This app does its real validation through valibot + <UForm>/<UFormField>,
+ * which surface their own light-themed inline messages. The native bubble is
+ * therefore never the intended feedback — it is unreadable noise. Suppress it
+ * site-wide.
+ *
+ * The `invalid` event does NOT bubble, so we listen in the capture phase on
+ * `window` to catch it for every current and future field. `preventDefault()`
+ * stops the browser from popping its bubble. Field validity is untouched, so
+ * UForm's schema validation and submit-blocking keep working exactly as before.
+ */
+export default defineNuxtPlugin(() => {
+  if (import.meta.server) return;
+
+  window.addEventListener(
+    'invalid',
+    (event) => event.preventDefault(),
+    true,
+  );
+});


### PR DESCRIPTION
## Problema

Tras #159 (clamp de fechas), el usuario aún veía un **tooltip de error negro/ilegible** en su Android, reproducible en otros casos (p. ej. hoy a mediodía). Inspeccionando todos los controles del buscador en ese estado, **todos reportan `valid: true`** — el globo es el **mensaje de validación nativo del navegador**, que se dispara de forma transitoria (interacción con el picker nativo) y, bajo el force-dark de Chrome Android, se dibuja oscuro-sobre-oscuro pese a `color-scheme: light`.

Esos globos nativos **no son estilizables** (Chrome quitó `::-webkit-validation-bubble*`), así que no se pueden "poner claros". El usuario pidió que **no salga ninguno** (este ni otros que no tenga presentes).

## Solución

Plugin cliente en el **layer compartido `logic`** (aplica a los 3 brands): escucha el evento `invalid` en fase de captura (no burbujea) y hace `preventDefault()`, suprimiendo el globo nativo de cualquier campo, presente o futuro.

- La **validez del campo no se toca** → la validación por esquema (valibot + `<UForm>`/`<UFormField>`, con sus mensajes inline claros) y el bloqueo de submit siguen igual.
- El reservation form usa `<u-form :schema>` con mensajes propios; el buscador no depende de globos nativos (clamp + submit por router-link). Los únicos otros `required` están en herramientas SEO internas.

## Verificación (runtime, agent-browser)
Forzando un valor inválido y llamando `reportValidity()` con el plugin activo:
- `valid: false` (validez intacta) ✅
- `reportValidity(): false` (sigue bloqueando submit) ✅
- `bubbleSuppressed: true` (el `defaultPrevented` del evento `invalid` → no se muestra el globo) ✅
- Consola sin errores.

## Alcance
1 archivo nuevo: `packages/logic/plugins/suppress-native-validation-bubble.client.ts`. Sin cambios en componentes, lógica de negocio ni tipos.