### PR TITLE
fix(ui): ocultar 'Borrar' del date input y igualar tamaño de botones WhatsApp/Llámanos (#161)

### DIFF
--- a/packages/ui-alquicarros/app/assets/css/rentacar-main/base.css
+++ b/packages/ui-alquicarros/app/assets/css/rentacar-main/base.css
@@ -6,6 +6,15 @@ html {
   color-scheme: light;
 }
 
+/* Hide the native clear (✕) button on date inputs. The searcher's date fields
+   are always populated (store defaults + the mobile clamp), so a clear action
+   would only let users empty a required field. Note: the Android OS date-picker
+   dialog's own "Borrar"/"Clear" is drawn by the operating system and cannot be
+   removed from the web side — this only hides the field-level control. */
+input[type="date"]::-webkit-clear-button {
+  display: none;
+}
+
 /* ============================================
    CRITICAL CSS - Previene FOUC en hero section
    Estos estilos deben coincidir con los de Nuxt UI

--- a/packages/ui-alquicarros/app/components/ChatWidget.vue
+++ b/packages/ui-alquicarros/app/components/ChatWidget.vue
@@ -9,7 +9,7 @@
           <p class="text-gray-600">Estamos a un mensaje de distancia</p>
           <UButton
             size="xl"
-            class="bg-[#25D366] hover:bg-[#128C7E] text-white mt-3 transition-colors"
+            class="bg-[#25D366] hover:bg-[#128C7E] text-white mt-3 transition-colors w-64 justify-center py-4"
             label="Whatsapp"
             target="_blank"
             :external="true"
@@ -26,7 +26,7 @@
           <UButton
             color="info"
             size="xl"
-            class="text-white mt-3"
+            class="text-white mt-3 w-64 justify-center py-4"
             :external="true"
             :label="franchise.phone"
             :to="`tel:${franchise.phone}`"

--- a/packages/ui-alquilame/app/assets/css/rentacar-main/base.css
+++ b/packages/ui-alquilame/app/assets/css/rentacar-main/base.css
@@ -6,6 +6,15 @@ html {
   color-scheme: light;
 }
 
+/* Hide the native clear (✕) button on date inputs. The searcher's date fields
+   are always populated (store defaults + the mobile clamp), so a clear action
+   would only let users empty a required field. Note: the Android OS date-picker
+   dialog's own "Borrar"/"Clear" is drawn by the operating system and cannot be
+   removed from the web side — this only hides the field-level control. */
+input[type="date"]::-webkit-clear-button {
+  display: none;
+}
+
 /* ============================================
    CRITICAL CSS - Previene FOUC en hero section
    Estos estilos deben coincidir con los de Nuxt UI

--- a/packages/ui-alquilatucarro/app/assets/css/rentacar-main/base.css
+++ b/packages/ui-alquilatucarro/app/assets/css/rentacar-main/base.css
@@ -6,6 +6,15 @@ html {
   color-scheme: light;
 }
 
+/* Hide the native clear (✕) button on date inputs. The searcher's date fields
+   are always populated (store defaults + the mobile clamp), so a clear action
+   would only let users empty a required field. Note: the Android OS date-picker
+   dialog's own "Borrar"/"Clear" is drawn by the operating system and cannot be
+   removed from the web side — this only hides the field-level control. */
+input[type="date"]::-webkit-clear-button {
+  display: none;
+}
+
 /* ============================================
    CRITICAL CSS - Previene FOUC en hero section
    Estos estilos deben coincidir con los de Nuxt UI

--- a/packages/ui-alquilatucarro/app/components/ChatWidget.vue
+++ b/packages/ui-alquilatucarro/app/components/ChatWidget.vue
@@ -9,7 +9,7 @@
           <p class="text-gray-600">Estamos a un mensaje de distancia</p>
           <UButton
             size="xl"
-            class="bg-[#25D366] hover:bg-[#128C7E] text-white mt-3 transition-colors"
+            class="bg-[#25D366] hover:bg-[#128C7E] text-white mt-3 transition-colors w-64 justify-center py-4"
             label="Whatsapp"
             target="_blank"
             :external="true"
@@ -26,7 +26,7 @@
           <UButton
             color="info"
             size="xl"
-            class="text-white mt-3"
+            class="text-white mt-3 w-64 justify-center py-4"
             :external="true"
             :label="franchise.phone"
             :to="`tel:${franchise.phone}`"


### PR DESCRIPTION
Implementa los puntos **3** y **4** de #161.

## 3. Quitar "Borrar" del selector de fecha
`input[type="date"]::-webkit-clear-button { display: none; }` en el `base.css` de los 3 brands.
- Oculta el botón limpiar (✕) **a nivel del campo**. Los campos de fecha del buscador siempre están poblados (defaults del store + clamp de #159), así que ese clear solo permitía vaciar un campo requerido.
- **Limitación honesta:** el botón "Borrar" del **diálogo nativo del SO en Android** lo dibuja el sistema operativo y **no** es removible desde la web. Esta regla cubre la parte que sí es controlable (queda documentado en el comentario del CSS).

## 4. Botones WhatsApp y Llámanos: alto = botón de tarjeta, ancho igual entre sí
`ChatWidget.vue` (alquilatucarro + alquicarros): a ambos botones se les añade `py-4` (mismo alto que el botón principal de la tarjeta `.boton-seleccion` = `size="xl"` + `py-4`) y `w-64 justify-center` (mismo ancho entre sí; antes dependía del contenido: "Whatsapp" vs el número).

- **`alquilame` se deja intacto a propósito**: su ChatWidget es un FAB de iconos circulares (diseño distinto), no tiene botones etiquetados WhatsApp/Llámanos.

## Verificación (runtime, agent-browser)
- Item 3: la regla `::-webkit-clear-button { display:none }` está presente en el CSS cargado en runtime.
- Item 4: con el modal abierto, ambos botones miden **256×56** (ancho y alto idénticos entre sí). Captura adjunta abajo.
- Paridad de alto con la tarjeta: garantizada por construcción (mismo `size="xl"` + `py-4` que `.boton-seleccion`). No pude medir el botón de tarjeta en local porque las páginas de búsqueda dan 500 en local (issue de entorno ya conocido) — se confirma en el preview de Vercel.
- Sin errores de consola.

## Alcance
5 archivos: 3× `base.css` (item 3) + 2× `ChatWidget.vue` (item 4). Sin cambios en lógica ni tipos. Los puntos 1 y 2 de #161 (imágenes rotas por el optimizer de Vercel en `w=1536`) quedan pendientes en la issue.