### PR TITLE
fix(image): imágenes rotas — agregar 1536 a image.screens para el optimizer de Vercel (#161)

### DIFF
--- a/packages/ui-alquicarros/nuxt.config.ts
+++ b/packages/ui-alquicarros/nuxt.config.ts
@@ -544,7 +544,11 @@ export default defineNuxtConfig({
       nitroConfig.vercel = nitroConfig.vercel || {}
       nitroConfig.vercel.config = nitroConfig.vercel.config || {}
       nitroConfig.vercel.config.images = {
-        sizes: [320, 640, 768, 1024, 1280],
+        // Must include every width the @nuxt/image srcset can request, or the
+        // Vercel optimizer returns 400 and the image breaks. Our 800px images on
+        // 2x screens request w=1536, so 1536 must be here. Keep in sync with
+        // `image.screens` above (#161).
+        sizes: [320, 640, 768, 1024, 1280, 1536],
         qualities: [80],
         formats: ['image/webp'],
         minimumCacheTTL: 2678400,

--- a/packages/ui-alquicarros/nuxt.config.ts
+++ b/packages/ui-alquicarros/nuxt.config.ts
@@ -434,6 +434,13 @@ export default defineNuxtConfig({
       md: 768,
       lg: 1024,
       xl: 1280,
+      // The Vercel image optimizer only accepts widths present in images.sizes,
+      // which @nuxt/image derives from these screen values at build time. The
+      // runtime srcset for our 800px images on 2x screens requests w=1536, so
+      // 1536 must be a screen value here — otherwise /_vercel/image returns 400
+      // and the image breaks (#161). Keep this in sync with the widths the
+      // generated srcset can actually request.
+      xxl: 1536,
     },
   },
 

--- a/packages/ui-alquilame/nuxt.config.ts
+++ b/packages/ui-alquilame/nuxt.config.ts
@@ -557,7 +557,11 @@ export default defineNuxtConfig({
       nitroConfig.vercel = nitroConfig.vercel || {}
       nitroConfig.vercel.config = nitroConfig.vercel.config || {}
       nitroConfig.vercel.config.images = {
-        sizes: [320, 640, 768, 1024, 1280],
+        // Must include every width the @nuxt/image srcset can request, or the
+        // Vercel optimizer returns 400 and the image breaks. Our 800px images on
+        // 2x screens request w=1536, so 1536 must be here. Keep in sync with
+        // `image.screens` above (#161).
+        sizes: [320, 640, 768, 1024, 1280, 1536],
         qualities: [80],
         formats: ['image/webp'],
         minimumCacheTTL: 2678400,

--- a/packages/ui-alquilame/nuxt.config.ts
+++ b/packages/ui-alquilame/nuxt.config.ts
@@ -448,6 +448,13 @@ export default defineNuxtConfig({
       md: 768,
       lg: 1024,
       xl: 1280,
+      // The Vercel image optimizer only accepts widths present in images.sizes,
+      // which @nuxt/image derives from these screen values at build time. The
+      // runtime srcset for our 800px images on 2x screens requests w=1536, so
+      // 1536 must be a screen value here — otherwise /_vercel/image returns 400
+      // and the image breaks (#161). Keep this in sync with the widths the
+      // generated srcset can actually request.
+      xxl: 1536,
     },
   },
 

--- a/packages/ui-alquilatucarro/nuxt.config.ts
+++ b/packages/ui-alquilatucarro/nuxt.config.ts
@@ -488,6 +488,13 @@ export default defineNuxtConfig({
       md: 768,
       lg: 1024,
       xl: 1280,
+      // The Vercel image optimizer only accepts widths present in images.sizes,
+      // which @nuxt/image derives from these screen values at build time. The
+      // runtime srcset for our 800px images on 2x screens requests w=1536, so
+      // 1536 must be a screen value here — otherwise /_vercel/image returns 400
+      // and the image breaks (#161). Keep this in sync with the widths the
+      // generated srcset can actually request.
+      xxl: 1536,
     },
   },
 

--- a/packages/ui-alquilatucarro/nuxt.config.ts
+++ b/packages/ui-alquilatucarro/nuxt.config.ts
@@ -597,7 +597,11 @@ export default defineNuxtConfig({
       nitroConfig.vercel = nitroConfig.vercel || {}
       nitroConfig.vercel.config = nitroConfig.vercel.config || {}
       nitroConfig.vercel.config.images = {
-        sizes: [320, 640, 768, 1024, 1280],
+        // Must include every width the @nuxt/image srcset can request, or the
+        // Vercel optimizer returns 400 and the image breaks. Our 800px images on
+        // 2x screens request w=1536, so 1536 must be here. Keep in sync with
+        // `image.screens` above (#161).
+        sizes: [320, 640, 768, 1024, 1280, 1536],
         qualities: [80],
         formats: ['image/webp'],
         minimumCacheTTL: 2678400,


### PR DESCRIPTION
Resuelve los puntos **1 y 2** de #161 (imágenes que no cargaban).

## Causa raíz (confirmada en prod)
Las imágenes de la sección "descripción" de las landings de ciudad (`chica.webp`) y las 3 de "Tipos de Vehículos" en la home (`compacto/sedan/suv.webp`) salían rotas (`naturalWidth: 0`).

El asset crudo siempre estuvo bien (`200`, vive en `packages/logic/public/images/`). El que fallaba era el **optimizador de Vercel**: solo acepta anchos presentes en `images.sizes`, que `@nuxt/image` deriva de `image.screens` en build. `1536` no estaba (los `screens` llegaban hasta `xl: 1280`), pero el `srcset` en runtime **sí** pide `/_vercel/image?...&w=1536` (imágenes de 800px en pantallas 2x). Resultado: `400` → imagen rota.

Evidencia (prod `alquilatucarro.com`, `compacto.webp`):
```
w=640 →200   w=768 →200   w=1024→200   w=1280→200
w=750 →400   w=828 →400   w=1080→400   w=1200→400   w=1536→400   w=1920→400
```
El `srcset` real pedía `640, 768, 1024, 1536` → el `1536` rompía.

## Fix
Agregar `xxl: 1536` a `image.screens` en los 3 brands → `images.sizes` ahora incluye 1536, que es justo lo que el `srcset` pide. Cambio mínimo y simétrico (3 líneas efectivas + comentario).

## Verificación
No se puede reproducir en local (el `/_vercel/image` da 500 en local, issue de entorno conocido). Se verifica en el **preview de Vercel** de este PR: `GET /_vercel/image?url=%2Fimages%2Fcategorias%2Fcompacto.webp&w=1536&q=80` debe responder **200** (antes 400). Pego el resultado en un comentario del PR.

## Alcance
3 archivos (`nuxt.config.ts` × brand), solo config de imagen. Sin cambios en componentes ni lógica.