### PR TITLE
fix(searcher): eliminar min/max de los date inputs móviles para matar el tooltip negro de Android

### DIFF
--- a/packages/logic/src/stores/__tests__/useStoreReservationForm.minReturnDate.test.ts
+++ b/packages/logic/src/stores/__tests__/useStoreReservationForm.minReturnDate.test.ts
@@ -64,10 +64,24 @@ describe.each(BRANDS)(
       expect(calendarBlock).not.toMatch(/:min-value="minPickupDate"/)
     })
 
-    it('binds the mobile return <input type="date"> min to minReturnDate, not minPickupDate', () => {
+    it('clamps the mobile return <input type="date"> into [minReturnDate, maxReturnDate] via @change, with no native min/max', () => {
+      // The mobile native input carries NO `min`/`max` on purpose: a native
+      // `min` makes the field `:invalid` for out-of-range dates and Android
+      // Chrome then shows an unstyleable dark validation balloon (unreadable
+      // under force-dark). Range is enforced by the @change clamp instead, so
+      // the field is never `:invalid`.
       const mobileInput = extractBlock(source, 'id="return-date-mobile"', '>')
-      expect(mobileInput).toContain(':min="minReturnDate.toString()"')
-      expect(mobileInput).not.toMatch(/:min="minPickupDate\.toString\(\)"/)
+      expect(mobileInput).toContain('@change="onMobileReturnDateChange"')
+      expect(mobileInput).not.toMatch(/:min=/)
+      expect(mobileInput).not.toMatch(/:max=/)
+
+      // The clamp still floors the return at minReturnDate (tracks the selected
+      // pickup), not minPickupDate, so a return before the chosen pickup snaps
+      // back up — preserving the original scenario this suite guards.
+      const handler = extractBlock(source, 'const onMobileReturnDateChange =', '};')
+      expect(handler).toContain('minReturnDate.value?.toString()')
+      expect(handler).toContain('maxReturnDate.value?.toString()')
+      expect(handler).not.toMatch(/minPickupDate\.value/)
     })
   },
 )

--- a/packages/ui-alquicarros/app/components/Searcher.vue
+++ b/packages/ui-alquicarros/app/components/Searcher.vue
@@ -103,6 +103,11 @@
         <!-- MÓVIL: Form field con input date nativo -->
         <div class="bg-white rounded-xl p-2 shadow-sm sm:hidden">
             <u-form-field label="Día de recogida" size="xl">
+                <!-- No `min`/`max` here on purpose: a native `min` makes the field
+                     `:invalid` for out-of-range dates, and Android Chrome then shows
+                     an unstyleable dark validation balloon (unreadable under
+                     force-dark). The @change handler clamps the value into range
+                     instead, so the field is never `:invalid`. -->
                 <input
                     v-if="minPickupDate"
                     type="date"
@@ -111,7 +116,6 @@
                     v-model="selectedPickupDate"
                     aria-label="Día de recogida"
                     class="w-full"
-                    :min="minPickupDate.toString()"
                     @change="onMobilePickupDateChange"
                 >
             </u-form-field>
@@ -171,6 +175,8 @@
                 class="absolute top-0 right-0 z-10 bg-[#a3f78b] text-black text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
             >{{ rentalDays }} {{ rentalDays === 1 ? 'día' : 'días' }}</span>
             <u-form-field label="Día de devolución" size="xl">
+                <!-- No `min`/`max` here on purpose — see the pickup-date note above.
+                     The @change handler clamps into [minReturnDate, maxReturnDate]. -->
                 <input
                     v-if="minReturnDate"
                     type="date"
@@ -179,8 +185,6 @@
                     v-model="selectedReturnDate"
                     aria-label="Día de devolución"
                     class="w-full"
-                    :min="minReturnDate.toString()"
-                    :max="maxReturnDate?.toString()"
                     @change="onMobileReturnDateChange"
                 >
             </u-form-field>

--- a/packages/ui-alquilame/app/components/Searcher.vue
+++ b/packages/ui-alquilame/app/components/Searcher.vue
@@ -103,6 +103,11 @@
         <!-- MÓVIL: Form field con input date nativo -->
         <div class="bg-white rounded-xl p-2 shadow-sm sm:hidden">
             <u-form-field label="Día de recogida" size="xl">
+                <!-- No `min`/`max` here on purpose: a native `min` makes the field
+                     `:invalid` for out-of-range dates, and Android Chrome then shows
+                     an unstyleable dark validation balloon (unreadable under
+                     force-dark). The @change handler clamps the value into range
+                     instead, so the field is never `:invalid`. -->
                 <input
                     v-if="minPickupDate"
                     type="date"
@@ -111,7 +116,6 @@
                     v-model="selectedPickupDate"
                     aria-label="Día de recogida"
                     class="w-full"
-                    :min="minPickupDate.toString()"
                     @change="onMobilePickupDateChange"
                 >
             </u-form-field>
@@ -171,6 +175,8 @@
                 class="absolute top-0 right-0 z-10 bg-red-600 text-white text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
             >{{ rentalDays }} {{ rentalDays === 1 ? 'día' : 'días' }}</span>
             <u-form-field label="Día de devolución" size="xl">
+                <!-- No `min`/`max` here on purpose — see the pickup-date note above.
+                     The @change handler clamps into [minReturnDate, maxReturnDate]. -->
                 <input
                     v-if="minReturnDate"
                     type="date"
@@ -179,8 +185,6 @@
                     v-model="selectedReturnDate"
                     aria-label="Día de devolución"
                     class="w-full"
-                    :min="minReturnDate.toString()"
-                    :max="maxReturnDate?.toString()"
                     @change="onMobileReturnDateChange"
                 >
             </u-form-field>

--- a/packages/ui-alquilatucarro/app/components/Searcher.vue
+++ b/packages/ui-alquilatucarro/app/components/Searcher.vue
@@ -103,6 +103,11 @@
         <!-- MÓVIL: Form field con input date nativo -->
         <div class="bg-white rounded-xl px-2 py-2 max-sm:py-0.5! shadow-sm sm:hidden">
             <u-form-field label="Día de recogida" size="xl">
+                <!-- No `min`/`max` here on purpose: a native `min` makes the field
+                     `:invalid` for out-of-range dates, and Android Chrome then shows
+                     an unstyleable dark validation balloon (unreadable under
+                     force-dark). The @change handler clamps the value into range
+                     instead, so the field is never `:invalid`. -->
                 <input
                     v-if="minPickupDate"
                     type="date"
@@ -111,7 +116,6 @@
                     v-model="selectedPickupDate"
                     aria-label="Día de recogida"
                     class="w-full"
-                    :min="minPickupDate.toString()"
                     @change="onMobilePickupDateChange"
                 >
             </u-form-field>
@@ -171,6 +175,8 @@
                 class="absolute top-0 right-0 z-10 bg-[#a3f78b] text-black text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
             >{{ rentalDays }} {{ rentalDays === 1 ? 'día' : 'días' }}</span>
             <u-form-field label="Día de devolución" size="xl">
+                <!-- No `min`/`max` here on purpose — see the pickup-date note above.
+                     The @change handler clamps into [minReturnDate, maxReturnDate]. -->
                 <input
                     v-if="minReturnDate"
                     type="date"
@@ -179,8 +185,6 @@
                     v-model="selectedReturnDate"
                     aria-label="Día de devolución"
                     class="w-full"
-                    :min="minReturnDate.toString()"
-                    :max="maxReturnDate?.toString()"
                     @change="onMobileReturnDateChange"
                 >
             </u-form-field>


### PR DESCRIPTION
## Problema
El tooltip de error **negro/ilegible** en móvil seguía apareciendo pese a #159 (clamp) y #160 (supresión global del evento `invalid`).

## Diagnóstico (en prod, emulación móvil)
Confirmé que **ambos arreglos previos funcionan** en prod:
- Clamp (#159): una fecha pasada se ajusta sola al mínimo (`2026-06-01` → hoy). ✅
- Supresor (#160): `reportValidity()` → `bubbleSuppressed: true`. ✅

Entonces el tooltip que queda **no** es el globo que se dispara por submit/`reportValidity`. Es el **globo de validación automático de Chrome Android**, que se muestra mientras el `<input type="date">` está `:invalid` por su atributo `min` durante la interacción con el picker. Ese globo **no es un evento `invalid` cancelable**, así que el supresor no lo agarra, y bajo force-dark se dibuja oscuro-sobre-oscuro.

## Fix
Quitar `min`/`max` de los `<input type="date">` **móviles**. Sin `min`/`max` el campo **nunca** queda `:invalid`, así que Chrome no tiene nada que reportar → no hay globo, de ningún color.

El rango se sigue garantizando con el clamp `@change` existente (lee los refs `minPickupDate`/`minReturnDate`/`maxReturnDate`, no los atributos del elemento).

## Verificación (runtime)
```
pickup móvil: hasMinAttr=false, fecha pasada → valid:true (¡nunca inválido!), clamp → hoy
return móvil: hasMin/hasMax=false, clampedLow→2026-06-16, clampedHigh→2026-07-16, validAlways:true
```
- Desktop intacto: `<u-calendar>`/`<u-input-date>` conservan `min-value`/`max-value` (están estilizados, sin problema de color).

## Alcance
3 archivos (`Searcher.vue` × brand). Mantiene los handlers de clamp; solo elimina los atributos `min`/`max` del elemento nativo móvil.

## Nota
Si el elemento oscuro que ves fuera realmente el **diálogo del calendario nativo del SO** (no este globo de error), eso ya sería force-dark a nivel de Android y no removible desde la web. Pero la evidencia (aparece al elegir fecha inválida, tipo "mensaje de error") apunta al globo de validación, que este PR elimina de raíz.