### PR TITLE
fix(reservation-resume): quitar borde de pico y placa, Gama en negrilla, descripción con mayúscula inicial

### DIFF
--- a/packages/ui-alquicarros/app/assets/css/rentacar-main/reservation-resume.css
+++ b/packages/ui-alquicarros/app/assets/css/rentacar-main/reservation-resume.css
@@ -13,11 +13,11 @@
         @apply flex flex-col text-sm text-black;
 
         .category-name {
-            @apply mb-0 text-sm;
+            @apply mb-0 text-sm font-bold;
         }
 
         .category-description {
-            @apply lowercase leading-tight font-bold;
+            @apply lowercase first-letter:uppercase leading-tight font-bold;
         }
 
         .category-picoyplaca {

--- a/packages/ui-alquicarros/app/components/ReservationResume.vue
+++ b/packages/ui-alquicarros/app/components/ReservationResume.vue
@@ -14,7 +14,7 @@
           <div class="category-name" v-text="`Gama ${categoryCode}`"></div>
           <div class="category-description" v-text="categoryDescription"></div>
           <div v-if="isPicoyPlacaExempt()" class="category-picoyplaca" >
-            <span class="inline-block px-2 py-0.5 text-xs bg-[#a3f78b] border border-green-600 text-green-900 rounded-full">sin pico y placa</span>
+            <span class="inline-block px-2 py-0.5 text-xs bg-[#a3f78b] text-green-900 rounded-full">sin pico y placa</span>
           </div>
           <div class="pickup-info">
             <div class="pickup-location">

--- a/packages/ui-alquilame/app/assets/css/rentacar-main/reservation-resume.css
+++ b/packages/ui-alquilame/app/assets/css/rentacar-main/reservation-resume.css
@@ -15,11 +15,11 @@
         /* Brand: Gama title uses .heading-card (Plus Jakarta) + red from the
            template; keep tight bottom margin here. */
         .category-name {
-            @apply mb-0 text-sm;
+            @apply mb-0 text-sm font-bold;
         }
 
         .category-description {
-            @apply lowercase leading-tight font-bold;
+            @apply lowercase first-letter:uppercase leading-tight font-bold;
         }
 
         .category-picoyplaca {

--- a/packages/ui-alquilame/app/components/ReservationResume.vue
+++ b/packages/ui-alquilame/app/components/ReservationResume.vue
@@ -15,7 +15,7 @@
           <div class="category-name heading-card text-red-700" v-text="`Gama ${categoryCode}`"></div>
           <div class="category-description" v-text="categoryDescription"></div>
           <div v-if="isPicoyPlacaExempt()" class="category-picoyplaca" >
-            <span class="inline-block px-2 py-0.5 text-xs bg-[#a3f78b] border border-green-600 text-green-900 rounded-full">sin pico y placa</span>
+            <span class="inline-block px-2 py-0.5 text-xs bg-[#a3f78b] text-green-900 rounded-full">sin pico y placa</span>
           </div>
           <div class="pickup-info">
             <div class="pickup-location">

--- a/packages/ui-alquilatucarro/app/assets/css/rentacar-main/reservation-resume.css
+++ b/packages/ui-alquilatucarro/app/assets/css/rentacar-main/reservation-resume.css
@@ -13,11 +13,11 @@
         @apply flex flex-col text-sm text-black;
 
         .category-name {
-            @apply mb-0 text-sm;
+            @apply mb-0 text-sm font-bold;
         }
 
         .category-description {
-            @apply lowercase leading-tight font-bold;
+            @apply lowercase first-letter:uppercase leading-tight font-bold;
         }
 
         .category-picoyplaca {

--- a/packages/ui-alquilatucarro/app/components/ReservationResume.vue
+++ b/packages/ui-alquilatucarro/app/components/ReservationResume.vue
@@ -14,7 +14,7 @@
           <div class="category-name" v-text="`Gama ${categoryCode}`"></div>
           <div class="category-description" v-text="categoryDescription"></div>
           <div v-if="isPicoyPlacaExempt()" class="category-picoyplaca" >
-            <span class="inline-block px-2 py-0.5 text-xs bg-[#a3f78b] border border-green-600 text-green-900 rounded-full">sin pico y placa</span>
+            <span class="inline-block px-2 py-0.5 text-xs bg-[#a3f78b] text-green-900 rounded-full">sin pico y placa</span>
           </div>
           <div class="pickup-info">
             <div class="pickup-location">


### PR DESCRIPTION
Cambios en el **resumen de reserva** (los 3 brands), pedidos por el usuario:

1. **Pico y placa sin borde:** la píldora "sin pico y placa" ya no tiene el aro verde (`border border-green-600`); conserva fondo `#a3f78b` y texto verde.
2. **"Gama \<código\>" en negrilla:** `.category-name` ahora `font-bold`.
3. **Descripción con primera letra en mayúscula:** `.category-description` pasa de `lowercase` a `lowercase first-letter:uppercase` → "sedán automático" se muestra como **"Sedán automático"** (solo la primera letra).

## Nota de interpretación
"primera letra en mayúscula" lo implementé como **solo la primera letra** ("Sedán automático"). Si lo querías con **cada palabra** en mayúscula ("Sedán Automático"), cambio `first-letter:uppercase` por `capitalize` — avísame.

## Verificación
El resumen solo aparece tras hacer una búsqueda y elegir categoría (que da 500 en local), así que verifico en el **preview de Vercel** de este PR (búsqueda real → tarjeta → slideover de resumen) y pego captura.

## Alcance
6 archivos: `ReservationResume.vue` + `reservation-resume.css` × 3 brands. Solo presentación.