### PR TITLE
fix(searcher): mover el chip de días del selector de fecha de entrega 3px arriba y 3px a la derecha

### DIFF
--- a/packages/ui-alquicarros/app/components/Searcher.vue
+++ b/packages/ui-alquicarros/app/components/Searcher.vue
@@ -172,7 +172,7 @@
         <div class="relative bg-white rounded-xl p-2 shadow-sm sm:hidden">
             <span
                 v-if="rentalDays > 0"
-                class="absolute top-0 right-0 z-10 bg-[#a3f78b] text-black text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
+                class="absolute -top-[3px] -right-[3px] z-10 bg-[#a3f78b] text-black text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
             >{{ rentalDays }} {{ rentalDays === 1 ? 'día' : 'días' }}</span>
             <u-form-field label="Día de devolución" size="xl">
                 <!-- No `min`/`max` here on purpose — see the pickup-date note above.
@@ -194,7 +194,7 @@
         <div class="relative bg-white rounded-xl p-2 shadow-sm hidden sm:block">
             <span
                 v-if="rentalDays > 0"
-                class="absolute top-0 right-0 z-10 bg-[#a3f78b] text-black text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
+                class="absolute -top-[3px] -right-[3px] z-10 bg-[#a3f78b] text-black text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
             >{{ rentalDays }} {{ rentalDays === 1 ? 'día' : 'días' }}</span>
             <u-form-field label="Día de devolución" size="xl">
                 <u-input-date

--- a/packages/ui-alquilame/app/components/Searcher.vue
+++ b/packages/ui-alquilame/app/components/Searcher.vue
@@ -172,7 +172,7 @@
         <div class="relative bg-white rounded-xl p-2 shadow-sm sm:hidden">
             <span
                 v-if="rentalDays > 0"
-                class="absolute top-0 right-0 z-10 bg-red-600 text-white text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
+                class="absolute -top-[3px] -right-[3px] z-10 bg-red-600 text-white text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
             >{{ rentalDays }} {{ rentalDays === 1 ? 'día' : 'días' }}</span>
             <u-form-field label="Día de devolución" size="xl">
                 <!-- No `min`/`max` here on purpose — see the pickup-date note above.
@@ -194,7 +194,7 @@
         <div class="relative bg-white rounded-xl p-2 shadow-sm hidden sm:block">
             <span
                 v-if="rentalDays > 0"
-                class="absolute top-0 right-0 z-10 bg-red-600 text-white text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
+                class="absolute -top-[3px] -right-[3px] z-10 bg-red-600 text-white text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
             >{{ rentalDays }} {{ rentalDays === 1 ? 'día' : 'días' }}</span>
             <u-form-field label="Día de devolución" size="xl">
                 <u-input-date

--- a/packages/ui-alquilatucarro/app/components/Searcher.vue
+++ b/packages/ui-alquilatucarro/app/components/Searcher.vue
@@ -172,7 +172,7 @@
         <div class="relative bg-white rounded-xl px-2 py-2 max-sm:py-0.5! shadow-sm sm:hidden">
             <span
                 v-if="rentalDays > 0"
-                class="absolute top-0 right-0 z-10 bg-[#a3f78b] text-black text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
+                class="absolute -top-[3px] -right-[3px] z-10 bg-[#a3f78b] text-black text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
             >{{ rentalDays }} {{ rentalDays === 1 ? 'día' : 'días' }}</span>
             <u-form-field label="Día de devolución" size="xl">
                 <!-- No `min`/`max` here on purpose — see the pickup-date note above.
@@ -194,7 +194,7 @@
         <div class="relative bg-white rounded-xl px-2 py-2 max-sm:py-0.5! shadow-sm hidden sm:block">
             <span
                 v-if="rentalDays > 0"
-                class="absolute top-0 right-0 z-10 bg-[#a3f78b] text-black text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
+                class="absolute -top-[3px] -right-[3px] z-10 bg-[#a3f78b] text-black text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
             >{{ rentalDays }} {{ rentalDays === 1 ? 'día' : 'días' }}</span>
             <u-form-field label="Día de devolución" size="xl">
                 <u-input-date


### PR DESCRIPTION
El chip "\<n\> días" del selector **Día de devolución** pasa de `top-0 right-0` a `-top-[3px] -right-[3px]` (es decir `top:-3px; right:-3px`) → 3px más arriba y 3px más a la derecha.

Aplicado en los 3 brands, tanto la instancia **móvil** como la **desktop**.

Verificado en runtime: el chip computa `top: -3px` y `right: -3px`; la tarjeta contenedora no recorta (sin overflow), así que el chip queda limpio sobre la esquina superior derecha.

Alcance: 3 archivos (`Searcher.vue` × brand), solo posicionamiento del chip.