### PR TITLE
feat(searcher): evitar hora de recogida pasada (hoy) + aviso amable en vez de 'Error'

### DIFF
--- a/packages/logic/src/composables/useSearch.ts
+++ b/packages/logic/src/composables/useSearch.ts
@@ -15,6 +15,8 @@ import useMessages from './useMessages';
 import {
   createTimeFromString,
   createCurrentDateObject,
+  createCurrentDateTimeObject,
+  futurePickupHourOptions,
   toDatetime,
   formatHumanTime,
   formatTime,
@@ -96,6 +98,22 @@ export default function useSearch() {
   
   const doSearch = () => {
     flushMessages();
+
+    // Block a pickup that is already in the past before hitting the backend.
+    // Realistically this is only the hour on today's date (past dates are
+    // blocked by the calendar/mobile clamp). Show a friendly notice instead of
+    // the backend's harsh "Error" toast, and skip the search entirely.
+    if (selectedPickupDate.value && horaRecogida.value) {
+      const pickupAt = toDatetime(selectedPickupDate.value, createTimeFromString(horaRecogida.value));
+      if (pickupAt.compare(createCurrentDateTimeObject()) <= 0) {
+        createMessage({
+          type: "info",
+          title: "Revisa la hora de recogida",
+          message: "Por favor escoge una hora de recogida posterior a la hora actual.",
+        });
+        return;
+      }
+    }
 
     if (horaRecogida.value != horaDevolucion.value) {
       createMessage({
@@ -222,8 +240,28 @@ export default function useSearch() {
     };
   });
 
-  // Usa cache estático - no regenera 48 opciones en cada re-render
-  const pickupHourOptions = computed(() => getHourOptions());
+  // When the pickup date is today, only offer hours strictly after the current
+  // time (a customer can't pick a slot that already passed → no backend "past
+  // date" error). Any future date offers the full static list. Late-night
+  // fallback: if nothing is left today, keep all options so the select isn't
+  // empty — the doSearch guard still blocks an actually-past pickup.
+  const pickupHourOptions = computed(() => {
+    const allOptions = getHourOptions();
+    const pickupDate = selectedPickupDate.value;
+    if (!pickupDate) return allOptions;
+    const filtered = futurePickupHourOptions(allOptions, pickupDate, createCurrentDateTimeObject());
+    return filtered.length ? filtered : allOptions;
+  });
+
+  // Keep the selected pickup hour valid: when the date moves to today and the
+  // chosen hour is now in the past, snap to the earliest still-available slot.
+  // horaDevolucion follows via the horaRecogida → horaDevolucion sync watcher.
+  watch(pickupHourOptions, (options) => {
+    if (!horaRecogida.value || !options.length) return;
+    if (!options.some((o) => o.value === horaRecogida.value)) {
+      horaRecogida.value = options[0].value;
+    }
+  });
 
   // Filtra desde cache cuando hay restricción mensual
   const returnHourOptions = computed(() => {

--- a/packages/logic/src/utils/__tests__/futurePickupHourOptions.test.ts
+++ b/packages/logic/src/utils/__tests__/futurePickupHourOptions.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import {
+  futurePickupHourOptions,
+  createDateFromString,
+  createDateTimeFromString,
+} from '../useDateFunctions'
+
+// A customer choosing today as the pickup date must not be offered an hour that
+// already passed (e.g. it's 5:05 p.m. and they pick noon) — the backend rejects
+// that pickup. futurePickupHourOptions trims the hour list to slots strictly
+// after "now" on the same day, and leaves future dates untouched. Pure: "now"
+// is injected so the cases below are deterministic.
+
+const OPTS = [
+  { value: '00:00' },
+  { value: '11:30' },
+  { value: '12:00' },
+  { value: '17:00' },
+  { value: '17:30' },
+  { value: '18:00' },
+  { value: '23:30' },
+]
+
+describe('futurePickupHourOptions', () => {
+  it('keeps every option when the pickup date is in the future', () => {
+    const pickup = createDateFromString('2026-08-02')
+    const now = createDateTimeFromString('2026-08-01T17:05:00')
+    expect(futurePickupHourOptions(OPTS, pickup, now)).toEqual(OPTS)
+  })
+
+  it('on today, drops slots at or before the current time', () => {
+    const pickup = createDateFromString('2026-08-01')
+    const now = createDateTimeFromString('2026-08-01T17:05:00')
+    expect(futurePickupHourOptions(OPTS, pickup, now).map((o) => o.value)).toEqual([
+      '17:30',
+      '18:00',
+      '23:30',
+    ])
+  })
+
+  it('on today, a slot exactly equal to now is excluded (strictly after)', () => {
+    const pickup = createDateFromString('2026-08-01')
+    const now = createDateTimeFromString('2026-08-01T17:30:00')
+    expect(futurePickupHourOptions(OPTS, pickup, now).map((o) => o.value)).toEqual([
+      '18:00',
+      '23:30',
+    ])
+  })
+
+  it('just after midnight keeps the rest of the day but drops 00:00', () => {
+    const pickup = createDateFromString('2026-08-01')
+    const now = createDateTimeFromString('2026-08-01T00:01:00')
+    expect(futurePickupHourOptions(OPTS, pickup, now).map((o) => o.value)).toEqual([
+      '11:30',
+      '12:00',
+      '17:00',
+      '17:30',
+      '18:00',
+      '23:30',
+    ])
+  })
+
+  it('returns empty late at night (caller is responsible for the fallback)', () => {
+    const pickup = createDateFromString('2026-08-01')
+    const now = createDateTimeFromString('2026-08-01T23:45:00')
+    expect(futurePickupHourOptions(OPTS, pickup, now)).toEqual([])
+  })
+})

--- a/packages/logic/src/utils/useDateFunctions.ts
+++ b/packages/logic/src/utils/useDateFunctions.ts
@@ -1,12 +1,14 @@
-import { 
+import {
     toCalendarDateTime,
     DateFormatter,
-    parseDate, 
-    parseDateTime, 
-    parseTime, 
-    today
+    parseDate,
+    parseDateTime,
+    parseTime,
+    today,
+    now,
+    Time
 } from '@internationalized/date';
-import type { CalendarDate, CalendarDateTime, Time } from '@internationalized/date';
+import type { CalendarDate, CalendarDateTime } from '@internationalized/date';
 
 export type DateObject = CalendarDate;
 export type DateTimeObject = CalendarDateTime;
@@ -16,6 +18,36 @@ const defaultTimezone = 'America/Bogota';
 
 export function createCurrentDateObject(): DateObject {
     return today(defaultTimezone);
+}
+
+/**
+ * Current wall-clock datetime in the app timezone (America/Bogota), as a
+ * CalendarDateTime. Used to compare a chosen pickup moment against "now".
+ */
+export function createCurrentDateTimeObject(): DateTimeObject {
+    return toCalendarDateTime(now(defaultTimezone));
+}
+
+/**
+ * Filter pickup-hour options to those still valid for `pickupDate` relative to
+ * `nowDateTime`. When `pickupDate` is the same calendar day as `nowDateTime`,
+ * only keep slots whose time-of-day is strictly after the current time, so a
+ * customer can't choose a pickup hour that already passed. Any future date keeps
+ * every option. Pure (now is injected) → deterministic and unit-testable.
+ */
+export function futurePickupHourOptions<T extends { value: string }>(
+    options: T[],
+    pickupDate: DateObject,
+    nowDateTime: DateTimeObject,
+): T[] {
+    const sameDay =
+        pickupDate.year === nowDateTime.year &&
+        pickupDate.month === nowDateTime.month &&
+        pickupDate.day === nowDateTime.day;
+    if (!sameDay) return options;
+
+    const currentTime = new Time(nowDateTime.hour, nowDateTime.minute, nowDateTime.second);
+    return options.filter((opt) => parseTime(opt.value).compare(currentTime) > 0);
 }
 
 export function createDateFromString(


### PR DESCRIPTION
Resuelve los dos pedidos sobre el mensaje "Selecciona la fecha de recogida igual o posterior a la fecha actual".

## Contexto
Ese texto lo manda el **backend** cuando la recogida quedó en el pasado, y `createErrorMessage` le ponía el título **"Error"**. La causa: el selector de hora mostraba **las 24 horas del día** aunque la fecha fuera hoy. Como la fecha pasada ya está bloqueada (calendario + clamp móvil), en la práctica esto solo pasa por la **hora** cuando la fecha es hoy.

## Cambios

**1. Evitarlo (principal):** cuando la fecha de recogida es **hoy**, el selector de hora solo ofrece franjas **estrictamente posteriores a la hora actual** (zona horaria America/Bogota). Si la hora elegida queda en el pasado (cambió la fecha a hoy, o pasó el tiempo), se reajusta sola a la primera franja disponible.

**2. Red de seguridad (mensaje amable):** para la ventana corta en que el tiempo pasa entre elegir y buscar, `doSearch` bloquea una recogida ya pasada **antes** de llamar al backend y muestra un aviso amable en vez del "Error":
- Título: **"Revisa la hora de recogida"**
- Mensaje: **"Por favor escoge una hora de recogida posterior a la hora actual."**

## Verificación
- **Unit (nuevo):** `futurePickupHourOptions` — 5 casos (fecha futura = todas; hoy = descarta pasadas; igual-a-ahora excluido; recién pasada medianoche; vacío de madrugada tardía). Suite completa: **397 pasan**.
- **Runtime (móvil):** fecha=mañana → 47 horas; fecha=hoy (Bogotá ~2am) → 43 horas desde 02:00; con 00:30 elegido y cambio a hoy → se reajusta solo a 02:00. Consola limpia.

## Alcance
`useDateFunctions.ts` (+2 utilidades) y `useSearch.ts` (filtro + reajuste + guard) + test. Lógica compartida → los 3 brands, sin tocar componentes.

## Nota
El selector de hora es nativo en móvil (`<select>`), así que las horas filtradas simplemente no aparecen en la lista. La hora mínima es "desde la hora actual, sin margen" (lo acordado).