### PR TITLE
fix(toast): aviso amable en hora de recogida pasada en vez del error crudo del backend

### DIFF
--- a/packages/logic/src/composables/useMessages.ts
+++ b/packages/logic/src/composables/useMessages.ts
@@ -33,6 +33,15 @@ export default function useMessages(){
         if (message.error == "no_available_categories_error")
             error.title = "No hay vehículos";
 
+        // A pickup datetime in the past (e.g. an hour earlier today than now).
+        // The backend's raw message talks about the "fecha" and reads harsh;
+        // override title + message with a friendly, hour-focused notice so the
+        // customer knows exactly what to fix. Same copy as the doSearch guard.
+        if (message.error == "inferior_pickup_date") {
+            error.title = "Revisa la hora de recogida";
+            error.message = "Por favor escoge una hora de recogida posterior a la hora actual.";
+        }
+
         toast.add({
             title: error.title,
             description: error.message,


### PR DESCRIPTION
## Qué

Cuando la hora de recogida queda en el pasado (p. ej. eliges hoy y una hora anterior a la actual), el dashboard rechaza la búsqueda con `inferior_pickup_date` y un mensaje crudo bajo el título genérico **"Error"**:

> Selecciona la fecha de recogida igual o posterior a la fecha actual

Ese texto habla de la *fecha* cuando el caso real es la *hora*, y se siente agresivo.

## Cambio

`createErrorMessage` (`useMessages.ts`) ahora mapea el código `inferior_pickup_date` a una copia amable y enfocada en la hora — la misma del guard de `doSearch` del #168:

- **Título:** Revisa la hora de recogida
- **Mensaje:** Por favor escoge una hora de recogida posterior a la hora actual.

Sobrescribe título y mensaje, así que el texto crudo del backend ya no aparece para este caso. El resto de errores siguen igual.

## Blast radius

- 1 archivo: `packages/logic/src/composables/useMessages.ts` (capa compartida → aplica a las 3 marcas).
- Consumidores: `useStoreSearchData.ts` (rutas mensual + no-mensual). Sin cambios de componentes.

## Evidencia / verificación

- Código de error **confirmado en vivo** contra el endpoint de disponibilidad de producción (`inferior_pickup_date`, HTTP 500, `shortText: LLNRRE002`).
- **397/397 tests** del logic package pasan (`pnpm --filter @rentacar-main/logic test`).