### PR TITLE
feat(searcher): aviso de horas extra solo si la entrega es más tarde + chip de horas extra

### DIFF
--- a/packages/logic/src/composables/useSearch.ts
+++ b/packages/logic/src/composables/useSearch.ts
@@ -115,13 +115,22 @@ export default function useSearch() {
       }
     }
 
-    if (horaRecogida.value != horaDevolucion.value) {
-      createMessage({
-        type: "info",
-        title: "Tarifa adicional por horas extras",
-        message:
-          "El tiempo extra de uso puede incrementar el precio total del alquiler",
-      });
+    // Only warn about extra-hour charges when the return time-of-day is strictly
+    // later than pickup's. Returning at the same hour or earlier (e.g. pickup
+    // 12 p.m. June 5 → return 10 a.m. June 6) bills whole days with no extra-hour
+    // surcharge, so the old `horaRecogida != horaDevolucion` test fired a false
+    // warning whenever the hours merely differed.
+    if (horaRecogida.value && horaDevolucion.value) {
+      const pickupTime = createTimeFromString(horaRecogida.value);
+      const returnTime = createTimeFromString(horaDevolucion.value);
+      if (returnTime.compare(pickupTime) > 0) {
+        createMessage({
+          type: "info",
+          title: "Tarifa adicional por horas extras",
+          message:
+            "las horas extras de uso pueden incrementar el precio total del alquiler.",
+        });
+      }
     }
 
     if (lugarRecogida.value != lugarDevolucion.value) {

--- a/packages/logic/src/stores/useStoreReservationForm.ts
+++ b/packages/logic/src/stores/useStoreReservationForm.ts
@@ -17,6 +17,7 @@ import {
   createTimeFromString,
   dayDifference,
   rentalDayCount,
+  extraHourChipLabel,
   formatHumanDate,
   formatHumanTime,
   toDatetime,
@@ -218,6 +219,14 @@ const useStoreReservationForm = defineStore("reservationForm", () => {
     return dayDifference(pickupDate, returnDate);
   });
 
+  // Extra-hour surcharge hint for the Searcher's return-hour chip. Delegates to
+  // extraHourChipLabel, which compares the chosen TIME-OF-DAY of return vs pickup
+  // (not the full datetime) so it stays consistent with the calendar-day chip
+  // (rentalDays) and with the GRACE_HOURS billing rule.
+  const extraHoursLabel = computed<string | null>(() =>
+    extraHourChipLabel(selectedPickupHour.value, selectedReturnHour.value)
+  );
+
   const minPickupDate = computed<DateObject>(() => {
     return createCurrentDateObject();
   });
@@ -310,6 +319,7 @@ const useStoreReservationForm = defineStore("reservationForm", () => {
     // other vars
     selectedDays,
     rentalDays,
+    extraHoursLabel,
     selectedMonthlyMileage,
     isSubmittingForm,
     haveTotalInsurance,

--- a/packages/logic/src/utils/__tests__/extraHourChipLabel.test.ts
+++ b/packages/logic/src/utils/__tests__/extraHourChipLabel.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { createTimeFromString, extraHourChipLabel } from '../useDateFunctions'
+
+// Searcher's extra-hour chip on the "Hora de devolución" selector.
+//
+// Compares the chosen return TIME-OF-DAY against pickup (not the full datetime),
+// complementing the calendar-day chip. Whole-hour ceiling — any fraction of an
+// hour rounds up — and once the difference passes the 4h grace window it bills a
+// full day ("+1 día"). Nothing shows when the return hour is the same as or
+// earlier than pickup.
+
+const label = (pickup: string, return_: string) =>
+  extraHourChipLabel(createTimeFromString(pickup), createTimeFromString(return_))
+
+describe('extraHourChipLabel', () => {
+  it('hides when the return hour equals pickup', () => {
+    expect(label('12:00', '12:00')).toBeNull()
+  })
+
+  it('hides when the return hour is earlier than pickup', () => {
+    // e.g. pickup 12:00 → return 10:00 next day: the calendar-day chip owns it
+    expect(label('12:00', '10:00')).toBeNull()
+  })
+
+  it('hides when either time is missing', () => {
+    expect(extraHourChipLabel(null, createTimeFromString('12:00'))).toBeNull()
+    expect(extraHourChipLabel(createTimeFromString('12:00'), null)).toBeNull()
+  })
+
+  it('shows "+1 hora" (singular) for the first whole hour', () => {
+    expect(label('12:00', '13:00')).toBe('+1 hora')
+  })
+
+  it('rounds any fraction of an hour up (ceiling)', () => {
+    // 30 min into the first hour still reads "+1 hora"
+    expect(label('12:00', '12:30')).toBe('+1 hora')
+    // crossing into the next half-hour slot tips to the next whole hour
+    expect(label('12:00', '13:30')).toBe('+2 horas')
+  })
+
+  it('counts whole extra hours up to the grace ceiling', () => {
+    expect(label('12:00', '14:00')).toBe('+2 horas')
+    expect(label('12:00', '15:00')).toBe('+3 horas')
+    expect(label('12:00', '16:00')).toBe('+4 horas')
+  })
+
+  it('keeps "+4 horas" at exactly the 4h grace boundary', () => {
+    // 4h00 leftover is still within grace → no full-day jump yet
+    expect(label('12:00', '16:00')).toBe('+4 horas')
+  })
+
+  it('tips to "+1 día" once past the 4h grace window', () => {
+    // 4h30 > grace
+    expect(label('12:00', '16:30')).toBe('+1 día')
+    // 5h and beyond
+    expect(label('12:00', '17:00')).toBe('+1 día')
+    expect(label('08:00', '20:00')).toBe('+1 día')
+  })
+
+  it('matches the reported case: 7 days + 7 hours shows "+1 día"', () => {
+    // dates are handled by the day chip; the hour chip only sees +7h of day → +1 día
+    expect(label('12:00', '19:00')).toBe('+1 día')
+  })
+})

--- a/packages/logic/src/utils/useDateFunctions.ts
+++ b/packages/logic/src/utils/useDateFunctions.ts
@@ -169,10 +169,17 @@ export function hourDifference(
 }
 
 /**
+ * Hours past a full 24h block that are NOT billed as an extra day (grace window).
+ * Single source of truth: shared by rentalDayCount (billing) and the Searcher's
+ * extra-hour chip (extraHoursLabel) so neither drifts from the other.
+ */
+export const GRACE_HOURS = 4;
+
+/**
  * Counts billable rental days between two datetimes.
  *
  * Bills each full 24h block, plus one extra day when the leftover beyond the
- * last full block exceeds a 4h grace window. Any positive duration bills at
+ * last full block exceeds the GRACE_HOURS window. Any positive duration bills at
  * least one day. Returns 0 when the return is not strictly after the pickup.
  *
  * Replaces the prior calendar-day + abs(hour-of-day) heuristic, which
@@ -187,7 +194,6 @@ export function rentalDayCount(
     pickup: DateTimeObject,
     return_: DateTimeObject,
 ): number {
-    const GRACE_HOURS = 4;
     const totalHours =
         (return_.toDate('UTC').getTime() - pickup.toDate('UTC').getTime()) / (1000 * 60 * 60);
 
@@ -198,6 +204,38 @@ export function rentalDayCount(
     const days = fullDays + (leftoverHours > GRACE_HOURS ? 1 : 0);
 
     return days === 0 ? 1 : days;
+}
+
+/**
+ * Builds the Searcher's extra-hour chip label from the chosen pickup/return
+ * TIMES-OF-DAY (not full datetimes). Mirrors the company's hourly surcharge:
+ * any fraction of an hour rounds UP (whole-hour ceiling), so 1..60 min → "+1
+ * hora", 61..120 min → "+2 horas". Once the difference passes the GRACE_HOURS
+ * window it bills a full extra day → "+1 día".
+ *
+ * Returns null when there is nothing to charge — a time is missing, or the
+ * return hour is the same as or earlier than pickup — so the chip stays hidden.
+ * Hour-of-day (not datetime) on purpose: it complements the calendar-day chip,
+ * which already counts the day when the return hour is earlier than pickup.
+ *
+ * @param pickupHour chosen pickup time-of-day
+ * @param returnHour chosen return time-of-day
+ * @returns chip label, or null when nothing extra applies
+ */
+export function extraHourChipLabel(
+    pickupHour: TimeObject | null,
+    returnHour: TimeObject | null,
+): string | null {
+    if (!pickupHour || !returnHour) return null;
+
+    const diffMinutes =
+        (returnHour.hour * 60 + returnHour.minute) -
+        (pickupHour.hour * 60 + pickupHour.minute);
+    if (diffMinutes <= 0) return null;
+
+    const extraHours = Math.ceil(diffMinutes / 60);
+    if (extraHours > GRACE_HOURS) return '+1 día';
+    return extraHours === 1 ? '+1 hora' : `+${extraHours} horas`;
 }
 
 export function isTimeObject(obj: TimeObject | DateTimeObject | null): obj is TimeObject {

--- a/packages/ui-alquicarros/app/components/Searcher.vue
+++ b/packages/ui-alquicarros/app/components/Searcher.vue
@@ -281,7 +281,11 @@
             </u-form-field>
         </div>
         <!-- MÓVIL: Form field con select nativo -->
-        <div class="bg-white rounded-xl p-2 shadow-sm sm:hidden">
+        <div class="relative bg-white rounded-xl p-2 shadow-sm sm:hidden">
+            <span
+                v-if="extraHoursLabel"
+                class="absolute -top-[3px] -right-[3px] z-10 bg-[#a3f78b] text-black text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
+            >{{ extraHoursLabel }}</span>
             <u-form-field label="Hora de devolución" size="xl">
                 <select
                     id="return-hour-mobile"
@@ -300,7 +304,11 @@
         </div>
 
         <!-- DESKTOP: Form field con u-select-menu -->
-        <div class="bg-white rounded-xl p-2 shadow-sm hidden sm:block">
+        <div class="relative bg-white rounded-xl p-2 shadow-sm hidden sm:block">
+            <span
+                v-if="extraHoursLabel"
+                class="absolute -top-[3px] -right-[3px] z-10 bg-[#a3f78b] text-black text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
+            >{{ extraHoursLabel }}</span>
             <u-form-field label="Hora de devolución" size="xl">
                 <u-select-menu
                     id="return-hour"
@@ -346,6 +354,7 @@ const maxReturnDate = ref<any>(null);
 const selectedPickupDate = ref<any>(null);
 const selectedReturnDate = ref<any>(null);
 const rentalDays = ref<number>(0);
+const extraHoursLabel = ref<string | null>(null);
 const minReturnDate = computed<any>(() => selectedPickupDate.value ?? minPickupDate.value);
 
 // Mobile uses a native <input type="date">. On some Android date pickers an
@@ -449,6 +458,7 @@ onMounted(() => {
   watch(() => formRefs.selectedPickupDate.value, (val) => selectedPickupDate.value = val, { immediate: true });
   watch(() => formRefs.selectedReturnDate.value, (val) => selectedReturnDate.value = val, { immediate: true });
   watch(() => formRefs.rentalDays.value, (val) => rentalDays.value = val, { immediate: true });
+  watch(() => formRefs.extraHoursLabel.value, (val) => extraHoursLabel.value = val, { immediate: true });
   watch(() => searchRefs.pending.value, (val) => pendingSearching.value = val, { immediate: true });
   watch(() => adminRefs.sortedBranches.value, (val) => sortedBranches.value = val, { immediate: true });
 

--- a/packages/ui-alquilame/app/components/Searcher.vue
+++ b/packages/ui-alquilame/app/components/Searcher.vue
@@ -281,7 +281,11 @@
             </u-form-field>
         </div>
         <!-- MÓVIL: Form field con select nativo -->
-        <div class="bg-white rounded-xl p-2 shadow-sm sm:hidden">
+        <div class="relative bg-white rounded-xl p-2 shadow-sm sm:hidden">
+            <span
+                v-if="extraHoursLabel"
+                class="absolute -top-[3px] -right-[3px] z-10 bg-red-600 text-white text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
+            >{{ extraHoursLabel }}</span>
             <u-form-field label="Hora de devolución" size="xl">
                 <select
                     id="return-hour-mobile"
@@ -300,7 +304,11 @@
         </div>
 
         <!-- DESKTOP: Form field con u-select-menu -->
-        <div class="bg-white rounded-xl p-2 shadow-sm hidden sm:block">
+        <div class="relative bg-white rounded-xl p-2 shadow-sm hidden sm:block">
+            <span
+                v-if="extraHoursLabel"
+                class="absolute -top-[3px] -right-[3px] z-10 bg-red-600 text-white text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
+            >{{ extraHoursLabel }}</span>
             <u-form-field label="Hora de devolución" size="xl">
                 <u-select-menu
                     id="return-hour"
@@ -348,6 +356,7 @@ const maxReturnDate = ref<any>(null);
 const selectedPickupDate = ref<any>(null);
 const selectedReturnDate = ref<any>(null);
 const rentalDays = ref<number>(0);
+const extraHoursLabel = ref<string | null>(null);
 const minReturnDate = computed<any>(() => selectedPickupDate.value ?? minPickupDate.value);
 
 // Mobile uses a native <input type="date">. On some Android date pickers an
@@ -451,6 +460,7 @@ onMounted(() => {
   watch(() => formRefs.selectedPickupDate.value, (val) => selectedPickupDate.value = val, { immediate: true });
   watch(() => formRefs.selectedReturnDate.value, (val) => selectedReturnDate.value = val, { immediate: true });
   watch(() => formRefs.rentalDays.value, (val) => rentalDays.value = val, { immediate: true });
+  watch(() => formRefs.extraHoursLabel.value, (val) => extraHoursLabel.value = val, { immediate: true });
   watch(() => searchRefs.pending.value, (val) => pendingSearching.value = val, { immediate: true });
   watch(() => adminRefs.sortedBranches.value, (val) => sortedBranches.value = val, { immediate: true });
 

--- a/packages/ui-alquilatucarro/app/components/Searcher.vue
+++ b/packages/ui-alquilatucarro/app/components/Searcher.vue
@@ -281,7 +281,11 @@
             </u-form-field>
         </div>
         <!-- MÓVIL: Form field con select nativo -->
-        <div class="bg-white rounded-xl px-2 py-2 max-sm:py-0.5! shadow-sm sm:hidden">
+        <div class="relative bg-white rounded-xl px-2 py-2 max-sm:py-0.5! shadow-sm sm:hidden">
+            <span
+                v-if="extraHoursLabel"
+                class="absolute -top-[3px] -right-[3px] z-10 bg-[#a3f78b] text-black text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
+            >{{ extraHoursLabel }}</span>
             <u-form-field label="Hora de devolución" size="xl">
                 <select
                     id="return-hour-mobile"
@@ -300,7 +304,11 @@
         </div>
 
         <!-- DESKTOP: Form field con u-select-menu -->
-        <div class="bg-white rounded-xl px-2 py-2 max-sm:py-0.5! shadow-sm hidden sm:block">
+        <div class="relative bg-white rounded-xl px-2 py-2 max-sm:py-0.5! shadow-sm hidden sm:block">
+            <span
+                v-if="extraHoursLabel"
+                class="absolute -top-[3px] -right-[3px] z-10 bg-[#a3f78b] text-black text-xs px-2 py-0.5 rounded-full shadow-sm pointer-events-none"
+            >{{ extraHoursLabel }}</span>
             <u-form-field label="Hora de devolución" size="xl">
                 <u-select-menu
                     id="return-hour"
@@ -346,6 +354,7 @@ const maxReturnDate = ref<any>(null);
 const selectedPickupDate = ref<any>(null);
 const selectedReturnDate = ref<any>(null);
 const rentalDays = ref<number>(0);
+const extraHoursLabel = ref<string | null>(null);
 const minReturnDate = computed<any>(() => selectedPickupDate.value ?? minPickupDate.value);
 
 // Mobile uses a native <input type="date">. On some Android date pickers an
@@ -449,6 +458,7 @@ onMounted(() => {
   watch(() => formRefs.selectedPickupDate.value, (val) => selectedPickupDate.value = val, { immediate: true });
   watch(() => formRefs.selectedReturnDate.value, (val) => selectedReturnDate.value = val, { immediate: true });
   watch(() => formRefs.rentalDays.value, (val) => rentalDays.value = val, { immediate: true });
+  watch(() => formRefs.extraHoursLabel.value, (val) => extraHoursLabel.value = val, { immediate: true });
   watch(() => searchRefs.pending.value, (val) => pendingSearching.value = val, { immediate: true });
   watch(() => adminRefs.sortedBranches.value, (val) => sortedBranches.value = val, { immediate: true });
 


### PR DESCRIPTION
## Qué

Tres ajustes al buscador relacionados con las horas extra de uso:

1. **Fix del aviso** — La notificación *"Tarifa adicional por horas extras"* saltaba siempre que la hora de recogida y la de entrega diferían. Por eso entregar más temprano al día siguiente (recogida 5-jun 12:00 → entrega 6-jun 10:00) mostraba un aviso falso. Ahora solo aparece cuando la **hora de entrega es estrictamente posterior** a la de recogida.
2. **Copy** — Mensaje del aviso suavizado: `las horas extras de uso pueden incrementar el precio total del alquiler.`
3. **Chip de horas extra** — Segundo chip sobre el selector **Hora de devolución** que muestra el recargo por horas según la hora elegida.

## Regla del chip (Opción B acordada)

| Diferencia hora-entrega vs recogida | Chip |
|---|---|
| misma hora o anterior | *(nada)* |
| min 1 – 60 | `+1 hora` |
| 61 – 120 | `+2 horas` |
| 121 – 180 | `+3 horas` |
| 181 – 240 | `+4 horas` |
| más de 4 h | `+1 día` |

Techo a horas enteras; pasadas las 4h (`GRACE_HOURS`) salta a `+1 día`. Se basa en la **hora-del-día** (no en el datetime) para complementar el chip de días existente.

## Cómo

- `useDateFunctions.ts`: `GRACE_HOURS` ahora exportado (fuente única de verdad, compartido con `rentalDayCount`) + util puro `extraHourChipLabel`.
- `useStoreReservationForm.ts`: computed `extraHoursLabel` que delega en el util.
- 3 `Searcher.vue`: chip cableado con el patrón de `rentalDays`; color por marca (verde alquilatucarro/alquicarros, rojo alquilame).

## Notas

- El chip es un **aviso visual**. El motor de días (`rentalDayCount`) no cobra 2/3/4 horas sueltas — solo el salto a +1 día tras 4h; el cobro por hora lo aplica el backend/mostrador. Consistente con el toast existente.

## Verificación

- ✅ Tests logic: **406 pasan** (9 nuevos en `extraHourChipLabel.test.ts`).
- ✅ Typecheck: sin errores nuevos (218 con cambios vs 219 sin; el resto es baseline preexistente).
- ⏳ Pendiente: QA visual en el preview (3 marcas).