### PR TITLE
feat(searcher): nuevo umbral de horas extra (primera hora gratis, floor) + tostada unificada con el chip

### DIFF
--- a/packages/logic/src/composables/useSearch.ts
+++ b/packages/logic/src/composables/useSearch.ts
@@ -16,6 +16,7 @@ import {
   createTimeFromString,
   createCurrentDateObject,
   createCurrentDateTimeObject,
+  extraHourChipLabel,
   futurePickupHourOptions,
   toDatetime,
   formatHumanTime,
@@ -115,22 +116,21 @@ export default function useSearch() {
       }
     }
 
-    // Only warn about extra-hour charges when the return time-of-day is strictly
-    // later than pickup's. Returning at the same hour or earlier (e.g. pickup
-    // 12 p.m. June 5 → return 10 a.m. June 6) bills whole days with no extra-hour
-    // surcharge, so the old `horaRecogida != horaDevolucion` test fired a false
-    // warning whenever the hours merely differed.
-    if (horaRecogida.value && horaDevolucion.value) {
-      const pickupTime = createTimeFromString(horaRecogida.value);
-      const returnTime = createTimeFromString(horaDevolucion.value);
-      if (returnTime.compare(pickupTime) > 0) {
-        createMessage({
-          type: "info",
-          title: "Tarifa adicional por horas extras",
-          message:
-            "las horas extras de uso pueden incrementar el precio total del alquiler.",
-        });
-      }
+    // Warn about extra-hour charges under the exact same condition that renders
+    // the return-hour chip — extraHourChipLabel returns non-null. So the toast
+    // and the chip always agree: nothing for a return <= 1 h after pickup (grace)
+    // or same/earlier; shown from 1 h 30 on.
+    const extraHoursNotice = extraHourChipLabel(
+      horaRecogida.value ? createTimeFromString(horaRecogida.value) : null,
+      horaDevolucion.value ? createTimeFromString(horaDevolucion.value) : null,
+    );
+    if (extraHoursNotice) {
+      createMessage({
+        type: "info",
+        title: "Tarifa adicional por horas extras",
+        message:
+          "las horas extras de uso pueden incrementar el precio total del alquiler.",
+      });
     }
 
     if (lugarRecogida.value != lugarDevolucion.value) {

--- a/packages/logic/src/utils/__tests__/extraHourChipLabel.test.ts
+++ b/packages/logic/src/utils/__tests__/extraHourChipLabel.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect } from 'vitest'
 import { createTimeFromString, extraHourChipLabel } from '../useDateFunctions'
 
-// Searcher's extra-hour chip on the "Hora de devolución" selector.
+// Searcher's extra-hour chip on the "Hora de devolución" selector — and the
+// "Tarifa adicional por horas extras" toast, which is gated by the same
+// non-null result.
 //
-// Compares the chosen return TIME-OF-DAY against pickup (not the full datetime),
-// complementing the calendar-day chip. Whole-hour ceiling — any fraction of an
-// hour rounds up — and once the difference passes the 4h grace window it bills a
-// full day ("+1 día"). Nothing shows when the return hour is the same as or
-// earlier than pickup.
+// The first full hour is free and silent: a return 1 h or less after pickup (or
+// the same/earlier hour) shows nothing. From 1 h 30 on it counts COMPLETED extra
+// hours (floor): 1h30 → "+1 hora", 2h00/2h30 → "+2 horas", up to "+4 horas".
+// Five hours or more becomes a full day → "+1 día".
 
 const label = (pickup: string, return_: string) =>
   extraHourChipLabel(createTimeFromString(pickup), createTimeFromString(return_))
@@ -27,38 +28,32 @@ describe('extraHourChipLabel', () => {
     expect(extraHourChipLabel(createTimeFromString('12:00'), null)).toBeNull()
   })
 
-  it('shows "+1 hora" (singular) for the first whole hour', () => {
-    expect(label('12:00', '13:00')).toBe('+1 hora')
+  it('hides within the first free hour (30 min and exactly 1 h)', () => {
+    expect(label('12:00', '12:30')).toBeNull()
+    expect(label('12:00', '13:00')).toBeNull()
   })
 
-  it('rounds any fraction of an hour up (ceiling)', () => {
-    // 30 min into the first hour still reads "+1 hora"
-    expect(label('12:00', '12:30')).toBe('+1 hora')
-    // crossing into the next half-hour slot tips to the next whole hour
-    expect(label('12:00', '13:30')).toBe('+2 horas')
+  it('shows "+1 hora" from 1 h 30', () => {
+    expect(label('12:00', '13:30')).toBe('+1 hora')
   })
 
-  it('counts whole extra hours up to the grace ceiling', () => {
+  it('floors completed hours (2 h and 2 h 30 both read "+2 horas")', () => {
     expect(label('12:00', '14:00')).toBe('+2 horas')
+    expect(label('12:00', '14:30')).toBe('+2 horas')
+  })
+
+  it('reads "+3 horas" at 3 h and 3 h 30', () => {
     expect(label('12:00', '15:00')).toBe('+3 horas')
-    expect(label('12:00', '16:00')).toBe('+4 horas')
+    expect(label('12:00', '15:30')).toBe('+3 horas')
   })
 
-  it('keeps "+4 horas" at exactly the 4h grace boundary', () => {
-    // 4h00 leftover is still within grace → no full-day jump yet
+  it('reads "+4 horas" at 4 h and 4 h 30 (cap before the day jump)', () => {
     expect(label('12:00', '16:00')).toBe('+4 horas')
+    expect(label('12:00', '16:30')).toBe('+4 horas')
   })
 
-  it('tips to "+1 día" once past the 4h grace window', () => {
-    // 4h30 > grace
-    expect(label('12:00', '16:30')).toBe('+1 día')
-    // 5h and beyond
+  it('tips to "+1 día" from 5 h onward', () => {
     expect(label('12:00', '17:00')).toBe('+1 día')
     expect(label('08:00', '20:00')).toBe('+1 día')
-  })
-
-  it('matches the reported case: 7 days + 7 hours shows "+1 día"', () => {
-    // dates are handled by the day chip; the hour chip only sees +7h of day → +1 día
-    expect(label('12:00', '19:00')).toBe('+1 día')
   })
 })

--- a/packages/logic/src/utils/useDateFunctions.ts
+++ b/packages/logic/src/utils/useDateFunctions.ts
@@ -208,13 +208,15 @@ export function rentalDayCount(
 
 /**
  * Builds the Searcher's extra-hour chip label from the chosen pickup/return
- * TIMES-OF-DAY (not full datetimes). Mirrors the company's hourly surcharge:
- * any fraction of an hour rounds UP (whole-hour ceiling), so 1..60 min → "+1
- * hora", 61..120 min → "+2 horas". Once the difference passes the GRACE_HOURS
- * window it bills a full extra day → "+1 día".
+ * TIMES-OF-DAY (not full datetimes). The first full hour is free and silent:
+ * a return 1 h or less after pickup (or the same/earlier hour) shows nothing.
+ * From 1 h 30 on it counts COMPLETED extra hours (floor) — 1h30 → "+1 hora",
+ * 2h00/2h30 → "+2 horas", … up to GRACE_HOURS ("+4 horas"). Beyond that the
+ * surcharge becomes a full extra day → "+1 día".
  *
- * Returns null when there is nothing to charge — a time is missing, or the
- * return hour is the same as or earlier than pickup — so the chip stays hidden.
+ * This same non-null/null result also gates the "Tarifa adicional por horas
+ * extras" toast in useSearch, so the toast and the chip always agree.
+ *
  * Hour-of-day (not datetime) on purpose: it complements the calendar-day chip,
  * which already counts the day when the return hour is earlier than pickup.
  *
@@ -231,9 +233,10 @@ export function extraHourChipLabel(
     const diffMinutes =
         (returnHour.hour * 60 + returnHour.minute) -
         (pickupHour.hour * 60 + pickupHour.minute);
-    if (diffMinutes <= 0) return null;
+    // First full hour is grace → nothing shown for <= 1 h (and same/earlier).
+    if (diffMinutes <= 60) return null;
 
-    const extraHours = Math.ceil(diffMinutes / 60);
+    const extraHours = Math.floor(diffMinutes / 60);
     if (extraHours > GRACE_HOURS) return '+1 día';
     return extraHours === 1 ? '+1 hora' : `+${extraHours} horas`;
 }


### PR DESCRIPTION
## Qué

Ajuste del aviso de horas extra del buscador (sobre lo desplegado en #170):

1. **Nuevo umbral del chip** — La primera hora completa es gratis y silenciosa; desde 1h30 cuenta horas cumplidas (floor); tope 4 horas; 5h o más → +1 día.
2. **Tostada unificada con el chip** — La tostada *"Tarifa adicional por horas extras"* ahora se dispara exactamente cuando el chip aparece (mismo `extraHourChipLabel`). Antes salía con cualquier hora de entrega posterior.

Comportamiento (recogida 12:00):

| Entrega | Chip | Tostada |
|---|---|---|
| 12:30 / 13:00 | — | no |
| 13:30 | +1 hora | sí |
| 14:00 / 14:30 | +2 horas | sí |
| 15:00 / 15:30 | +3 horas | sí |
| 16:00 / 16:30 | +4 horas | sí |
| 17:00+ | +1 día | sí |

## Cómo

- `useDateFunctions.ts`: `extraHourChipLabel` pasa de techo (ceiling) a piso (floor) con la primera hora de gracia (`diffMinutes <= 60 → null`).
- `useSearch.ts`: `doSearch` muestra la tostada sólo si `extraHourChipLabel` es no nulo.
- Test actualizado; chip `.vue` sin cambios (solo renderiza el string).

## Nota

- En la franja 4:01–4:59 el chip muestra "+4 horas" mientras `rentalDayCount` (gracia 4h) contaría +1 día. El cobro por hora real lo aplica backend/mostrador, así que el chip refleja la política horaria; documentado a propósito.

## Verificación

- ✅ Tests logic: **406** (test de `extraHourChipLabel` reescrito).
- ✅ Typecheck: sin errores nuevos (baseline preexistente intacto).