### PR TITLE
fix(searcher): mensaje 'Local cerrado a esa hora' + adelanto de 1 hora para recogida hoy

### DIFF
--- a/packages/logic/src/composables/useMessages.ts
+++ b/packages/logic/src/composables/useMessages.ts
@@ -42,6 +42,17 @@ export default function useMessages(){
             error.message = "Por favor escoge una hora de recogida posterior a la hora actual.";
         }
 
+        // The chosen pickup/return HOUR is outside the branch's opening hours.
+        // The backend message reads harsh and date-centric; replace it with a
+        // clear "the location is closed then" notice. Covers both hour codes.
+        if (
+            message.error == "out_of_schedule_pickup_hour_error" ||
+            message.error == "out_of_schedule_return_hour_error"
+        ) {
+            error.title = "Local cerrado a esa hora";
+            error.message = "La sede seleccionada no está abierta en el horario que elegiste.";
+        }
+
         toast.add({
             title: error.title,
             description: error.message,

--- a/packages/logic/src/utils/__tests__/futurePickupHourOptions.test.ts
+++ b/packages/logic/src/utils/__tests__/futurePickupHourOptions.test.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect } from 'vitest'
 import {
   futurePickupHourOptions,
+  SAME_DAY_PICKUP_LEAD_MINUTES,
   createDateFromString,
   createDateTimeFromString,
 } from '../useDateFunctions'
 
-// A customer choosing today as the pickup date must not be offered an hour that
-// already passed (e.g. it's 5:05 p.m. and they pick noon) — the backend rejects
-// that pickup. futurePickupHourOptions trims the hour list to slots strictly
-// after "now" on the same day, and leaves future dates untouched. Pure: "now"
-// is injected so the cases below are deterministic.
+// A customer choosing today as the pickup date must be offered only hours that
+// are at least 1 hour ahead of "now" (SAME_DAY_PICKUP_LEAD_MINUTES) — earlier
+// slots already passed or leave the branch too little lead time. Future dates
+// keep every option. Pure: "now" is injected so the cases below are deterministic.
 
 const OPTS = [
   { value: '00:00' },
@@ -22,27 +22,46 @@ const OPTS = [
 ]
 
 describe('futurePickupHourOptions', () => {
+  it('uses a 1-hour same-day lead', () => {
+    expect(SAME_DAY_PICKUP_LEAD_MINUTES).toBe(60)
+  })
+
   it('keeps every option when the pickup date is in the future', () => {
     const pickup = createDateFromString('2026-08-02')
     const now = createDateTimeFromString('2026-08-01T17:05:00')
     expect(futurePickupHourOptions(OPTS, pickup, now)).toEqual(OPTS)
   })
 
-  it('on today, drops slots at or before the current time', () => {
+  it('on today, includes a slot exactly 1 hour ahead and drops the nearer one', () => {
+    // now 11:00 → earliest offered is 12:00; 11:30 (only 30 min away) is dropped
     const pickup = createDateFromString('2026-08-01')
-    const now = createDateTimeFromString('2026-08-01T17:05:00')
+    const now = createDateTimeFromString('2026-08-01T11:00:00')
     expect(futurePickupHourOptions(OPTS, pickup, now).map((o) => o.value)).toEqual([
+      '12:00',
+      '17:00',
       '17:30',
       '18:00',
       '23:30',
     ])
   })
 
-  it('on today, a slot exactly equal to now is excluded (strictly after)', () => {
+  it('on today, drops a slot less than 1 hour ahead', () => {
+    // now 11:05 → 12:00 is only 55 min away, so it is excluded
     const pickup = createDateFromString('2026-08-01')
-    const now = createDateTimeFromString('2026-08-01T17:30:00')
+    const now = createDateTimeFromString('2026-08-01T11:05:00')
     expect(futurePickupHourOptions(OPTS, pickup, now).map((o) => o.value)).toEqual([
+      '17:00',
+      '17:30',
       '18:00',
+      '23:30',
+    ])
+  })
+
+  it('drops everything within the next hour in the afternoon', () => {
+    // now 17:05 → only 23:30 is ≥ 1 hour ahead (17:30 and 18:00 are too soon)
+    const pickup = createDateFromString('2026-08-01')
+    const now = createDateTimeFromString('2026-08-01T17:05:00')
+    expect(futurePickupHourOptions(OPTS, pickup, now).map((o) => o.value)).toEqual([
       '23:30',
     ])
   })
@@ -60,9 +79,10 @@ describe('futurePickupHourOptions', () => {
     ])
   })
 
-  it('returns empty late at night (caller is responsible for the fallback)', () => {
+  it('returns empty late at night, lead past midnight (caller falls back)', () => {
+    // now 23:15 → earliest 00:15 next day → no same-day slot qualifies
     const pickup = createDateFromString('2026-08-01')
-    const now = createDateTimeFromString('2026-08-01T23:45:00')
+    const now = createDateTimeFromString('2026-08-01T23:15:00')
     expect(futurePickupHourOptions(OPTS, pickup, now)).toEqual([])
   })
 })

--- a/packages/logic/src/utils/useDateFunctions.ts
+++ b/packages/logic/src/utils/useDateFunctions.ts
@@ -29,11 +29,19 @@ export function createCurrentDateTimeObject(): DateTimeObject {
 }
 
 /**
+ * Minimum lead time, in minutes, for a same-day pickup: the earliest hour we
+ * offer when the customer picks today is at least this far ahead of "now".
+ */
+export const SAME_DAY_PICKUP_LEAD_MINUTES = 60;
+
+/**
  * Filter pickup-hour options to those still valid for `pickupDate` relative to
  * `nowDateTime`. When `pickupDate` is the same calendar day as `nowDateTime`,
- * only keep slots whose time-of-day is strictly after the current time, so a
- * customer can't choose a pickup hour that already passed. Any future date keeps
- * every option. Pure (now is injected) → deterministic and unit-testable.
+ * only keep slots at least SAME_DAY_PICKUP_LEAD_MINUTES (1 hour) ahead of the
+ * current time, so a customer can't pick an hour that already passed or is too
+ * soon for the branch to prepare the car. Any future date keeps every option.
+ * Works in minutes-of-day so a late-night "now" (lead past midnight) trims to
+ * empty and lets the caller fall back. Pure (now is injected) → unit-testable.
  */
 export function futurePickupHourOptions<T extends { value: string }>(
     options: T[],
@@ -46,8 +54,12 @@ export function futurePickupHourOptions<T extends { value: string }>(
         pickupDate.day === nowDateTime.day;
     if (!sameDay) return options;
 
-    const currentTime = new Time(nowDateTime.hour, nowDateTime.minute, nowDateTime.second);
-    return options.filter((opt) => parseTime(opt.value).compare(currentTime) > 0);
+    const earliestMinutes =
+        nowDateTime.hour * 60 + nowDateTime.minute + SAME_DAY_PICKUP_LEAD_MINUTES;
+    return options.filter((opt) => {
+        const slot = parseTime(opt.value);
+        return slot.hour * 60 + slot.minute >= earliestMinutes;
+    });
 }
 
 export function createDateFromString(


### PR DESCRIPTION
## Qué

Dos ajustes del buscador:

1. **Mensaje de horario más claro.** El error de hora fuera del horario de la sede ya no muestra el mensaje crudo del backend. Ahora:
   - Título: **Local cerrado a esa hora**
   - Mensaje: **La sede seleccionada no está abierta en el horario que elegiste.**
   - Mapeado en `createErrorMessage` para `out_of_schedule_pickup_hour_error` y `out_of_schedule_return_hour_error`. Los códigos de fecha/feriado mantienen su copia (ahí "a esa hora" no aplica).

2. **Adelanto mínimo de 1 hora para recogida el mismo día.** Antes el selector ofrecía el siguiente slot (~30 min); ahora exige 1 hora. Si son las 11:00, la primera opción es 12:00.

## Cómo

- `useMessages.ts`: nueva rama de mapeo en `createErrorMessage`.
- `useDateFunctions.ts`: `futurePickupHourOptions` filtra a slots `>= now + SAME_DAY_PICKUP_LEAD_MINUTES` (60), en minutos-del-día (de noche cae al fallback existente).
- Test de `futurePickupHourOptions` actualizado.

## Verificación

- ✅ Tests logic: **408**.
- ✅ Typecheck: sin errores nuevos (baseline intacto).
- El mensaje de horario solo se ve si el backend rechaza por horario de sede (QA en vivo requiere intentar reserva fuera de horario de una sede real).